### PR TITLE
Add QOL features: scouts, battlefield labels, wall drag-to-build, UI polish

### DIFF
--- a/Sporefront/Assets/Scripts/Commands/BuildCommand.cs
+++ b/Sporefront/Assets/Scripts/Commands/BuildCommand.cs
@@ -80,9 +80,10 @@ namespace Sporefront.Commands
                 if (!group.ownerID.HasValue || group.ownerID.Value != PlayerID)
                     return EngineCommandResult.Failure("Assigned villager group not owned by player.");
             }
-            else
+            else if (buildingType != BuildingType.Wall)
             {
                 // No specific villager — require at least one idle villager group
+                // Walls skip this check (drag-to-build places many at once; builders chain automatically)
                 var villagers = state.GetVillagerGroupsForPlayer(PlayerID);
                 bool hasIdleVillager = villagers != null &&
                     villagers.Any(g => g.currentTask.IsIdle && g.currentPath == null);

--- a/Sporefront/Assets/Scripts/Commands/MoveScoutCommand.cs
+++ b/Sporefront/Assets/Scripts/Commands/MoveScoutCommand.cs
@@ -1,0 +1,78 @@
+// ============================================================================
+// FILE: Commands/MoveScoutCommand.cs
+// PURPOSE: Command to move a Mycelium Scout to a destination hex.
+//          Validates ownership, stamina, and destination. Pathfinding is
+//          handled by MovementEngine after the path is set.
+// ============================================================================
+
+using System;
+using System.Collections.Generic;
+using Sporefront.Engine;
+using Sporefront.Data;
+using Sporefront.Models;
+
+namespace Sporefront.Commands
+{
+    public class MoveScoutCommand : BaseEngineCommand
+    {
+        public Guid scoutID;
+        public HexCoordinate destination;
+
+        public MoveScoutCommand(Guid playerID, Guid scoutID, HexCoordinate destination)
+            : base(playerID)
+        {
+            this.scoutID = scoutID;
+            this.destination = destination;
+        }
+
+        // Reconstruction constructor for online deserialization
+        public MoveScoutCommand(Guid id, Guid playerID, double timestamp, Guid scoutID, HexCoordinate destination)
+            : base(id, playerID, timestamp)
+        {
+            this.scoutID = scoutID;
+            this.destination = destination;
+        }
+
+        public override EngineCommandResult Validate(GameState state)
+        {
+            if (!state.mapData.IsValidCoordinate(destination))
+                return EngineCommandResult.Failure("Destination is not a valid coordinate");
+
+            var scout = state.GetScout(scoutID);
+            if (scout == null)
+                return EngineCommandResult.Failure("Scout not found");
+
+            if (!scout.ownerID.HasValue || scout.ownerID.Value != PlayerID)
+                return EngineCommandResult.Failure("Scout is not owned by this player");
+
+            if (!scout.HasEnoughStamina())
+                return EngineCommandResult.Failure("Scout lacks stamina to move");
+
+            return EngineCommandResult.Success(null);
+        }
+
+        public override EngineCommandResult Execute(GameState state, StateChangeBuilder builder)
+        {
+            var scout = state.GetScout(scoutID);
+            if (scout == null)
+                return EngineCommandResult.Failure("Scout not found");
+
+            // Pathfind to destination
+            var path = state.mapData.FindPath(scout.coordinate, destination, scout.ownerID, state);
+            if (path == null || path.Count == 0)
+                return EngineCommandResult.Failure("No valid path to destination");
+
+            scout.SetPath(path);
+
+            builder.Add(new ScoutMovedChange
+            {
+                scoutID = scoutID,
+                from = scout.coordinate,
+                to = destination,
+                path = path
+            });
+
+            return EngineCommandResult.Success(builder.Build().changes);
+        }
+    }
+}

--- a/Sporefront/Assets/Scripts/Commands/MoveScoutCommand.cs.meta
+++ b/Sporefront/Assets/Scripts/Commands/MoveScoutCommand.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: fe21c4d0b596748aa81ce9f9c8aa84de

--- a/Sporefront/Assets/Scripts/Commands/TrainScoutCommand.cs
+++ b/Sporefront/Assets/Scripts/Commands/TrainScoutCommand.cs
@@ -1,0 +1,87 @@
+// ============================================================================
+// FILE: Commands/TrainScoutCommand.cs
+// PURPOSE: Command to train a Mycelium Scout from the City Center.
+//          Validates ownership, building type, and resources.
+// ============================================================================
+
+using System;
+using System.Collections.Generic;
+using Sporefront.Engine;
+using Sporefront.Data;
+using Sporefront.Models;
+
+namespace Sporefront.Commands
+{
+    public class TrainScoutCommand : BaseEngineCommand
+    {
+        public Guid buildingID;
+
+        public TrainScoutCommand(Guid playerID, Guid buildingID)
+            : base(playerID)
+        {
+            this.buildingID = buildingID;
+        }
+
+        // Reconstruction constructor for online deserialization
+        public TrainScoutCommand(Guid id, Guid playerID, double timestamp, Guid buildingID)
+            : base(id, playerID, timestamp)
+        {
+            this.buildingID = buildingID;
+        }
+
+        public override EngineCommandResult Validate(GameState state)
+        {
+            var building = state.GetBuilding(buildingID);
+            if (building == null)
+                return EngineCommandResult.Failure("Building not found");
+
+            if (!building.ownerID.HasValue || building.ownerID.Value != PlayerID)
+                return EngineCommandResult.Failure("Building is not owned by this player");
+
+            if (!building.IsOperational)
+                return EngineCommandResult.Failure("Building is not operational");
+
+            if (building.buildingType != BuildingType.CityCenter)
+                return EngineCommandResult.Failure("Scouts can only be trained at the City Center");
+
+            // Check player can afford
+            var player = state.GetPlayer(PlayerID);
+            if (player == null)
+                return EngineCommandResult.Failure("Player not found");
+
+            var cost = new Dictionary<ResourceType, int> { { ResourceType.Food, GameConfig.Scout.FoodCost } };
+            if (!player.CanAfford(cost))
+                return EngineCommandResult.Failure("Not enough food to train scout");
+
+            return EngineCommandResult.Success(null);
+        }
+
+        public override EngineCommandResult Execute(GameState state, StateChangeBuilder changeBuilder)
+        {
+            var building = state.GetBuilding(buildingID);
+            if (building == null)
+                return EngineCommandResult.Failure("Building not found");
+
+            var player = state.GetPlayer(PlayerID);
+            if (player == null)
+                return EngineCommandResult.Failure("Player not found");
+
+            // Deduct resources
+            player.RemoveResource(ResourceType.Food, GameConfig.Scout.FoodCost);
+
+            // Start scout training
+            building.StartScoutTraining(state.currentTime);
+
+            // Emit state change
+            changeBuilder.Add(new ScoutTrainingStartedChange
+            {
+                buildingID = buildingID,
+                startTime = state.currentTime
+            });
+
+            DebugLog.Log(string.Format("TrainScoutCommand: Started training scout at building {0}", buildingID));
+
+            return EngineCommandResult.Success(changeBuilder.Build().changes);
+        }
+    }
+}

--- a/Sporefront/Assets/Scripts/Commands/TrainScoutCommand.cs.meta
+++ b/Sporefront/Assets/Scripts/Commands/TrainScoutCommand.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a770eb4119ada4a6694719d04556d635

--- a/Sporefront/Assets/Scripts/Data/BuildingData.cs
+++ b/Sporefront/Assets/Scripts/Data/BuildingData.cs
@@ -45,6 +45,7 @@ namespace Sporefront.Data
         // Training Queues
         public List<TrainingQueueEntry> trainingQueue = new List<TrainingQueueEntry>();
         public List<VillagerTrainingEntry> villagerTrainingQueue = new List<VillagerTrainingEntry>();
+        public List<ScoutTrainingEntry> scoutTrainingQueue = new List<ScoutTrainingEntry>();
 
         // Computed Properties
         public int MaxLevel => buildingType.MaxLevel();
@@ -284,6 +285,11 @@ namespace Sporefront.Data
                    (buildingType == BuildingType.CityCenter || buildingType == BuildingType.Neighborhood);
         }
 
+        public bool CanTrainScouts()
+        {
+            return state == BuildingState.Completed && buildingType == BuildingType.CityCenter;
+        }
+
         public void StartTraining(MilitaryUnitType unitType, int quantity, double time)
         {
             if (!CanTrain(unitType)) return;
@@ -294,6 +300,37 @@ namespace Sporefront.Data
         {
             if (!CanTrainVillagers()) return;
             villagerTrainingQueue.Add(new VillagerTrainingEntry(quantity, time));
+        }
+
+        public void StartScoutTraining(double time)
+        {
+            if (!CanTrainScouts()) return;
+            scoutTrainingQueue.Add(new ScoutTrainingEntry(time));
+        }
+
+        public List<ScoutTrainingEntry> UpdateScoutTraining(double currentTime)
+        {
+            if (scoutTrainingQueue.Count == 0) return new List<ScoutTrainingEntry>();
+
+            var completed = new List<ScoutTrainingEntry>();
+            var completedIndices = new List<int>();
+
+            for (int i = 0; i < scoutTrainingQueue.Count; i++)
+            {
+                double progress = scoutTrainingQueue[i].GetProgress(currentTime);
+                scoutTrainingQueue[i].progress = progress;
+
+                if (progress >= 1.0)
+                {
+                    completed.Add(scoutTrainingQueue[i]);
+                    completedIndices.Add(i);
+                }
+            }
+
+            for (int i = completedIndices.Count - 1; i >= 0; i--)
+                scoutTrainingQueue.RemoveAt(completedIndices[i]);
+
+            return completed;
         }
 
         public List<TrainingQueueEntry> UpdateTraining(double currentTime, double researchMultiplier = 1.0)

--- a/Sporefront/Assets/Scripts/Data/GameSession.cs
+++ b/Sporefront/Assets/Scripts/Data/GameSession.cs
@@ -53,8 +53,10 @@ namespace Sporefront.Data
         public int mineralDepositCount = 12;
         public int mineralDepositSizeMin = 2;
         public int mineralDepositSizeMax = 4;
-        public double hillClusterChance = 0.15;
-        public int maxElevation = 3;
+        public int ridgeCount = 4;
+        public int ridgeLengthMin = 6;
+        public int ridgeLengthMax = 12;
+        public double ridgeFoothillChance = 0.4;
 
         public MapGenerationConfig(string mapType, ulong seed, int width, int height)
         {
@@ -73,8 +75,10 @@ namespace Sporefront.Data
             config.mineralDepositCount = mineralDepositCount;
             config.mineralDepositSizeMin = mineralDepositSizeMin;
             config.mineralDepositSizeMax = mineralDepositSizeMax;
-            config.hillClusterChance = hillClusterChance;
-            config.maxElevation = maxElevation;
+            config.ridgeCount = ridgeCount;
+            config.ridgeLengthMin = ridgeLengthMin;
+            config.ridgeLengthMax = ridgeLengthMax;
+            config.ridgeFoothillChance = ridgeFoothillChance;
             return config;
         }
 
@@ -90,8 +94,10 @@ namespace Sporefront.Data
             mapConfig.mineralDepositCount = config.mineralDepositCount;
             mapConfig.mineralDepositSizeMin = config.mineralDepositSizeMin;
             mapConfig.mineralDepositSizeMax = config.mineralDepositSizeMax;
-            mapConfig.hillClusterChance = config.hillClusterChance;
-            mapConfig.maxElevation = config.maxElevation;
+            mapConfig.ridgeCount = config.ridgeCount;
+            mapConfig.ridgeLengthMin = config.ridgeLengthMin;
+            mapConfig.ridgeLengthMax = config.ridgeLengthMax;
+            mapConfig.ridgeFoothillChance = config.ridgeFoothillChance;
             return mapConfig;
         }
 
@@ -109,8 +115,10 @@ namespace Sporefront.Data
                 { "mineralDepositCount", mineralDepositCount },
                 { "mineralDepositSizeMin", mineralDepositSizeMin },
                 { "mineralDepositSizeMax", mineralDepositSizeMax },
-                { "hillClusterChance", hillClusterChance },
-                { "maxElevation", maxElevation }
+                { "ridgeCount", ridgeCount },
+                { "ridgeLengthMin", ridgeLengthMin },
+                { "ridgeLengthMax", ridgeLengthMax },
+                { "ridgeFoothillChance", ridgeFoothillChance }
             };
         }
 
@@ -136,8 +144,10 @@ namespace Sporefront.Data
             if (data.ContainsKey("mineralDepositCount")) config.mineralDepositCount = Convert.ToInt32(data["mineralDepositCount"]);
             if (data.ContainsKey("mineralDepositSizeMin")) config.mineralDepositSizeMin = Convert.ToInt32(data["mineralDepositSizeMin"]);
             if (data.ContainsKey("mineralDepositSizeMax")) config.mineralDepositSizeMax = Convert.ToInt32(data["mineralDepositSizeMax"]);
-            if (data.ContainsKey("hillClusterChance")) config.hillClusterChance = Convert.ToDouble(data["hillClusterChance"]);
-            if (data.ContainsKey("maxElevation")) config.maxElevation = Convert.ToInt32(data["maxElevation"]);
+            if (data.ContainsKey("ridgeCount")) config.ridgeCount = Convert.ToInt32(data["ridgeCount"]);
+            if (data.ContainsKey("ridgeLengthMin")) config.ridgeLengthMin = Convert.ToInt32(data["ridgeLengthMin"]);
+            if (data.ContainsKey("ridgeLengthMax")) config.ridgeLengthMax = Convert.ToInt32(data["ridgeLengthMax"]);
+            if (data.ContainsKey("ridgeFoothillChance")) config.ridgeFoothillChance = Convert.ToDouble(data["ridgeFoothillChance"]);
             return config;
         }
     }

--- a/Sporefront/Assets/Scripts/Data/GameState.cs
+++ b/Sporefront/Assets/Scripts/Data/GameState.cs
@@ -33,6 +33,9 @@ namespace Sporefront.Data
         // Commanders
         public Dictionary<Guid, CommanderData> commanders = new Dictionary<Guid, CommanderData>();
 
+        // Scouts (Mycelium Scouts)
+        public Dictionary<Guid, ScoutData> scouts = new Dictionary<Guid, ScoutData>();
+
         // Time
         public double currentTime;
         public double gameStartTime;
@@ -58,6 +61,8 @@ namespace Sporefront.Data
         private Dictionary<Guid, List<ArmyData>> armiesByPlayer = new Dictionary<Guid, List<ArmyData>>();
         [System.NonSerialized]
         private Dictionary<Guid, List<VillagerGroupData>> villagerGroupsByPlayer = new Dictionary<Guid, List<VillagerGroupData>>();
+        [System.NonSerialized]
+        private Dictionary<Guid, List<ScoutData>> scoutsByPlayer = new Dictionary<Guid, List<ScoutData>>();
 
         // Enemy composition analysis cache (transient)
         [System.NonSerialized]
@@ -590,6 +595,65 @@ namespace Sporefront.Data
             if (!villagerGroups.TryGetValue(groupID, out group)) return;
             group.coordinate = to;
             mapData.UpdateVillagerGroupPosition(groupID, to);
+        }
+
+        // ================================================================
+        // Scouts
+        // ================================================================
+
+        public void AddScout(ScoutData scout)
+        {
+            scouts[scout.id] = scout;
+            mapData.RegisterScout(scout.id, scout.coordinate);
+
+            if (scout.ownerID.HasValue)
+            {
+                List<ScoutData> playerScouts;
+                if (!scoutsByPlayer.TryGetValue(scout.ownerID.Value, out playerScouts))
+                {
+                    playerScouts = new List<ScoutData>();
+                    scoutsByPlayer[scout.ownerID.Value] = playerScouts;
+                }
+                playerScouts.Add(scout);
+            }
+        }
+
+        public void RemoveScout(Guid id)
+        {
+            ScoutData scout;
+            if (!scouts.TryGetValue(id, out scout)) return;
+
+            if (scout.ownerID.HasValue)
+            {
+                List<ScoutData> playerScouts;
+                if (scoutsByPlayer.TryGetValue(scout.ownerID.Value, out playerScouts))
+                    playerScouts.Remove(scout);
+            }
+
+            mapData.UnregisterScout(id);
+            scouts.Remove(id);
+        }
+
+        public ScoutData GetScout(Guid id)
+        {
+            ScoutData scout;
+            return scouts.TryGetValue(id, out scout) ? scout : null;
+        }
+
+        public List<ScoutData> GetScoutsForPlayer(Guid playerID)
+        {
+            List<ScoutData> cached;
+            if (scoutsByPlayer.TryGetValue(playerID, out cached))
+                return new List<ScoutData>(cached);
+            return new List<ScoutData>();
+        }
+
+        public void UpdateScoutPosition(Guid scoutID, HexCoordinate to)
+        {
+            ScoutData scout;
+            if (!scouts.TryGetValue(scoutID, out scout)) return;
+            scout.coordinate = to;
+            mapData.UpdateScoutPosition(scoutID, to);
         }
 
         // ================================================================
@@ -1287,6 +1351,7 @@ namespace Sporefront.Data
         public List<VillagerGroupData> villagerGroups;
         public List<ResourcePointData> resourcePoints;
         public List<CommanderData> commanders;
+        public List<ScoutData> scouts;
         public Guid? localPlayerID;
 
         // Default constructor for deserialization
@@ -1303,6 +1368,7 @@ namespace Sporefront.Data
             this.villagerGroups = new List<VillagerGroupData>(gameState.villagerGroups.Values);
             this.resourcePoints = new List<ResourcePointData>(gameState.resourcePoints.Values);
             this.commanders = new List<CommanderData>(gameState.commanders.Values);
+            this.scouts = new List<ScoutData>(gameState.scouts.Values);
             this.localPlayerID = gameState.localPlayerID;
         }
 
@@ -1337,6 +1403,8 @@ namespace Sporefront.Data
             }
             foreach (var group in villagerGroups) gameState.AddVillagerGroup(group);
             foreach (var commander in commanders) gameState.AddCommander(commander);
+            if (scouts != null)
+                foreach (var scout in scouts) gameState.AddScout(scout);
 
             return gameState;
         }

--- a/Sporefront/Assets/Scripts/Data/MapData.cs
+++ b/Sporefront/Assets/Scripts/Data/MapData.cs
@@ -32,12 +32,14 @@ namespace Sporefront.Data
         public HashSet<Guid> armyIDs = new HashSet<Guid>();
         public HashSet<Guid> villagerGroupIDs = new HashSet<Guid>();
         public HashSet<Guid> resourcePointIDs = new HashSet<Guid>();
+        public HashSet<Guid> scoutIDs = new HashSet<Guid>();
 
         // Coordinate tracking
         public Dictionary<Guid, HexCoordinate> buildingCoordinates = new Dictionary<Guid, HexCoordinate>();
         public Dictionary<Guid, HexCoordinate> armyCoordinates = new Dictionary<Guid, HexCoordinate>();
         public Dictionary<Guid, HexCoordinate> villagerGroupCoordinates = new Dictionary<Guid, HexCoordinate>();
         public Dictionary<Guid, HexCoordinate> resourcePointCoordinates = new Dictionary<Guid, HexCoordinate>();
+        public Dictionary<Guid, HexCoordinate> scoutCoordinates = new Dictionary<Guid, HexCoordinate>();
 
         // Multi-tile building support
         public Dictionary<HexCoordinate, Guid> occupiedCoordinates = new Dictionary<HexCoordinate, Guid>();
@@ -195,6 +197,44 @@ namespace Sporefront.Data
         {
             HexCoordinate coord;
             return villagerGroupCoordinates.TryGetValue(id, out coord) ? (HexCoordinate?)coord : null;
+        }
+
+        // Scout Management
+
+        // Reverse lookup: coordinate → scout ID (O(1) instead of O(N) scan)
+        private Dictionary<HexCoordinate, Guid> coordinateToScout = new Dictionary<HexCoordinate, Guid>();
+
+        public void RegisterScout(Guid id, HexCoordinate coordinate)
+        {
+            scoutIDs.Add(id);
+            scoutCoordinates[id] = coordinate;
+            coordinateToScout[coordinate] = id;
+        }
+
+        public void UnregisterScout(Guid id)
+        {
+            HexCoordinate coord;
+            if (scoutCoordinates.TryGetValue(id, out coord))
+                coordinateToScout.Remove(coord);
+            scoutIDs.Remove(id);
+            scoutCoordinates.Remove(id);
+        }
+
+        public void UpdateScoutPosition(Guid id, HexCoordinate coordinate)
+        {
+            HexCoordinate oldCoord;
+            if (scoutCoordinates.TryGetValue(id, out oldCoord))
+                coordinateToScout.Remove(oldCoord);
+            scoutCoordinates[id] = coordinate;
+            coordinateToScout[coordinate] = id;
+        }
+
+        public Guid? GetScoutID(HexCoordinate coordinate)
+        {
+            Guid id;
+            if (coordinateToScout.TryGetValue(coordinate, out id))
+                return id;
+            return null;
         }
 
         // Entity Stacking

--- a/Sporefront/Assets/Scripts/Data/PlayerCommandRegistry.cs
+++ b/Sporefront/Assets/Scripts/Data/PlayerCommandRegistry.cs
@@ -194,6 +194,20 @@ namespace Sporefront.Data
         public string buildingID;
     }
 
+    [Serializable]
+    public class MoveScoutParams
+    {
+        public string scoutID;
+        public int destinationQ;
+        public int destinationR;
+    }
+
+    [Serializable]
+    public class TrainScoutParams
+    {
+        public string buildingID;
+    }
+
     // ================================================================
     // Player Command Registry
     // ================================================================
@@ -451,6 +465,22 @@ namespace Sporefront.Data
                 {
                     upgradeTypeRawValue = upgradeUnit.upgradeTypeRawValue,
                     buildingID = upgradeUnit.buildingID.ToString()
+                });
+            }
+            if (command is MoveScoutCommand moveScout)
+            {
+                return JsonUtility.ToJson(new MoveScoutParams
+                {
+                    scoutID = moveScout.scoutID.ToString(),
+                    destinationQ = moveScout.destination.q,
+                    destinationR = moveScout.destination.r
+                });
+            }
+            if (command is TrainScoutCommand trainScout)
+            {
+                return JsonUtility.ToJson(new TrainScoutParams
+                {
+                    buildingID = trainScout.buildingID.ToString()
                 });
             }
 
@@ -781,6 +811,25 @@ namespace Sporefront.Data
                     Guid bID;
                     if (!Guid.TryParse(p.buildingID, out bID)) return null;
                     return new UpgradeUnitCommand(cmdId, pid, timestamp, p.upgradeTypeRawValue, bID);
+                }
+
+                case "MoveScoutCommand":
+                {
+                    var p = SafeFromJson<MoveScoutParams>(json);
+                    if (p == null) return null;
+                    Guid sID;
+                    if (!Guid.TryParse(p.scoutID, out sID)) return null;
+                    var dest = new HexCoordinate(p.destinationQ, p.destinationR);
+                    return new MoveScoutCommand(cmdId, pid, timestamp, sID, dest);
+                }
+
+                case "TrainScoutCommand":
+                {
+                    var p = SafeFromJson<TrainScoutParams>(json);
+                    if (p == null) return null;
+                    Guid bID;
+                    if (!Guid.TryParse(p.buildingID, out bID)) return null;
+                    return new TrainScoutCommand(cmdId, pid, timestamp, bID);
                 }
 
                 default:

--- a/Sporefront/Assets/Scripts/Data/ScoutData.cs
+++ b/Sporefront/Assets/Scripts/Data/ScoutData.cs
@@ -1,0 +1,91 @@
+// ============================================================================
+// FILE: Data/ScoutData.cs
+// PURPOSE: Mycelium Scout — fast, fragile scouting entity with extended vision
+//          and stamina. Trained from City Center, player starts with one.
+// ============================================================================
+
+using System;
+using System.Collections.Generic;
+using Sporefront.Models;
+using Sporefront.Engine;
+
+namespace Sporefront.Data
+{
+    [System.Serializable]
+    public class ScoutData
+    {
+        public Guid id;
+        public Guid? ownerID;
+        public HexCoordinate coordinate;
+
+        // Movement
+        public List<HexCoordinate> currentPath;
+        public int pathIndex;
+        public double movementProgress;
+        [System.NonSerialized] public double movementSpeed;
+
+        // Stats
+        public double hp;
+        public double maxHp;
+        public double stamina;
+        public double maxStamina;
+        public int visionRange;
+
+        public ScoutData(HexCoordinate coordinate, Guid? ownerID = null)
+        {
+            this.id = Guid.NewGuid();
+            this.ownerID = ownerID;
+            this.coordinate = coordinate;
+            this.currentPath = new List<HexCoordinate>();
+            this.pathIndex = 0;
+            this.movementProgress = 0.0;
+            this.hp = GameConfig.Scout.MaxHp;
+            this.maxHp = GameConfig.Scout.MaxHp;
+            this.stamina = GameConfig.Scout.MaxStamina;
+            this.maxStamina = GameConfig.Scout.MaxStamina;
+            this.visionRange = GameConfig.Scout.VisionRange;
+        }
+
+        // ================================================================
+        // Path Management
+        // ================================================================
+
+        public void SetPath(List<HexCoordinate> path)
+        {
+            currentPath = path ?? new List<HexCoordinate>();
+            pathIndex = 0;
+            movementProgress = 0.0;
+        }
+
+        public void ClearPath()
+        {
+            currentPath.Clear();
+            pathIndex = 0;
+            movementProgress = 0.0;
+        }
+
+        public bool HasPath()
+        {
+            return currentPath != null && pathIndex < currentPath.Count;
+        }
+
+        // ================================================================
+        // Stamina
+        // ================================================================
+
+        public bool HasEnoughStamina()
+        {
+            return stamina >= GameConfig.Scout.StaminaCostPerTile;
+        }
+
+        public void ConsumeStamina(double amount)
+        {
+            stamina = Math.Max(0, stamina - amount);
+        }
+
+        public void RegenerateStamina(double amount)
+        {
+            stamina = Math.Min(maxStamina, stamina + amount);
+        }
+    }
+}

--- a/Sporefront/Assets/Scripts/Data/ScoutData.cs.meta
+++ b/Sporefront/Assets/Scripts/Data/ScoutData.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 60e9b3e598a8d4dc8a99b2a5d692c678

--- a/Sporefront/Assets/Scripts/Data/StateChange.cs
+++ b/Sporefront/Assets/Scripts/Data/StateChange.cs
@@ -22,6 +22,7 @@ namespace Sporefront.Data
         Commander     = 1 << 10,
         Entrenchment  = 1 << 11,
         UnitUpgrade   = 1 << 12,
+        Scouts        = 1 << 13,
     }
 
     // Base class for all state changes
@@ -146,6 +147,17 @@ namespace Sporefront.Data
                 case UnitUpgradeProgressChange _:
                 case UnitUpgradeCompletedChange _:
                     return StateChangeFlags.UnitUpgrade;
+
+                // Scouts
+                case ScoutCreatedChange _:
+                case ScoutRemovedChange _:
+                case ScoutStaminaChange _:
+                case ScoutTrainingStartedChange _:
+                case ScoutTrainingCompletedChange _:
+                case ScoutTrainingProgressChange _:
+                    return StateChangeFlags.Scouts;
+                case ScoutMovedChange _:
+                    return StateChangeFlags.Scouts | StateChangeFlags.Movement;
 
                 // Diplomacy
                 case DiplomacyChangedChange _:
@@ -417,6 +429,24 @@ namespace Sporefront.Data
             this.buildingDamage = buildingDamage;
         }
     }
+
+    // ================================================================
+    // Scout Changes
+    // ================================================================
+
+    public class ScoutCreatedChange : StateChange { public Guid scoutID; public Guid ownerID; public HexCoordinate coordinate; }
+    public class ScoutMovedChange : StateChange
+    {
+        public Guid scoutID;
+        public HexCoordinate from;
+        public HexCoordinate to;
+        public List<HexCoordinate> path;
+    }
+    public class ScoutRemovedChange : StateChange { public Guid scoutID; public HexCoordinate coordinate; }
+    public class ScoutStaminaChange : StateChange { public Guid scoutID; public double stamina; }
+    public class ScoutTrainingStartedChange : StateChange { public Guid buildingID; public double startTime; }
+    public class ScoutTrainingCompletedChange : StateChange { public Guid buildingID; public Guid scoutID; public HexCoordinate coordinate; }
+    public class ScoutTrainingProgressChange : StateChange { public Guid buildingID; public int entryIndex; public double progress; }
 
     [System.Serializable]
     public class StateChangeBatch

--- a/Sporefront/Assets/Scripts/Data/TrainingQueueEntry.cs
+++ b/Sporefront/Assets/Scripts/Data/TrainingQueueEntry.cs
@@ -1,4 +1,5 @@
 using System;
+using Sporefront.Engine;
 using Sporefront.Models;
 
 namespace Sporefront.Data
@@ -53,6 +54,27 @@ namespace Sporefront.Data
             double elapsed = currentTime - startTime;
             double totalTime = TrainingTimePerVillager * quantity;
             return Math.Min(1.0, elapsed / totalTime);
+        }
+    }
+
+    [System.Serializable]
+    public class ScoutTrainingEntry
+    {
+        public Guid id;
+        public double startTime;
+        public double progress;
+
+        public ScoutTrainingEntry(double startTime)
+        {
+            this.id = Guid.NewGuid();
+            this.startTime = startTime;
+            this.progress = 0.0;
+        }
+
+        public double GetProgress(double currentTime)
+        {
+            double elapsed = currentTime - startTime;
+            return Math.Min(1.0, elapsed / Sporefront.Engine.GameConfig.Scout.TrainingTime);
         }
     }
 }

--- a/Sporefront/Assets/Scripts/Engine/ArabiaMapGenerator.cs
+++ b/Sporefront/Assets/Scripts/Engine/ArabiaMapGenerator.cs
@@ -559,27 +559,7 @@ namespace Sporefront.Engine
             int exclusionRadius,
             HashSet<HexCoordinate> used)
         {
-            for (int attempt = 0; attempt < 20 && candidates.Count > 0; attempt++)
-            {
-                int idx = rng.NextInt(0, candidates.Count - 1);
-                var coord = candidates[idx];
-
-                if (used.Contains(coord)) continue;
-
-                bool tooClose = false;
-                foreach (var startPos in startPositions)
-                {
-                    if (coord.Distance(startPos) < exclusionRadius)
-                    {
-                        tooClose = true;
-                        break;
-                    }
-                }
-                if (tooClose) continue;
-
-                return coord;
-            }
-            return null;
+            return FindValidPlacement(rng, candidates, startPositions, exclusionRadius, used);
         }
 
         // ================================================================
@@ -714,181 +694,27 @@ namespace Sporefront.Engine
         /// Place a small mining hill (4-5 tiles) at distance 5-6 from spawn for starting ore/stone.
         /// Returns the hill tile coordinates.
         /// </summary>
+        // Delegates to base class methods
+
         private List<HexCoordinate> PlaceStartingMiningHill(
             Dictionary<HexCoordinate, TerrainGenerationData> terrain,
             HexCoordinate spawnPosition)
         {
-            var hillCoords = new List<HexCoordinate>();
-
-            // Find a suitable center at distance 5-6 from spawn
-            var candidates = new List<HexCoordinate>();
-            for (int q = -7; q <= 7; q++)
-            {
-                for (int r = -7; r <= 7; r++)
-                {
-                    var coord = new HexCoordinate(spawnPosition.q + q, spawnPosition.r + r);
-                    int dist = coord.Distance(spawnPosition);
-                    if (dist >= 5 && dist <= 6)
-                    {
-                        if (coord.q >= 0 && coord.q < Width && coord.r >= 0 && coord.r < Height)
-                        {
-                            candidates.Add(coord);
-                        }
-                    }
-                }
-            }
-
-            if (candidates.Count == 0) return hillCoords;
-
-            rng.Shuffle(candidates);
-            var center = candidates[0];
-
-            // BFS expand 4-5 hill tiles from center
-            int hillSize = rng.NextInt(4, 5);
-            var frontier = new List<HexCoordinate> { center };
-            var visited = new HashSet<HexCoordinate>();
-            int placed = 0;
-
-            while (placed < hillSize && frontier.Count > 0)
-            {
-                var current = frontier[0];
-                frontier.RemoveAt(0);
-
-                if (visited.Contains(current)) continue;
-                if (current.q < 0 || current.q >= Width || current.r < 0 || current.r >= Height) continue;
-                visited.Add(current);
-
-                TerrainGenerationData data;
-                if (terrain.TryGetValue(current, out data))
-                {
-                    data.terrain = TerrainType.Hill;
-                    data.elevation = 1;
-                    terrain[current] = data;
-                    hillCoords.Add(current);
-                    placed++;
-
-                    var neighbors = current.Neighbors();
-                    var neighborList = new List<HexCoordinate>(neighbors);
-                    rng.Shuffle(neighborList);
-                    foreach (var neighbor in neighborList)
-                    {
-                        if (!visited.Contains(neighbor))
-                        {
-                            frontier.Add(neighbor);
-                        }
-                    }
-                }
-            }
-
-            return hillCoords;
-        }
-
-        private HexCoordinate? FindUnusedCoordinate(
-            List<HexCoordinate> coords, HashSet<HexCoordinate> used)
-        {
-            while (coords.Count > 0)
-            {
-                var coord = coords[0];
-                coords.RemoveAt(0);
-                if (!used.Contains(coord))
-                    return coord;
-            }
-            return null;
+            return base.PlaceStartingMiningHill(rng, terrain, spawnPosition, 4, 5);
         }
 
         private List<ResourcePlacement> PlaceResourceCluster(
             ResourcePointType type, int size, HexCoordinate center,
             int radius, HashSet<HexCoordinate> used)
         {
-            var placements = new List<ResourcePlacement>();
-            var usedLocal = new HashSet<HexCoordinate>(used);
-
-            // Find candidate starting points for the cluster
-            var candidates = new List<HexCoordinate>();
-            for (int q = -radius; q <= radius; q++)
-            {
-                for (int r = -radius; r <= radius; r++)
-                {
-                    var coord = new HexCoordinate(center.q + q, center.r + r);
-                    if (coord.Distance(center) <= radius && !usedLocal.Contains(coord))
-                    {
-                        candidates.Add(coord);
-                    }
-                }
-            }
-
-            rng.Shuffle(candidates);
-
-            if (candidates.Count == 0) return placements;
-            var startCoord = candidates[0];
-
-            // BFS to create adjacent cluster
-            var frontier = new List<HexCoordinate> { startCoord };
-            int placed = 0;
-
-            while (placed < size && frontier.Count > 0)
-            {
-                var current = frontier[0];
-                frontier.RemoveAt(0);
-
-                if (usedLocal.Contains(current)) continue;
-                if (current.Distance(center) > radius) continue;
-
-                placements.Add(new ResourcePlacement(current, type));
-                usedLocal.Add(current);
-                placed++;
-
-                // Add neighbors to frontier (shuffled for organic shape)
-                var neighbors = current.Neighbors();
-                var neighborList = new List<HexCoordinate>(neighbors);
-                rng.Shuffle(neighborList);
-                foreach (var neighbor in neighborList)
-                {
-                    if (!usedLocal.Contains(neighbor) && neighbor.Distance(center) <= radius)
-                    {
-                        frontier.Add(neighbor);
-                    }
-                }
-            }
-
-            return placements;
+            return base.PlaceResourceCluster(rng, type, size, center, radius, used);
         }
 
         private List<ResourcePlacement> GenerateResourceCluster(
             ResourcePointType type, int size, HexCoordinate center,
             HashSet<HexCoordinate> used)
         {
-            var placements = new List<ResourcePlacement>();
-            var usedLocal = new HashSet<HexCoordinate>(used);
-            var frontier = new List<HexCoordinate> { center };
-            int placed = 0;
-
-            while (placed < size && frontier.Count > 0)
-            {
-                var current = frontier[0];
-                frontier.RemoveAt(0);
-
-                if (usedLocal.Contains(current)) continue;
-                if (current.q < 0 || current.q >= Width || current.r < 0 || current.r >= Height) continue;
-
-                placements.Add(new ResourcePlacement(current, type));
-                usedLocal.Add(current);
-                placed++;
-
-                // Add neighbors to frontier (shuffled for organic shape)
-                var neighbors = current.Neighbors();
-                var neighborList = new List<HexCoordinate>(neighbors);
-                rng.Shuffle(neighborList);
-                foreach (var neighbor in neighborList)
-                {
-                    if (!usedLocal.Contains(neighbor))
-                    {
-                        frontier.Add(neighbor);
-                    }
-                }
-            }
-
-            return placements;
+            return base.GenerateResourceCluster(rng, type, size, center, used);
         }
     }
 }

--- a/Sporefront/Assets/Scripts/Engine/CombatEngine.cs
+++ b/Sporefront/Assets/Scripts/Engine/CombatEngine.cs
@@ -196,6 +196,46 @@ namespace Sporefront.Engine
             var poisonChanges = ProcessPoisonDamage(currentTime, gameState);
             changes.AddRange(poisonChanges);
 
+            // Eliminate scouts on contact with enemy armies
+            var scoutChanges = ProcessScoutElimination(gameState);
+            changes.AddRange(scoutChanges);
+
+            return changes;
+        }
+
+        // MARK: - Scout Elimination (instant kill on enemy army contact)
+
+        private List<StateChange> ProcessScoutElimination(GameState state)
+        {
+            var changes = new List<StateChange>();
+            var scoutsToRemove = new List<Guid>();
+
+            foreach (var scout in state.scouts.Values)
+            {
+                if (!scout.ownerID.HasValue) continue;
+
+                // Check if any enemy army is on the same tile
+                var armiesAtTile = state.GetArmies(scout.coordinate);
+                foreach (var army in armiesAtTile)
+                {
+                    if (army.ownerID.HasValue && army.ownerID.Value != scout.ownerID.Value)
+                    {
+                        scoutsToRemove.Add(scout.id);
+                        changes.Add(new ScoutRemovedChange
+                        {
+                            scoutID = scout.id,
+                            coordinate = scout.coordinate
+                        });
+                        break;
+                    }
+                }
+            }
+
+            foreach (var id in scoutsToRemove)
+            {
+                state.RemoveScout(id);
+            }
+
             return changes;
         }
 

--- a/Sporefront/Assets/Scripts/Engine/ConstructionEngine.cs
+++ b/Sporefront/Assets/Scripts/Engine/ConstructionEngine.cs
@@ -45,14 +45,50 @@ namespace Sporefront.Engine
                 // Check for builder arrival at planning-state buildings
                 if (building.state == BuildingState.Planning)
                 {
+                    bool hasBuilder = false;
                     foreach (var group in gameState.villagerGroups.Values)
                     {
-                        if (group.currentTask is BuildingTask bt && bt.BuildingID == building.id &&
-                            group.coordinate == building.coordinate && group.currentPath == null)
+                        if (group.currentTask is BuildingTask bt && bt.BuildingID == building.id)
                         {
-                            building.StartConstruction(currentTime, group.villagerCount);
-                            changes.Add(new BuildingConstructionStartedChange { buildingID = building.id });
+                            hasBuilder = true;
+                            if (group.coordinate == building.coordinate && group.currentPath == null)
+                            {
+                                building.StartConstruction(currentTime, group.villagerCount);
+                                changes.Add(new BuildingConstructionStartedChange { buildingID = building.id });
+                            }
                             break;
+                        }
+                    }
+
+                    // Auto-assign nearest idle villager to unattended Planning buildings
+                    if (!hasBuilder && building.ownerID.HasValue)
+                    {
+                        VillagerGroupData nearest = null;
+                        int bestDist = int.MaxValue;
+                        var playerGroups = gameState.GetVillagerGroupsForPlayer(building.ownerID.Value);
+                        if (playerGroups != null)
+                        {
+                            foreach (var g in playerGroups)
+                            {
+                                if (g.currentTask.IsIdle && !g.HasPath() && g.HasVillagers())
+                                {
+                                    int d = g.coordinate.Distance(building.coordinate);
+                                    if (d < bestDist) { bestDist = d; nearest = g; }
+                                }
+                            }
+                        }
+                        if (nearest != null)
+                        {
+                            nearest.AssignTask(new BuildingTask(building.id), building.coordinate, building.id);
+                            changes.Add(new VillagerGroupTaskChangedChange
+                            {
+                                groupID = nearest.id,
+                                task = "Building",
+                                targetCoordinate = building.coordinate
+                            });
+                            var path = gameState.mapData.FindPath(nearest.coordinate, building.coordinate,
+                                building.ownerID.Value, gameState);
+                            if (path != null) nearest.SetPath(path);
                         }
                     }
                 }

--- a/Sporefront/Assets/Scripts/Engine/GameConfig.cs
+++ b/Sporefront/Assets/Scripts/Engine/GameConfig.cs
@@ -52,6 +52,18 @@ namespace Sporefront.Engine
             public const double LethalSporesDurationMultiplier = 1.5;    // Tier II: +50% duration
         }
 
+        public static class Scout
+        {
+            public const double MovementSpeedMultiplier = 1.5;     // 50% faster than armies
+            public const double MaxStamina = 100.0;
+            public const double StaminaCostPerTile = 10.0;
+            public const double StaminaRegenPerSecond = 5.0;
+            public const int VisionRange = 3;
+            public const double TrainingTime = 15.0;
+            public const int FoodCost = 50;
+            public const double MaxHp = 30.0;
+        }
+
         public static class Resources
         {
             public const double BaseGatherRatePerVillager = 0.2;

--- a/Sporefront/Assets/Scripts/Engine/GoldRushMapGenerator.cs
+++ b/Sporefront/Assets/Scripts/Engine/GoldRushMapGenerator.cs
@@ -480,82 +480,19 @@ namespace Sporefront.Engine
             Dictionary<HexCoordinate, TerrainGenerationData> terrain,
             HexCoordinate spawnPosition)
         {
-            var candidates = new List<HexCoordinate>();
-            for (int q = -7; q <= 7; q++)
-            {
-                for (int r = -7; r <= 7; r++)
-                {
-                    var coord = new HexCoordinate(spawnPosition.q + q, spawnPosition.r + r);
-                    int dist = coord.Distance(spawnPosition);
-                    if (dist >= 5 && dist <= 6)
-                    {
-                        if (coord.q >= 0 && coord.q < Width && coord.r >= 0 && coord.r < Height)
-                            candidates.Add(coord);
-                    }
-                }
-            }
-
-            if (candidates.Count == 0) return;
-
-            rng.Shuffle(candidates);
-            var center = candidates[0];
-
-            int hillSize = rng.NextInt(3, 4);
-            var frontier = new List<HexCoordinate> { center };
-            var visited = new HashSet<HexCoordinate>();
-            int placed = 0;
-
-            while (placed < hillSize && frontier.Count > 0)
-            {
-                var cur = frontier[0];
-                frontier.RemoveAt(0);
-
-                if (visited.Contains(cur)) continue;
-                if (cur.q < 0 || cur.q >= Width || cur.r < 0 || cur.r >= Height) continue;
-                visited.Add(cur);
-
-                TerrainGenerationData data;
-                if (terrain.TryGetValue(cur, out data))
-                {
-                    data.terrain = TerrainType.Hill;
-                    data.elevation = 1;
-                    terrain[cur] = data;
-                    placed++;
-
-                    var neighbors = cur.Neighbors();
-                    var neighborList = new List<HexCoordinate>(neighbors);
-                    rng.Shuffle(neighborList);
-                    foreach (var neighbor in neighborList)
-                    {
-                        if (!visited.Contains(neighbor))
-                            frontier.Add(neighbor);
-                    }
-                }
-            }
+            base.PlaceStartingMiningHill(rng, terrain, spawnPosition, 3, 4);
         }
 
         // ================================================================
-        // Resource Placement Helpers
+        // Resource Placement Helpers — delegates to MapGeneratorBase
         // ================================================================
 
         private void PlaceTreePockets(int count, int sizeMin, int sizeMax,
             List<HexCoordinate> zoneTiles, List<HexCoordinate> startPositions,
             int exclusionRadius, List<ResourcePlacement> placements, HashSet<HexCoordinate> used)
         {
-            for (int i = 0; i < count; i++)
-            {
-                var center = FindValidPlacement(zoneTiles, startPositions, exclusionRadius, used);
-                if (!center.HasValue) continue;
-
-                int pocketSize = rng.NextInt(sizeMin, sizeMax);
-                var treePlacements = GenerateResourceCluster(
-                    ResourcePointType.Trees, pocketSize, center.Value, used);
-                foreach (var placement in treePlacements)
-                {
-                    placements.Add(placement);
-                    used.Add(placement.coordinate);
-                }
-            }
+            base.PlaceTreePockets(rng, count, sizeMin, sizeMax, zoneTiles, startPositions,
+                exclusionRadius, placements, used);
         }
 
         private void PlaceMineralClusters(int count, ResourcePointType type, int sizeMin, int sizeMax,
@@ -564,12 +501,11 @@ namespace Sporefront.Engine
         {
             for (int i = 0; i < count; i++)
             {
-                var center = FindValidPlacement(zoneTiles, startPositions, exclusionRadius, used);
+                var center = FindValidPlacement(rng, zoneTiles, startPositions, exclusionRadius, used);
                 if (!center.HasValue) continue;
 
                 int depositSize = rng.NextInt(sizeMin, sizeMax);
-                var mineralPlacements = GenerateResourceCluster(
-                    type, depositSize, center.Value, used);
+                var mineralPlacements = GenerateResourceCluster(rng, type, depositSize, center.Value, used);
                 foreach (var placement in mineralPlacements)
                 {
                     placements.Add(placement);
@@ -582,158 +518,29 @@ namespace Sporefront.Engine
             List<HexCoordinate> zoneTiles, List<HexCoordinate> startPositions,
             int exclusionRadius, List<ResourcePlacement> placements, HashSet<HexCoordinate> used)
         {
-            for (int i = 0; i < count; i++)
-            {
-                var coord = FindValidPlacement(zoneTiles, startPositions, exclusionRadius, used);
-                if (!coord.HasValue) continue;
-
-                var animalType = rng.NextBool() ? ResourcePointType.Deer : ResourcePointType.WildBoar;
-                placements.Add(new ResourcePlacement(coord.Value, animalType));
-                used.Add(coord.Value);
-            }
+            base.PlaceAnimals(rng, count, zoneTiles, startPositions, exclusionRadius, placements, used);
         }
 
         private void PlaceScatteredResources(int count, ResourcePointType type,
             List<HexCoordinate> zoneTiles, List<HexCoordinate> startPositions,
             int exclusionRadius, List<ResourcePlacement> placements, HashSet<HexCoordinate> used)
         {
-            for (int i = 0; i < count; i++)
-            {
-                var coord = FindValidPlacement(zoneTiles, startPositions, exclusionRadius, used);
-                if (!coord.HasValue) continue;
-
-                placements.Add(new ResourcePlacement(coord.Value, type));
-                used.Add(coord.Value);
-            }
-        }
-
-        private HexCoordinate? FindValidPlacement(
-            List<HexCoordinate> candidates, List<HexCoordinate> startPositions,
-            int exclusionRadius, HashSet<HexCoordinate> used)
-        {
-            for (int attempt = 0; attempt < 20 && candidates.Count > 0; attempt++)
-            {
-                int idx = rng.NextInt(0, candidates.Count - 1);
-                var coord = candidates[idx];
-
-                if (used.Contains(coord)) continue;
-
-                if (exclusionRadius > 0)
-                {
-                    bool tooClose = false;
-                    foreach (var startPos in startPositions)
-                    {
-                        if (coord.Distance(startPos) < exclusionRadius)
-                        {
-                            tooClose = true;
-                            break;
-                        }
-                    }
-                    if (tooClose) continue;
-                }
-
-                return coord;
-            }
-            return null;
-        }
-
-        private HexCoordinate? FindUnusedCoordinate(
-            List<HexCoordinate> coords, HashSet<HexCoordinate> used)
-        {
-            while (coords.Count > 0)
-            {
-                var coord = coords[0];
-                coords.RemoveAt(0);
-                if (!used.Contains(coord))
-                    return coord;
-            }
-            return null;
+            base.PlaceScatteredResources(rng, count, type, zoneTiles, startPositions,
+                exclusionRadius, placements, used);
         }
 
         private List<ResourcePlacement> PlaceResourceCluster(
             ResourcePointType type, int size, HexCoordinate center,
             int radius, HashSet<HexCoordinate> used)
         {
-            var placements = new List<ResourcePlacement>();
-            var usedLocal = new HashSet<HexCoordinate>(used);
-
-            var candidates = new List<HexCoordinate>();
-            for (int q = -radius; q <= radius; q++)
-            {
-                for (int r = -radius; r <= radius; r++)
-                {
-                    var coord = new HexCoordinate(center.q + q, center.r + r);
-                    if (coord.Distance(center) <= radius && !usedLocal.Contains(coord))
-                    {
-                        candidates.Add(coord);
-                    }
-                }
-            }
-
-            rng.Shuffle(candidates);
-            if (candidates.Count == 0) return placements;
-            var startCoord = candidates[0];
-
-            var frontier = new List<HexCoordinate> { startCoord };
-            int placed = 0;
-
-            while (placed < size && frontier.Count > 0)
-            {
-                var current = frontier[0];
-                frontier.RemoveAt(0);
-
-                if (usedLocal.Contains(current)) continue;
-                if (current.Distance(center) > radius) continue;
-
-                placements.Add(new ResourcePlacement(current, type));
-                usedLocal.Add(current);
-                placed++;
-
-                var neighbors = current.Neighbors();
-                var neighborList = new List<HexCoordinate>(neighbors);
-                rng.Shuffle(neighborList);
-                foreach (var neighbor in neighborList)
-                {
-                    if (!usedLocal.Contains(neighbor) && neighbor.Distance(center) <= radius)
-                        frontier.Add(neighbor);
-                }
-            }
-
-            return placements;
+            return base.PlaceResourceCluster(rng, type, size, center, radius, used);
         }
 
         private List<ResourcePlacement> GenerateResourceCluster(
             ResourcePointType type, int size, HexCoordinate center,
             HashSet<HexCoordinate> used)
         {
-            var placements = new List<ResourcePlacement>();
-            var usedLocal = new HashSet<HexCoordinate>(used);
-            var frontier = new List<HexCoordinate> { center };
-            int placed = 0;
-
-            while (placed < size && frontier.Count > 0)
-            {
-                var current = frontier[0];
-                frontier.RemoveAt(0);
-
-                if (usedLocal.Contains(current)) continue;
-                if (current.q < 0 || current.q >= Width || current.r < 0 || current.r >= Height) continue;
-
-                placements.Add(new ResourcePlacement(current, type));
-                usedLocal.Add(current);
-                placed++;
-
-                var neighbors = current.Neighbors();
-                var neighborList = new List<HexCoordinate>(neighbors);
-                rng.Shuffle(neighborList);
-                foreach (var neighbor in neighborList)
-                {
-                    if (!usedLocal.Contains(neighbor))
-                        frontier.Add(neighbor);
-                }
-            }
-
-            return placements;
+            return base.GenerateResourceCluster(rng, type, size, center, used);
         }
     }
 }

--- a/Sporefront/Assets/Scripts/Engine/GoldRushMapGenerator.cs.meta
+++ b/Sporefront/Assets/Scripts/Engine/GoldRushMapGenerator.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 257d4c334884647da9b4129b7bad233e

--- a/Sporefront/Assets/Scripts/Engine/MapGenerator.cs
+++ b/Sporefront/Assets/Scripts/Engine/MapGenerator.cs
@@ -4,6 +4,7 @@
 //          C# port of MapGenerator.swift
 // ============================================================================
 
+using System;
 using System.Collections.Generic;
 using Sporefront.Data;
 using Sporefront.Models;
@@ -123,6 +124,257 @@ namespace Sporefront.Engine
                     }
                 }
             }
+        }
+
+        // ================================================================
+        // Shared Resource Placement Utilities
+        // ================================================================
+
+        protected HexCoordinate? FindValidPlacement(
+            SeededRandom rng, List<HexCoordinate> candidates,
+            List<HexCoordinate> startPositions, int exclusionRadius,
+            HashSet<HexCoordinate> used)
+        {
+            for (int attempt = 0; attempt < 20 && candidates.Count > 0; attempt++)
+            {
+                int idx = rng.NextInt(0, candidates.Count - 1);
+                var coord = candidates[idx];
+
+                if (used.Contains(coord)) continue;
+
+                if (exclusionRadius > 0)
+                {
+                    bool tooClose = false;
+                    foreach (var startPos in startPositions)
+                    {
+                        if (coord.Distance(startPos) < exclusionRadius)
+                        {
+                            tooClose = true;
+                            break;
+                        }
+                    }
+                    if (tooClose) continue;
+                }
+
+                return coord;
+            }
+            return null;
+        }
+
+        protected HexCoordinate? FindUnusedCoordinate(
+            List<HexCoordinate> coords, HashSet<HexCoordinate> used)
+        {
+            while (coords.Count > 0)
+            {
+                var coord = coords[0];
+                coords.RemoveAt(0);
+                if (!used.Contains(coord))
+                    return coord;
+            }
+            return null;
+        }
+
+        protected List<ResourcePlacement> GenerateResourceCluster(
+            SeededRandom rng, ResourcePointType type, int size,
+            HexCoordinate center, HashSet<HexCoordinate> used)
+        {
+            var placements = new List<ResourcePlacement>();
+            var usedLocal = new HashSet<HexCoordinate>(used);
+            var frontier = new List<HexCoordinate> { center };
+            int placed = 0;
+
+            while (placed < size && frontier.Count > 0)
+            {
+                var current = frontier[0];
+                frontier.RemoveAt(0);
+
+                if (usedLocal.Contains(current)) continue;
+                if (current.q < 0 || current.q >= Width || current.r < 0 || current.r >= Height) continue;
+
+                placements.Add(new ResourcePlacement(current, type));
+                usedLocal.Add(current);
+                placed++;
+
+                var neighbors = current.Neighbors();
+                var neighborList = new List<HexCoordinate>(neighbors);
+                rng.Shuffle(neighborList);
+                foreach (var neighbor in neighborList)
+                {
+                    if (!usedLocal.Contains(neighbor))
+                        frontier.Add(neighbor);
+                }
+            }
+
+            return placements;
+        }
+
+        protected List<ResourcePlacement> PlaceResourceCluster(
+            SeededRandom rng, ResourcePointType type, int size,
+            HexCoordinate center, int radius, HashSet<HexCoordinate> used)
+        {
+            var placements = new List<ResourcePlacement>();
+            var usedLocal = new HashSet<HexCoordinate>(used);
+
+            var candidates = new List<HexCoordinate>();
+            for (int q = -radius; q <= radius; q++)
+            {
+                for (int r = -radius; r <= radius; r++)
+                {
+                    var coord = new HexCoordinate(center.q + q, center.r + r);
+                    if (coord.Distance(center) <= radius && !usedLocal.Contains(coord))
+                        candidates.Add(coord);
+                }
+            }
+
+            rng.Shuffle(candidates);
+            if (candidates.Count == 0) return placements;
+            var startCoord = candidates[0];
+
+            var frontier = new List<HexCoordinate> { startCoord };
+            int placed = 0;
+
+            while (placed < size && frontier.Count > 0)
+            {
+                var current = frontier[0];
+                frontier.RemoveAt(0);
+
+                if (usedLocal.Contains(current)) continue;
+                if (current.Distance(center) > radius) continue;
+
+                placements.Add(new ResourcePlacement(current, type));
+                usedLocal.Add(current);
+                placed++;
+
+                var neighbors = current.Neighbors();
+                var neighborList = new List<HexCoordinate>(neighbors);
+                rng.Shuffle(neighborList);
+                foreach (var neighbor in neighborList)
+                {
+                    if (!usedLocal.Contains(neighbor) && neighbor.Distance(center) <= radius)
+                        frontier.Add(neighbor);
+                }
+            }
+
+            return placements;
+        }
+
+        protected void PlaceAnimals(
+            SeededRandom rng, int count,
+            List<HexCoordinate> zoneTiles, List<HexCoordinate> startPositions,
+            int exclusionRadius, List<ResourcePlacement> placements,
+            HashSet<HexCoordinate> used)
+        {
+            for (int i = 0; i < count; i++)
+            {
+                var coord = FindValidPlacement(rng, zoneTiles, startPositions, exclusionRadius, used);
+                if (!coord.HasValue) continue;
+
+                var animalType = rng.NextBool() ? ResourcePointType.Deer : ResourcePointType.WildBoar;
+                placements.Add(new ResourcePlacement(coord.Value, animalType));
+                used.Add(coord.Value);
+            }
+        }
+
+        protected void PlaceScatteredResources(
+            SeededRandom rng, int count, ResourcePointType type,
+            List<HexCoordinate> zoneTiles, List<HexCoordinate> startPositions,
+            int exclusionRadius, List<ResourcePlacement> placements,
+            HashSet<HexCoordinate> used)
+        {
+            for (int i = 0; i < count; i++)
+            {
+                var coord = FindValidPlacement(rng, zoneTiles, startPositions, exclusionRadius, used);
+                if (!coord.HasValue) continue;
+
+                placements.Add(new ResourcePlacement(coord.Value, type));
+                used.Add(coord.Value);
+            }
+        }
+
+        protected void PlaceTreePockets(
+            SeededRandom rng, int count, int sizeMin, int sizeMax,
+            List<HexCoordinate> zoneTiles, List<HexCoordinate> startPositions,
+            int exclusionRadius, List<ResourcePlacement> placements,
+            HashSet<HexCoordinate> used)
+        {
+            for (int i = 0; i < count; i++)
+            {
+                var center = FindValidPlacement(rng, zoneTiles, startPositions, exclusionRadius, used);
+                if (!center.HasValue) continue;
+
+                int pocketSize = rng.NextInt(sizeMin, sizeMax);
+                var treePlacements = GenerateResourceCluster(
+                    rng, ResourcePointType.Trees, pocketSize, center.Value, used);
+                foreach (var placement in treePlacements)
+                {
+                    placements.Add(placement);
+                    used.Add(placement.coordinate);
+                }
+            }
+        }
+
+        protected List<HexCoordinate> PlaceStartingMiningHill(
+            SeededRandom rng,
+            Dictionary<HexCoordinate, TerrainGenerationData> terrain,
+            HexCoordinate spawnPosition, int hillSizeMin = 4, int hillSizeMax = 5)
+        {
+            var hillCoords = new List<HexCoordinate>();
+
+            var candidates = new List<HexCoordinate>();
+            for (int q = -7; q <= 7; q++)
+            {
+                for (int r = -7; r <= 7; r++)
+                {
+                    var coord = new HexCoordinate(spawnPosition.q + q, spawnPosition.r + r);
+                    int dist = coord.Distance(spawnPosition);
+                    if (dist >= 5 && dist <= 6)
+                    {
+                        if (coord.q >= 0 && coord.q < Width && coord.r >= 0 && coord.r < Height)
+                            candidates.Add(coord);
+                    }
+                }
+            }
+
+            if (candidates.Count == 0) return hillCoords;
+
+            rng.Shuffle(candidates);
+            var center = candidates[0];
+
+            int hillSize = rng.NextInt(hillSizeMin, hillSizeMax);
+            var frontier = new List<HexCoordinate> { center };
+            var visited = new HashSet<HexCoordinate>();
+            int placed = 0;
+
+            while (placed < hillSize && frontier.Count > 0)
+            {
+                var cur = frontier[0];
+                frontier.RemoveAt(0);
+
+                if (visited.Contains(cur)) continue;
+                if (cur.q < 0 || cur.q >= Width || cur.r < 0 || cur.r >= Height) continue;
+                visited.Add(cur);
+
+                TerrainGenerationData data;
+                if (terrain.TryGetValue(cur, out data))
+                {
+                    data.terrain = TerrainType.Hill;
+                    data.elevation = 1;
+                    terrain[cur] = data;
+                    hillCoords.Add(cur);
+                    placed++;
+
+                    var neighbors = cur.Neighbors();
+                    var neighborList = new List<HexCoordinate>(neighbors);
+                    rng.Shuffle(neighborList);
+                    foreach (var neighbor in neighborList)
+                    {
+                        if (!visited.Contains(neighbor))
+                            frontier.Add(neighbor);
+                    }
+                }
+            }
+
+            return hillCoords;
         }
     }
 }

--- a/Sporefront/Assets/Scripts/Engine/MountainValleyMapGenerator.cs
+++ b/Sporefront/Assets/Scripts/Engine/MountainValleyMapGenerator.cs
@@ -48,7 +48,7 @@ namespace Sporefront.Engine
         public int zoneJitter = 4;
 
         // Terrain variation — probability of plains clearings on slopes (0.0–1.0)
-        public float slopePlainsClearingChance = 0.12f;
+        public double slopePlainsClearingChance = 0.12;
         public int plainsClearingMinSize = 3;
         public int plainsClearingMaxSize = 6;
 
@@ -433,7 +433,7 @@ namespace Sporefront.Engine
             int ridgeAnimals = config.ridgeAnimalCount * 2; // both ridges
             for (int i = 0; i < ridgeAnimals; i++)
             {
-                var coord = FindValidPlacement(ridgeTiles, aroundPositions, excludingRadius, usedCoordinates);
+                var coord = FindValidPlacement(rng, ridgeTiles, aroundPositions, excludingRadius, usedCoordinates);
                 if (coord.HasValue)
                 {
                     placements.Add(new ResourcePlacement(coord.Value, ResourcePointType.Deer));
@@ -516,7 +516,7 @@ namespace Sporefront.Engine
             foreach (var seed in slopeTiles)
             {
                 if (cleared.Contains(seed)) continue;
-                if (rng.NextFloat() > config.slopePlainsClearingChance) continue;
+                if (rng.NextDouble(0.0, 1.0) > config.slopePlainsClearingChance) continue;
 
                 // BFS expand a small clearing
                 int clearingSize = rng.NextInt(config.plainsClearingMinSize, config.plainsClearingMaxSize);
@@ -662,36 +662,24 @@ namespace Sporefront.Engine
             int exclusionRadius, List<ResourcePlacement> placements, HashSet<HexCoordinate> used)
         {
             int treeExclusionRadius = 6;
-            for (int i = 0; i < count; i++)
-            {
-                var center = FindValidPlacementWithExclusion(zoneTiles, startPositions, treeExclusionRadius, used);
-                if (!center.HasValue) continue;
-
-                int pocketSize = rng.NextInt(sizeMin, sizeMax);
-                var treePlacements = GenerateResourceCluster(
-                    ResourcePointType.Trees, pocketSize, center.Value, used);
-                foreach (var placement in treePlacements)
-                {
-                    placements.Add(placement);
-                    used.Add(placement.coordinate);
-                }
-            }
+            base.PlaceTreePockets(rng, count, sizeMin, sizeMax, zoneTiles, startPositions,
+                treeExclusionRadius, placements, used);
         }
 
+        // PlaceMineralDeposits has unique alternating ore/stone logic, so keep inline but use base helpers
         private void PlaceMineralDeposits(int count, int sizeMin, int sizeMax,
             List<HexCoordinate> zoneTiles, List<HexCoordinate> startPositions,
             int exclusionRadius, List<ResourcePlacement> placements, HashSet<HexCoordinate> used)
         {
             for (int i = 0; i < count; i++)
             {
-                var center = FindValidPlacementWithExclusion(zoneTiles, startPositions, exclusionRadius + 3, used);
+                var center = FindValidPlacement(rng, zoneTiles, startPositions, exclusionRadius + 3, used);
                 if (!center.HasValue) continue;
 
                 int depositSize = rng.NextInt(sizeMin, sizeMax);
                 var resourceType = (i % 2 == 0) ? ResourcePointType.OreMine : ResourcePointType.StoneQuarry;
 
-                var mineralPlacements = GenerateResourceCluster(
-                    resourceType, depositSize, center.Value, used);
+                var mineralPlacements = GenerateResourceCluster(rng, resourceType, depositSize, center.Value, used);
                 foreach (var placement in mineralPlacements)
                 {
                     placements.Add(placement);
@@ -700,176 +688,37 @@ namespace Sporefront.Engine
             }
         }
 
+        // ================================================================
+        // Resource Placement Helpers — delegates to MapGeneratorBase
+        // ================================================================
+
         private void PlaceAnimals(int count,
             List<HexCoordinate> zoneTiles, List<HexCoordinate> startPositions,
             int exclusionRadius, List<ResourcePlacement> placements, HashSet<HexCoordinate> used)
         {
-            for (int i = 0; i < count; i++)
-            {
-                var coord = FindValidPlacement(zoneTiles, startPositions, exclusionRadius, used);
-                if (!coord.HasValue) continue;
-
-                var animalType = rng.NextBool() ? ResourcePointType.Deer : ResourcePointType.WildBoar;
-                placements.Add(new ResourcePlacement(coord.Value, animalType));
-                used.Add(coord.Value);
-            }
+            base.PlaceAnimals(rng, count, zoneTiles, startPositions, exclusionRadius, placements, used);
         }
 
         private void PlaceScatteredResources(int count, ResourcePointType type,
             List<HexCoordinate> zoneTiles, List<HexCoordinate> startPositions,
             int exclusionRadius, List<ResourcePlacement> placements, HashSet<HexCoordinate> used)
         {
-            for (int i = 0; i < count; i++)
-            {
-                var coord = FindValidPlacement(zoneTiles, startPositions, exclusionRadius, used);
-                if (!coord.HasValue) continue;
-
-                placements.Add(new ResourcePlacement(coord.Value, type));
-                used.Add(coord.Value);
-            }
-        }
-
-        private HexCoordinate? FindValidPlacement(
-            List<HexCoordinate> candidates, List<HexCoordinate> startPositions,
-            int exclusionRadius, HashSet<HexCoordinate> used)
-        {
-            return FindValidPlacementWithExclusion(candidates, startPositions, exclusionRadius, used);
-        }
-
-        private HexCoordinate? FindValidPlacementWithExclusion(
-            List<HexCoordinate> candidates, List<HexCoordinate> startPositions,
-            int exclusionRadius, HashSet<HexCoordinate> used)
-        {
-            // Try up to 20 random candidates from the zone tile list
-            for (int attempt = 0; attempt < 20 && candidates.Count > 0; attempt++)
-            {
-                int idx = rng.NextInt(0, candidates.Count - 1);
-                var coord = candidates[idx];
-
-                if (used.Contains(coord)) continue;
-
-                bool tooClose = false;
-                foreach (var startPos in startPositions)
-                {
-                    if (coord.Distance(startPos) < exclusionRadius)
-                    {
-                        tooClose = true;
-                        break;
-                    }
-                }
-                if (tooClose) continue;
-
-                return coord;
-            }
-            return null;
-        }
-
-        // ================================================================
-        // BFS Cluster Generation (same pattern as Arabia)
-        // ================================================================
-
-        private HexCoordinate? FindUnusedCoordinate(
-            List<HexCoordinate> coords, HashSet<HexCoordinate> used)
-        {
-            while (coords.Count > 0)
-            {
-                var coord = coords[0];
-                coords.RemoveAt(0);
-                if (!used.Contains(coord))
-                    return coord;
-            }
-            return null;
+            base.PlaceScatteredResources(rng, count, type, zoneTiles, startPositions,
+                exclusionRadius, placements, used);
         }
 
         private List<ResourcePlacement> PlaceResourceCluster(
             ResourcePointType type, int size, HexCoordinate center,
             int radius, HashSet<HexCoordinate> used)
         {
-            var placements = new List<ResourcePlacement>();
-            var usedLocal = new HashSet<HexCoordinate>(used);
-
-            var candidates = new List<HexCoordinate>();
-            for (int q = -radius; q <= radius; q++)
-            {
-                for (int r = -radius; r <= radius; r++)
-                {
-                    var coord = new HexCoordinate(center.q + q, center.r + r);
-                    if (coord.Distance(center) <= radius && !usedLocal.Contains(coord))
-                    {
-                        candidates.Add(coord);
-                    }
-                }
-            }
-
-            rng.Shuffle(candidates);
-
-            if (candidates.Count == 0) return placements;
-            var startCoord = candidates[0];
-
-            var frontier = new List<HexCoordinate> { startCoord };
-            int placed = 0;
-
-            while (placed < size && frontier.Count > 0)
-            {
-                var current = frontier[0];
-                frontier.RemoveAt(0);
-
-                if (usedLocal.Contains(current)) continue;
-                if (current.Distance(center) > radius) continue;
-
-                placements.Add(new ResourcePlacement(current, type));
-                usedLocal.Add(current);
-                placed++;
-
-                var neighbors = current.Neighbors();
-                var neighborList = new List<HexCoordinate>(neighbors);
-                rng.Shuffle(neighborList);
-                foreach (var neighbor in neighborList)
-                {
-                    if (!usedLocal.Contains(neighbor) && neighbor.Distance(center) <= radius)
-                    {
-                        frontier.Add(neighbor);
-                    }
-                }
-            }
-
-            return placements;
+            return base.PlaceResourceCluster(rng, type, size, center, radius, used);
         }
 
         private List<ResourcePlacement> GenerateResourceCluster(
             ResourcePointType type, int size, HexCoordinate center,
             HashSet<HexCoordinate> used)
         {
-            var placements = new List<ResourcePlacement>();
-            var usedLocal = new HashSet<HexCoordinate>(used);
-            var frontier = new List<HexCoordinate> { center };
-            int placed = 0;
-
-            while (placed < size && frontier.Count > 0)
-            {
-                var current = frontier[0];
-                frontier.RemoveAt(0);
-
-                if (usedLocal.Contains(current)) continue;
-                if (current.q < 0 || current.q >= Width || current.r < 0 || current.r >= Height) continue;
-
-                placements.Add(new ResourcePlacement(current, type));
-                usedLocal.Add(current);
-                placed++;
-
-                var neighbors = current.Neighbors();
-                var neighborList = new List<HexCoordinate>(neighbors);
-                rng.Shuffle(neighborList);
-                foreach (var neighbor in neighborList)
-                {
-                    if (!usedLocal.Contains(neighbor))
-                    {
-                        frontier.Add(neighbor);
-                    }
-                }
-            }
-
-            return placements;
+            return base.GenerateResourceCluster(rng, type, size, center, used);
         }
     }
 }

--- a/Sporefront/Assets/Scripts/Engine/MovementEngine.cs
+++ b/Sporefront/Assets/Scripts/Engine/MovementEngine.cs
@@ -29,6 +29,7 @@ namespace Sporefront.Engine
         // Reusable snapshot lists to avoid .ToList() allocations
         private readonly List<ArmyData> armySnapshot = new List<ArmyData>();
         private readonly List<VillagerGroupData> villagerSnapshot = new List<VillagerGroupData>();
+        private readonly List<ScoutData> scoutSnapshot = new List<ScoutData>();
 
         // Setup
 
@@ -84,6 +85,15 @@ namespace Sporefront.Engine
             {
                 var groupChanges = UpdateVillagerGroupMovement(group, currentTime);
                 changes.AddRange(groupChanges);
+            }
+
+            // Update scout movements + stamina regen
+            scoutSnapshot.Clear();
+            scoutSnapshot.AddRange(gameState.scouts.Values);
+            foreach (var scout in scoutSnapshot)
+            {
+                var scoutChanges = UpdateScoutMovement(scout, currentTime);
+                changes.AddRange(scoutChanges);
             }
 
             // Reuse army snapshot for reinforcement movements (re-snapshot since armies may have been removed)
@@ -470,6 +480,72 @@ namespace Sporefront.Engine
                     {
                         group.ClearTask();
                     }
+                }
+            }
+
+            return changes;
+        }
+
+        // Scout Movement
+
+        private List<StateChange> UpdateScoutMovement(ScoutData scout, double currentTime)
+        {
+            var changes = new List<StateChange>();
+
+            // Regenerate stamina when idle
+            if (!scout.HasPath())
+            {
+                if (scout.stamina < scout.maxStamina)
+                {
+                    double regen = GameConfig.Scout.StaminaRegenPerSecond * GameConfig.EngineIntervals.MovementUpdate;
+                    scout.RegenerateStamina(regen);
+                    changes.Add(new ScoutStaminaChange { scoutID = scout.id, stamina = scout.stamina });
+                }
+                return changes;
+            }
+
+            if (gameState == null) return StateChange.EmptyChanges;
+
+            var path = scout.currentPath;
+            var targetCoord = path[scout.pathIndex];
+
+            // Calculate movement speed (scouts are faster)
+            double speed = baseMovementSpeed * GameConfig.Scout.MovementSpeedMultiplier * terrainSpeedMultiplier;
+            scout.movementSpeed = speed;
+
+            // Update progress
+            scout.movementProgress += speed * GameConfig.EngineIntervals.MovementUpdate;
+
+            // Check if we've reached the next tile
+            if (scout.movementProgress >= 1.0)
+            {
+                var fromCoord = scout.coordinate;
+
+                // Consume stamina per tile
+                scout.ConsumeStamina(GameConfig.Scout.StaminaCostPerTile);
+                changes.Add(new ScoutStaminaChange { scoutID = scout.id, stamina = scout.stamina });
+
+                // Move to next tile
+                scout.coordinate = targetCoord;
+                gameState.mapData.UpdateScoutPosition(scout.id, targetCoord);
+                scout.pathIndex += 1;
+                scout.movementProgress -= 1.0;
+
+                changes.Add(new ScoutMovedChange
+                {
+                    scoutID = scout.id,
+                    from = fromCoord,
+                    to = targetCoord,
+                    path = scout.pathIndex < path.Count
+                        ? path.GetRange(scout.pathIndex, path.Count - scout.pathIndex)
+                        : new List<HexCoordinate>()
+                });
+
+                // Check if path is complete or out of stamina
+                if (scout.pathIndex >= path.Count || !scout.HasEnoughStamina())
+                {
+                    scout.ClearPath();
+                    scout.movementSpeed = 0.0;
                 }
             }
 

--- a/Sporefront/Assets/Scripts/Engine/TrainingEngine.cs
+++ b/Sporefront/Assets/Scripts/Engine/TrainingEngine.cs
@@ -54,6 +54,13 @@ namespace Sporefront.Engine
                     var villagerChanges = UpdateVillagerTraining(building, currentTime, gameState);
                     changes.AddRange(villagerChanges);
                 }
+
+                // Scout training
+                if (building.scoutTrainingQueue.Count > 0)
+                {
+                    var scoutChanges = UpdateScoutTraining(building, currentTime, gameState);
+                    changes.AddRange(scoutChanges);
+                }
             }
 
             return changes;
@@ -146,6 +153,60 @@ namespace Sporefront.Engine
                 if (entry.progress > 0 && entry.progress < 1.0)
                 {
                     changes.Add(new VillagerTrainingProgressChange
+                    {
+                        buildingID = building.id,
+                        entryIndex = index,
+                        progress = entry.progress
+                    });
+                }
+            }
+
+            return changes;
+        }
+
+        // ================================================================
+        // Scout Training
+        // ================================================================
+
+        private List<StateChange> UpdateScoutTraining(BuildingData building, double currentTime, GameState state)
+        {
+            var changes = new List<StateChange>();
+
+            var completedEntries = building.UpdateScoutTraining(currentTime);
+
+            foreach (var entry in completedEntries)
+            {
+                // Spawn scout at nearest walkable tile
+                HexCoordinate spawnCoord;
+                HexCoordinate? walkable = state.mapData.FindNearestWalkable(
+                    building.coordinate, 3, building.ownerID ?? Guid.Empty, state);
+                spawnCoord = walkable.HasValue ? walkable.Value : building.coordinate;
+
+                var scout = new ScoutData(spawnCoord, building.ownerID);
+                state.AddScout(scout);
+
+                changes.Add(new ScoutTrainingCompletedChange
+                {
+                    buildingID = building.id,
+                    scoutID = scout.id,
+                    coordinate = spawnCoord
+                });
+
+                changes.Add(new ScoutCreatedChange
+                {
+                    scoutID = scout.id,
+                    ownerID = building.ownerID ?? Guid.Empty,
+                    coordinate = spawnCoord
+                });
+            }
+
+            // Update progress for remaining entries
+            for (int index = 0; index < building.scoutTrainingQueue.Count; index++)
+            {
+                var entry = building.scoutTrainingQueue[index];
+                if (entry.progress > 0 && entry.progress < 1.0)
+                {
+                    changes.Add(new ScoutTrainingProgressChange
                     {
                         buildingID = building.id,
                         entryIndex = index,

--- a/Sporefront/Assets/Scripts/Engine/VisionEngine.cs
+++ b/Sporefront/Assets/Scripts/Engine/VisionEngine.cs
@@ -169,6 +169,12 @@ namespace Sporefront.Engine
                 GetCoordinatesInRange(group.coordinate, range, state, visibleCoords);
             }
 
+            // Vision from scouts
+            foreach (var scout in state.GetScoutsForPlayer(playerID))
+            {
+                GetCoordinatesInRange(scout.coordinate, scout.visionRange, state, visibleCoords);
+            }
+
             // Vision from reinforcements (just their tile)
             HashSet<HexCoordinate> reinforcementCoords;
             if (state.activeReinforcementPositions != null &&

--- a/Sporefront/Assets/Scripts/Models/HexCoordinate.cs
+++ b/Sporefront/Assets/Scripts/Models/HexCoordinate.cs
@@ -93,6 +93,59 @@ namespace Sporefront.Models
             return results;
         }
 
+        /// <summary>
+        /// Returns a list of hex coordinates forming a line from this coordinate to the target.
+        /// Uses cube-coordinate lerp for accurate hex line drawing (Red Blob Games algorithm).
+        /// </summary>
+        public List<HexCoordinate> LineTo(HexCoordinate target)
+        {
+            int dist = Distance(target);
+            if (dist == 0) return new List<HexCoordinate> { this };
+
+            // Convert odd-r offset → cube coordinates
+            int ax = q - (r - (r & 1)) / 2;
+            int az = r;
+            int ay = -ax - az;
+
+            int bx = target.q - (target.r - (target.r & 1)) / 2;
+            int bz = target.r;
+            int by = -bx - bz;
+
+            var results = new List<HexCoordinate>(dist + 1);
+            for (int i = 0; i <= dist; i++)
+            {
+                double t = (double)i / dist;
+                // Lerp in cube space with nudge to avoid ambiguous rounding on edges
+                double fx = ax + (bx - ax) * t + 1e-6;
+                double fy = ay + (by - ay) * t + 1e-6;
+                double fz = az + (bz - az) * t - 2e-6;
+
+                // Round cube coordinates
+                int rx = (int)Math.Round(fx);
+                int ry = (int)Math.Round(fy);
+                int rz = (int)Math.Round(fz);
+
+                // Fix rounding errors (cube constraint: x + y + z == 0)
+                double xDiff = Math.Abs(rx - fx);
+                double yDiff = Math.Abs(ry - fy);
+                double zDiff = Math.Abs(rz - fz);
+
+                if (xDiff > yDiff && xDiff > zDiff)
+                    rx = -ry - rz;
+                else if (yDiff > zDiff)
+                    ry = -rx - rz;
+                else
+                    rz = -rx - ry;
+
+                // Convert cube → odd-r offset
+                int oq = rx + (rz - (rz & 1)) / 2;
+                int or2 = rz;
+                results.Add(new HexCoordinate(oq, or2));
+            }
+
+            return results;
+        }
+
         // IEquatable
         public bool Equals(HexCoordinate other) => q == other.q && r == other.r;
         public override bool Equals(object obj) => obj is HexCoordinate other && Equals(other);

--- a/Sporefront/Assets/Scripts/Visual/ActionPanel.cs
+++ b/Sporefront/Assets/Scripts/Visual/ActionPanel.cs
@@ -25,6 +25,7 @@ namespace Sporefront.Visual
         {
             None,
             BuildSelect,
+            RotatePreview,
             MoveTarget,
             AttackTarget
         }
@@ -36,6 +37,7 @@ namespace Sporefront.Visual
         public event Action OnCancelled;
         public event Action<HexCoordinate, List<HexCoordinate>> OnBuildPreviewChanged;
         public event Action<BuildingType, HexCoordinate, int> OnBuildTypeSelected;
+        public event Action<HexCoordinate> OnWallDrawRequested;
 
         // ================================================================
         // State
@@ -55,7 +57,7 @@ namespace Sporefront.Visual
         private bool moveIsArmy;
         private Guid attackArmyID;
         private Guid localPlayerID;
-        private Text rotationLabel;
+        // rotationLabel removed — rotation now handled in RotatePreview mode
 
         // Entrenchment confirmation state
         private bool showingEntrenchConfirm;
@@ -86,7 +88,6 @@ namespace Sporefront.Visual
             buildCoord = coord;
             CurrentMode = ActionMode.BuildSelect;
             buildRotation = 0;
-            if (rotationLabel != null) rotationLabel.text = "Rotation: 0";
             RebuildBuildMenu(gameState);
             buildBackdrop.SetActive(true);
             targetBanner.SetActive(false);
@@ -253,23 +254,13 @@ namespace Sporefront.Visual
             headerRT.offsetMin = new Vector2(12, -40);
             headerRT.offsetMax = new Vector2(-12, -6);
 
-            // Rotation label (between header and scroll)
-            rotationLabel = UIHelper.CreateLabel(buildPanel.transform, "Rotation: 0",
-                UIConstants.FontSmall, UIHelper.InkMutedText, TextAnchor.MiddleCenter);
-            var rotLabelRT = rotationLabel.GetComponent<RectTransform>();
-            rotLabelRT.anchorMin = new Vector2(0, 1);
-            rotLabelRT.anchorMax = new Vector2(1, 1);
-            rotLabelRT.pivot = new Vector2(0.5f, 1);
-            rotLabelRT.offsetMin = new Vector2(12, -58);
-            rotLabelRT.offsetMax = new Vector2(-12, -42);
-
             // Scroll area for building list
             var scroll = UIHelper.CreateScrollView(buildPanel.transform, "BuildScroll", out buildContentRT);
             var scrollRT = scroll.GetComponent<RectTransform>();
             scrollRT.anchorMin = Vector2.zero;
             scrollRT.anchorMax = Vector2.one;
             scrollRT.offsetMin = new Vector2(0, 48); // Space for close button
-            scrollRT.offsetMax = new Vector2(0, -60); // Space for header + rotation label
+            scrollRT.offsetMax = new Vector2(0, -42); // Space for header
 
             // Close button at bottom
             var closeBtn = UIHelper.CreateInkCloseButton(buildPanel.transform, Cancel);
@@ -399,23 +390,6 @@ namespace Sporefront.Visual
             var spacerLE = spacer.AddComponent<LayoutElement>();
             spacerLE.flexibleWidth = 1;
 
-            // Rotation control for multi-hex buildings (#19)
-            if (bt.HexSize() > 1 || bt.RequiresRotation())
-            {
-                var rotateBtn = UIHelper.CreateButton(btnRow.transform, "Rotate",
-                    SporefrontColors.ParchmentDeep, UIHelper.InkBodyText, UIConstants.FontCaption, null);
-                var rotBtnLE = rotateBtn.gameObject.AddComponent<LayoutElement>();
-                rotBtnLE.preferredWidth = 62;
-
-                var capturedType = bt;
-                rotateBtn.onClick.AddListener(() =>
-                {
-                    buildRotation = (buildRotation + 1) % 6;
-                    if (rotationLabel != null) rotationLabel.text = $"Rotation: {buildRotation}";
-                    UpdateBuildPreview(capturedType);
-                });
-            }
-
             // Build button
             var buildBtn = UIHelper.CreateButton(btnRow.transform, "Build",
                 available ? SporefrontColors.SporeGreen : UIHelper.InkMutedText,
@@ -429,11 +403,24 @@ namespace Sporefront.Visual
             {
                 var capturedType = bt;
                 var capturedCoord = buildCoord.Value;
-                var capturedRotation = buildRotation;
                 buildBtn.onClick.AddListener(() =>
                 {
-                    OnBuildTypeSelected?.Invoke(capturedType, capturedCoord, capturedRotation);
-                    HideBuildMenu();
+                    if (capturedType == BuildingType.Wall)
+                    {
+                        // Enter wall draw mode for drag-to-build
+                        OnWallDrawRequested?.Invoke(capturedCoord);
+                        HideBuildMenu();
+                    }
+                    else if (capturedType.HexSize() > 1)
+                    {
+                        // Enter rotation preview for multi-tile buildings
+                        EnterRotatePreview(capturedType, capturedCoord);
+                    }
+                    else
+                    {
+                        OnBuildTypeSelected?.Invoke(capturedType, capturedCoord, 0);
+                        HideBuildMenu();
+                    }
                 });
             }
         }
@@ -443,6 +430,45 @@ namespace Sporefront.Visual
             if (!buildCoord.HasValue) return;
             var occupied = bt.GetOccupiedCoordinates(buildCoord.Value, buildRotation);
             OnBuildPreviewChanged?.Invoke(buildCoord.Value, occupied);
+        }
+
+        // ================================================================
+        // Rotation Preview Mode (for multi-tile buildings)
+        // ================================================================
+
+        private void EnterRotatePreview(BuildingType bt, HexCoordinate coord)
+        {
+            selectedBuildingType = bt;
+            buildCoord = coord;
+            buildRotation = 0;
+            CurrentMode = ActionMode.RotatePreview;
+
+            HideBuildMenu();
+            buildBackdrop.SetActive(false);
+
+            BuildRotationBannerContent(bt);
+            targetBanner.SetActive(true);
+
+            UpdateBuildPreview(bt);
+        }
+
+        public void RotateBuilding()
+        {
+            if (CurrentMode != ActionMode.RotatePreview) return;
+            buildRotation = (buildRotation + 1) % 6;
+            BuildRotationBannerContent(selectedBuildingType);
+            UpdateBuildPreview(selectedBuildingType);
+        }
+
+        public void ConfirmRotatePreview()
+        {
+            if (CurrentMode != ActionMode.RotatePreview || !buildCoord.HasValue) return;
+            var bt = selectedBuildingType;
+            var coord = buildCoord.Value;
+            var rot = buildRotation;
+            CurrentMode = ActionMode.None;
+            targetBanner.SetActive(false);
+            OnBuildTypeSelected?.Invoke(bt, coord, rot);
         }
 
         // ================================================================
@@ -457,8 +483,8 @@ namespace Sporefront.Visual
 
             targetBanner = UIHelper.CreatePanel(canvasTransform, "TargetBanner", UIHelper.HudBg);
             var rt = targetBanner.GetComponent<RectTransform>();
-            rt.anchorMin = new Vector2(0.3f, 1);
-            rt.anchorMax = new Vector2(0.7f, 1);
+            rt.anchorMin = new Vector2(0.2f, 1);
+            rt.anchorMax = new Vector2(0.8f, 1);
             rt.pivot = new Vector2(0.5f, 1f);
             rt.offsetMin = new Vector2(0, -80);
             rt.offsetMax = new Vector2(0, -44);
@@ -487,14 +513,15 @@ namespace Sporefront.Visual
             rt.offsetMax = new Vector2(0, -44);
             targetBanner.GetComponent<Image>().color = UIHelper.HudBg;
 
-            var row = UIHelper.CreateHorizontalRow(targetBanner.transform, 36f, 8f);
+            var row = UIHelper.CreateHorizontalRow(targetBanner.transform, 36f, 6f);
             var rowRT = row.GetComponent<RectTransform>();
             UIHelper.StretchFull(rowRT);
-            row.padding = new RectOffset(12, 12, 0, 0);
+            row.padding = new RectOffset(10, 10, 0, 0);
             row.childAlignment = TextAnchor.MiddleCenter;
 
-            var label = UIHelper.CreateLabel(row.transform, message, 14,
+            var label = UIHelper.CreateLabel(row.transform, message, UIConstants.FontCaption,
                 UIHelper.HudTextColor, TextAnchor.MiddleCenter);
+            UIHelper.EnableAutoFit(label, 10, UIConstants.FontCaption);
             label.gameObject.name = "BannerText";
             var labelLE = label.gameObject.AddComponent<LayoutElement>();
             labelLE.flexibleWidth = 1;
@@ -502,8 +529,64 @@ namespace Sporefront.Visual
             var cancelBtn = UIHelper.CreateButton(row.transform, "Cancel",
                 SporefrontColors.SporeRed, UIHelper.HudTextColor, UIConstants.FontCaption,
                 () => Cancel());
+            var cancelLabel = UIHelper.GetButtonLabel(cancelBtn);
+            UIHelper.EnableAutoFit(cancelLabel, 10, UIConstants.FontCaption);
             var btnLE = cancelBtn.gameObject.AddComponent<LayoutElement>();
-            btnLE.preferredWidth = 60;
+            btnLE.preferredWidth = 70;
+            btnLE.minWidth = 56;
+        }
+
+        private void BuildRotationBannerContent(BuildingType bt)
+        {
+            ClearBannerContent();
+
+            var rt = targetBanner.GetComponent<RectTransform>();
+            rt.offsetMin = new Vector2(0, -84);
+            rt.offsetMax = new Vector2(0, -44);
+            targetBanner.GetComponent<Image>().color = UIHelper.HudBg;
+
+            var row = UIHelper.CreateHorizontalRow(targetBanner.transform, 36f, 6f);
+            var rowRT = row.GetComponent<RectTransform>();
+            UIHelper.StretchFull(rowRT);
+            row.padding = new RectOffset(10, 10, 0, 0);
+            row.childAlignment = TextAnchor.MiddleCenter;
+
+            // Building name label
+            var label = UIHelper.CreateLabel(row.transform, bt.DisplayName(),
+                UIConstants.FontCaption, UIHelper.HudTextColor, TextAnchor.MiddleCenter);
+            UIHelper.EnableAutoFit(label, 10, UIConstants.FontCaption);
+            var labelLE = label.gameObject.AddComponent<LayoutElement>();
+            labelLE.flexibleWidth = 1;
+
+            // Rotate button
+            var rotateBtn = UIHelper.CreateButton(row.transform, "Rotate (R)",
+                SporefrontColors.SporeAmber, UIHelper.ButtonText, UIConstants.FontCaption,
+                () => RotateBuilding());
+            var rotateLabel = UIHelper.GetButtonLabel(rotateBtn);
+            UIHelper.EnableAutoFit(rotateLabel, 10, UIConstants.FontCaption);
+            var rotateBtnLE = rotateBtn.gameObject.AddComponent<LayoutElement>();
+            rotateBtnLE.preferredWidth = 85;
+            rotateBtnLE.minWidth = 70;
+
+            // Confirm button
+            var confirmBtn = UIHelper.CreateButton(row.transform, "Confirm",
+                SporefrontColors.SporeGreen, UIHelper.ButtonText, UIConstants.FontCaption,
+                () => ConfirmRotatePreview());
+            var confirmLabel = UIHelper.GetButtonLabel(confirmBtn);
+            UIHelper.EnableAutoFit(confirmLabel, 10, UIConstants.FontCaption);
+            var confirmBtnLE = confirmBtn.gameObject.AddComponent<LayoutElement>();
+            confirmBtnLE.preferredWidth = 75;
+            confirmBtnLE.minWidth = 60;
+
+            // Cancel button
+            var cancelBtn = UIHelper.CreateButton(row.transform, "Cancel",
+                SporefrontColors.SporeRed, UIHelper.HudTextColor, UIConstants.FontCaption,
+                () => Cancel());
+            var cancelLabel = UIHelper.GetButtonLabel(cancelBtn);
+            UIHelper.EnableAutoFit(cancelLabel, 10, UIConstants.FontCaption);
+            var cancelBtnLE = cancelBtn.gameObject.AddComponent<LayoutElement>();
+            cancelBtnLE.preferredWidth = 70;
+            cancelBtnLE.minWidth = 56;
         }
 
         private void RebuildTargetBannerDefault(string message)

--- a/Sporefront/Assets/Scripts/Visual/BuildingDetailPanel.cs
+++ b/Sporefront/Assets/Scripts/Visual/BuildingDetailPanel.cs
@@ -324,7 +324,8 @@ namespace Sporefront.Visual
             // State info
             if (building.state != BuildingState.Completed)
             {
-                var stateLabel = UIHelper.CreateLabel(statusCard.transform, $"State: {building.state}");
+                var stateLabel = UIHelper.CreateLabel(statusCard.transform, $"State: {building.state}",
+                    UIConstants.FontCaption, UIHelper.InkBodyText);
                 var stateLE = stateLabel.gameObject.AddComponent<LayoutElement>();
                 stateLE.preferredHeight = 20;
 
@@ -373,6 +374,8 @@ namespace Sporefront.Visual
                             {
                                 OnCancelUpgradeRequested?.Invoke(capturedID);
                             });
+                        var cancelLabel = UIHelper.GetButtonLabel(cancelBtn);
+                        UIHelper.EnableAutoFit(cancelLabel, 10, UIConstants.FontCaption);
                         var cancelLE = cancelBtn.gameObject.AddComponent<LayoutElement>();
                         cancelLE.preferredHeight = 30;
                     }

--- a/Sporefront/Assets/Scripts/Visual/BuildingMarketSection.cs
+++ b/Sporefront/Assets/Scripts/Visual/BuildingMarketSection.cs
@@ -54,7 +54,7 @@ namespace Sporefront.Visual
                 var row = UIHelper.CreateHorizontalRow(contentRT, 24f, 4f);
 
                 var nameLabel = UIHelper.CreateLabel(row.transform,
-                    $"{UIHelper.ResourceIcon(rt)} {rt}", UIConstants.FontCaption);
+                    $"{UIHelper.ResourceIcon(rt)} {rt}", UIConstants.FontCaption, UIHelper.InkBodyText);
                 var nameLE = nameLabel.gameObject.AddComponent<LayoutElement>();
                 nameLE.preferredWidth = 60;
 

--- a/Sporefront/Assets/Scripts/Visual/BuildingTrainingSection.cs
+++ b/Sporefront/Assets/Scripts/Visual/BuildingTrainingSection.cs
@@ -57,6 +57,12 @@ namespace Sporefront.Visual
                     currentPop, popCapacity);
             }
 
+            // Scout training (City Center only)
+            if (building.buildingType == BuildingType.CityCenter && building.IsOperational)
+            {
+                BuildScoutTrainingControl(contentRT, building, player, localPlayerID);
+            }
+
             // Military unit training
             var unitTypes = (MilitaryUnitType[])Enum.GetValues(typeof(MilitaryUnitType));
             foreach (var ut in unitTypes)
@@ -96,6 +102,25 @@ namespace Sporefront.Visual
                 foreach (var entry in building.villagerTrainingQueue)
                 {
                     BuildVillagerQueueRow(contentRT, building, entry, gameState, state);
+                }
+            }
+
+            // Scout training queue
+            if (building.scoutTrainingQueue != null && building.scoutTrainingQueue.Count > 0)
+            {
+                if ((building.trainingQueue == null || building.trainingQueue.Count == 0)
+                    && (building.villagerTrainingQueue == null || building.villagerTrainingQueue.Count == 0))
+                    UIHelper.CreateDivider(contentRT, null, 1);
+
+                var scoutQueueLabel = UIHelper.CreateLabel(contentRT,
+                    $"Scout queue: {building.scoutTrainingQueue.Count} item(s)", UIConstants.FontCaption,
+                    UIHelper.InkMutedText);
+                var sqLE = scoutQueueLabel.gameObject.AddComponent<LayoutElement>();
+                sqLE.preferredHeight = 20;
+
+                foreach (var entry in building.scoutTrainingQueue)
+                {
+                    BuildScoutQueueRow(contentRT, building, entry, gameState);
                 }
             }
 
@@ -285,6 +310,85 @@ namespace Sporefront.Visual
                 capturedCountLabel.text = selectedQty.ToString();
                 capturedTotalCostLabel.text = $"Total: F{capturedCostPerUnit * selectedQty}";
             });
+        }
+
+        // ================================================================
+        // Scout Training Control (single button — no slider, trains 1 at a time)
+        // ================================================================
+
+        private static void BuildScoutTrainingControl(RectTransform contentRT,
+            BuildingData building, PlayerState player, Guid localPlayerID)
+        {
+            int foodCost = GameConfig.Scout.FoodCost;
+            bool canAfford = player != null && player.GetResource(ResourceType.Food) >= foodCost;
+
+            // Name row
+            var nameRow = UIHelper.CreateHorizontalRow(contentRT, 22f, 4f);
+            var nameLabel = UIHelper.CreateLabel(nameRow.transform, "Mycelium Scout", UIConstants.FontCaption);
+            var nameLE = nameLabel.gameObject.AddComponent<LayoutElement>();
+            nameLE.flexibleWidth = 1;
+
+            var costLabel = UIHelper.CreateLabel(nameRow.transform, $"F{foodCost}", UIConstants.FontCaption,
+                canAfford ? UIHelper.InkMutedText : SporefrontColors.SporeRed);
+            var costLE = costLabel.gameObject.AddComponent<LayoutElement>();
+            costLE.preferredWidth = 100;
+
+            // Train button row
+            var row = UIHelper.CreateHorizontalRow(contentRT, 28f, 4f);
+            var capturedBuildingID = building.id;
+            var trainBtn = UIHelper.CreateButton(row.transform, "Train",
+                canAfford ? SporefrontColors.ParchmentDeep : UIHelper.InkMutedText,
+                UIHelper.InkBodyText, UIConstants.FontCaption,
+                canAfford ? (Action)(() =>
+                {
+                    var cmd = new TrainScoutCommand(localPlayerID, capturedBuildingID);
+                    UIManager.ExecutePlayerCommand(cmd);
+                }) : null);
+            trainBtn.interactable = canAfford;
+            var btnLE = trainBtn.gameObject.AddComponent<LayoutElement>();
+            btnLE.flexibleWidth = 1;
+        }
+
+        // ================================================================
+        // Scout Queue Progress Row
+        // ================================================================
+
+        private static void BuildScoutQueueRow(RectTransform contentRT,
+            BuildingData building, ScoutTrainingEntry entry, GameState gameState)
+        {
+            double progress = entry.GetProgress(gameState.currentTime);
+            float progressFloat = Mathf.Clamp01((float)progress);
+
+            var row = UIHelper.CreateHorizontalRow(contentRT, 20f, 4f);
+
+            var unitLabel = UIHelper.CreateLabel(row.transform,
+                "Mycelium Scout", UIConstants.FontCaption, UIHelper.InkMutedText);
+            var unitLE = unitLabel.gameObject.AddComponent<LayoutElement>();
+            unitLE.preferredWidth = 100;
+
+            var (bg, fill) = UIHelper.CreateInkProgressBar(row.transform, 12f,
+                UIHelper.InkMutedText, SporefrontColors.SporeTeal);
+            var fillRT = fill.GetComponent<RectTransform>();
+            fillRT.anchorMax = new Vector2(progressFloat, 1);
+            var barLE = bg.gameObject.AddComponent<LayoutElement>();
+            barLE.flexibleWidth = 1;
+            barLE.preferredHeight = 12;
+
+            var pctLabel = UIHelper.CreateLabel(row.transform,
+                $"{(int)(progressFloat * 100)}%", UIConstants.FontCaption, UIHelper.InkMutedText);
+            var pctLE = pctLabel.gameObject.AddComponent<LayoutElement>();
+            pctLE.preferredWidth = 30;
+
+            // Time remaining
+            double totalTime = GameConfig.Scout.TrainingTime;
+            double elapsed = gameState.currentTime - entry.startTime;
+            double remaining = Math.Max(0, totalTime - elapsed);
+
+            var timeLabel = UIHelper.CreateLabel(row.transform,
+                $"~{UIHelper.FormatTime(remaining)}",
+                UIConstants.FontCaption, UIHelper.InkMutedText);
+            var timeLE = timeLabel.gameObject.AddComponent<LayoutElement>();
+            timeLE.preferredWidth = 50;
         }
 
         // ================================================================

--- a/Sporefront/Assets/Scripts/Visual/EntitiesOverviewPanel.cs
+++ b/Sporefront/Assets/Scripts/Visual/EntitiesOverviewPanel.cs
@@ -22,6 +22,7 @@ namespace Sporefront.Visual
         // ================================================================
 
         public event Action<Guid, bool> OnEntitySelected; // (entityID, isArmy)
+        public event Action<Guid> OnScoutSelected;
         public event Action OnClose;
 
         // ================================================================
@@ -268,6 +269,29 @@ namespace Sporefront.Visual
                 }
             }
 
+            // Scouts (always shown in All mode)
+            if (currentFilter == FilterMode.All)
+            {
+                var scouts = gameState.GetScoutsForPlayer(localPlayerID);
+                if (scouts.Count > 0)
+                {
+                    UIHelper.CreateDivider(contentRT, UIHelper.InkDividerColor);
+
+                    var sectionLabel = UIHelper.CreateLabel(contentRT,
+                        $"Scouts ({scouts.Count})",
+                        UIConstants.FontSubheader, UIHelper.InkHeaderText,
+                        TextAnchor.MiddleLeft, true);
+                    var sectionLE = sectionLabel.gameObject.AddComponent<LayoutElement>();
+                    sectionLE.preferredHeight = 26;
+
+                    foreach (var scout in scouts)
+                    {
+                        BuildScoutRow(scout);
+                        entityCount++;
+                    }
+                }
+            }
+
             if (entityCount == 0)
             {
                 var emptyLabel = UIHelper.CreateLabel(contentRT, "No entities found.",
@@ -435,6 +459,40 @@ namespace Sporefront.Visual
 
             var capturedID = army.id;
             cardBtn.onClick.AddListener(() => OnEntitySelected?.Invoke(capturedID, true));
+        }
+
+        // ================================================================
+        // Scout Row
+        // ================================================================
+
+        private void BuildScoutRow(ScoutData scout)
+        {
+            var card = UIHelper.CreateLedgerCard(contentRT, "ScoutRow");
+            var cardLE = card.GetComponent<LayoutElement>();
+            if (cardLE != null) cardLE.minHeight = 50;
+
+            // Scout info
+            string status = scout.HasPath() ? "Moving" : "Idle";
+            string staminaStr = $"{(int)scout.stamina}/{(int)scout.maxStamina}";
+            var nameLabel = UIHelper.CreateLabel(card.transform,
+                $"Mycelium Scout — {status}",
+                UIConstants.FontBody, UIHelper.InkBodyText, TextAnchor.MiddleLeft);
+            var nameLE = nameLabel.gameObject.AddComponent<LayoutElement>();
+            nameLE.preferredHeight = 22;
+
+            var detailLabel = UIHelper.CreateLabel(card.transform,
+                $"HP: {(int)scout.hp}/{(int)scout.maxHp}  Stamina: {staminaStr}  Vision: {scout.visionRange}",
+                UIConstants.FontCaption, UIHelper.InkSubText, TextAnchor.MiddleLeft);
+            var detailLE = detailLabel.gameObject.AddComponent<LayoutElement>();
+            detailLE.preferredHeight = 18;
+
+            // Click to select
+            var cardBtn = card.AddComponent<Button>();
+            cardBtn.transition = Selectable.Transition.ColorTint;
+            cardBtn.colors = UIHelper.CardButtonColors(SporefrontColors.ParchmentDark);
+
+            var capturedID = scout.id;
+            cardBtn.onClick.AddListener(() => OnScoutSelected?.Invoke(capturedID));
         }
 
         // ================================================================

--- a/Sporefront/Assets/Scripts/Visual/EntityRenderer.cs
+++ b/Sporefront/Assets/Scripts/Visual/EntityRenderer.cs
@@ -51,6 +51,7 @@ namespace Sporefront.Visual
 
         // Cached label transforms to avoid Find() lookups
         private Dictionary<Guid, Transform> cachedLabelTransforms = new Dictionary<Guid, Transform>();
+        private Dictionary<Guid, GameObject> badgeLabels = new Dictionary<Guid, GameObject>();
 
         // Reusable collections to reduce GC
         private Dictionary<HexCoordinate, List<EntityPlacement>> entitiesPerTile =
@@ -97,6 +98,7 @@ namespace Sporefront.Visual
             if (toRemove == null) toRemove = new List<Guid>();
             if (movementStates == null) movementStates = new Dictionary<Guid, MovementInterpolationState>();
             if (timerLabels == null) timerLabels = new Dictionary<Guid, GameObject>();
+            if (badgeLabels == null) badgeLabels = new Dictionary<Guid, GameObject>();
             if (activelyMovingEntities == null) activelyMovingEntities = new HashSet<Guid>();
             if (smoothedETAs == null) smoothedETAs = new Dictionary<Guid, double>();
             if (buildingBars == null) buildingBars = new Dictionary<Guid, BuildingBarVisuals>();
@@ -142,6 +144,7 @@ namespace Sporefront.Visual
                 cachedLabelTransforms.Remove(id);
                 movementStates.Remove(id);
                 timerLabels.Remove(id); // child GO destroyed with parent
+                badgeLabels.Remove(id); // child GO destroyed with parent
                 buildingBars.Remove(id); // child GOs destroyed with parent
             }
 
@@ -202,6 +205,47 @@ namespace Sporefront.Visual
                                     ? SporefrontColors.InkBlack : SporefrontColors.ParchmentLight;
                             }
                         }
+                        changed = true;
+                    }
+
+                    // Update label text if changed (army count, villager task, etc.)
+                    if (current.label != desired.label)
+                    {
+                        if (!cachedLabelTransforms.TryGetValue(id, out var labelTF))
+                        {
+                            labelTF = go.transform.Find("Label");
+                            if (labelTF != null)
+                                cachedLabelTransforms[id] = labelTF;
+                        }
+
+                        if (desired.label != null && labelTF == null)
+                        {
+                            // Need to create a label that didn't exist before
+                            CreateLabel(go.transform, desired.label, desired.color);
+                            // Cache the newly created label transform
+                            var newLabelTF = go.transform.Find("Label");
+                            if (newLabelTF != null)
+                                cachedLabelTransforms[id] = newLabelTF;
+                        }
+                        else if (desired.label == null && labelTF != null)
+                        {
+                            // Remove label
+                            Destroy(labelTF.gameObject);
+                            cachedLabelTransforms.Remove(id);
+                        }
+                        else if (labelTF != null)
+                        {
+                            var textMesh = labelTF.GetComponent<TextMesh>();
+                            if (textMesh != null)
+                                textMesh.text = desired.label;
+                        }
+                        changed = true;
+                    }
+
+                    // Update badge label (garrison count on buildings)
+                    if (current.badgeLabel != desired.badgeLabel)
+                    {
+                        UpdateBadgeLabel(id, go, desired.badgeLabel, desired.color);
                         changed = true;
                     }
 
@@ -296,13 +340,57 @@ namespace Sporefront.Visual
 
                 string label = GetBuildingLabel(building.buildingType);
 
+                // Garrison badge: show troop count for own operational buildings
+                string badge = null;
+                if (!isEnemy && building.IsOperational)
+                {
+                    int garrisonCount = building.GetTotalGarrisonCount();
+                    if (garrisonCount > 0)
+                        badge = garrisonCount.ToString();
+                }
+
                 entitiesPerTile[coord].Add(new EntityPlacement
                 {
                     id = building.id,
                     type = EntityVisualType.Building,
                     color = color,
-                    label = label
+                    label = label,
+                    badgeLabel = badge
                 });
+
+                // Multi-tile buildings: render on all occupied tiles
+                if (building.buildingType.HexSize() > 1)
+                {
+                    var occupied = building.OccupiedCoordinates;
+                    for (int oi = 0; oi < occupied.Count; oi++)
+                    {
+                        var oCoord = occupied[oi];
+                        if (oCoord.Equals(coord)) continue; // skip anchor (already added)
+
+                        if (isEnemy)
+                        {
+                            var oLevel = localPlayer.GetVisibilityLevel(oCoord);
+                            if (oLevel == VisibilityLevel.Unexplored) continue;
+                        }
+
+                        if (!entitiesPerTile.ContainsKey(oCoord))
+                            entitiesPerTile[oCoord] = new List<EntityPlacement>();
+
+                        // Deterministic ID for secondary tiles: XOR building ID with tile index
+                        // to avoid Guid.NewGuid() churn causing constant GO destroy+recreate
+                        var bytes = building.id.ToByteArray();
+                        bytes[0] ^= (byte)(oi + 1);
+                        var secondaryID = new Guid(bytes);
+
+                        entitiesPerTile[oCoord].Add(new EntityPlacement
+                        {
+                            id = secondaryID,
+                            type = EntityVisualType.Building,
+                            color = color,
+                            label = null
+                        });
+                    }
+                }
             }
 
             // Collect armies
@@ -322,12 +410,13 @@ namespace Sporefront.Visual
 
                 Color color = GetOwnerColor(army.ownerID, gameState);
 
+                int unitCount = army.GetTotalUnits();
                 entitiesPerTile[coord].Add(new EntityPlacement
                 {
                     id = army.id,
                     type = EntityVisualType.Army,
                     color = color,
-                    label = null,
+                    label = unitCount > 0 ? unitCount.ToString() : null,
                     isEntrenched = army.isEntrenched,
                     isEntrenching = army.isEntrenching
                 });
@@ -350,12 +439,39 @@ namespace Sporefront.Visual
 
                 Color color = GetOwnerColor(group.ownerID, gameState);
 
+                string taskIcon = GetVillagerTaskIcon(group);
                 entitiesPerTile[coord].Add(new EntityPlacement
                 {
                     id = group.id,
                     type = EntityVisualType.Villager,
                     color = color,
-                    label = null
+                    label = taskIcon
+                });
+            }
+
+            // Collect scouts
+            foreach (var kvp in gameState.scouts)
+            {
+                var scout = kvp.Value;
+
+                // Fog filter: own scouts always shown; enemy scouts only when tile is Visible
+                if (localPlayer != null && (!scout.ownerID.HasValue || scout.ownerID.Value != fogLocalPlayerID))
+                {
+                    if (!localPlayer.IsVisible(scout.coordinate)) continue;
+                }
+
+                var coord = scout.coordinate;
+                if (!entitiesPerTile.ContainsKey(coord))
+                    entitiesPerTile[coord] = new List<EntityPlacement>();
+
+                Color color = GetOwnerColor(scout.ownerID, gameState);
+
+                entitiesPerTile[coord].Add(new EntityPlacement
+                {
+                    id = scout.id,
+                    type = EntityVisualType.Scout,
+                    color = color,
+                    label = "\ud83d\udc41" // eye icon for scout
                 });
             }
 
@@ -401,6 +517,7 @@ namespace Sporefront.Visual
                 var armies = new List<EntityPlacement>();
                 var villagers = new List<EntityPlacement>();
                 var resources = new List<EntityPlacement>();
+                var scouts = new List<EntityPlacement>();
 
                 foreach (var p in placements)
                 {
@@ -410,6 +527,7 @@ namespace Sporefront.Visual
                         case EntityVisualType.Army: armies.Add(p); break;
                         case EntityVisualType.Villager: villagers.Add(p); break;
                         case EntityVisualType.Resource: resources.Add(p); break;
+                        case EntityVisualType.Scout: scouts.Add(p); break;
                     }
                 }
 
@@ -438,6 +556,12 @@ namespace Sporefront.Visual
                 for (int i = 0; i < villagers.Count; i++)
                 {
                     AddDesiredState(villagers[i], tileCenter, Vector2.zero);
+                }
+
+                // Scouts at tile center
+                for (int i = 0; i < scouts.Count; i++)
+                {
+                    AddDesiredState(scouts[i], tileCenter, Vector2.zero);
                 }
             }
 
@@ -563,6 +687,28 @@ namespace Sporefront.Visual
                 }
             }
 
+            // Scout movement interpolation
+            foreach (var kvp in gameState.scouts)
+            {
+                var scout = kvp.Value;
+                if (scout.currentPath != null && scout.pathIndex < scout.currentPath.Count &&
+                    scout.movementSpeed > 0 && desiredStates.ContainsKey(scout.id))
+                {
+                    activelyMovingEntities.Add(scout.id);
+                    var desired = desiredStates[scout.id];
+                    var fromPos = desired.worldPosition;
+                    var nextTileCenter = HexMetrics.HexToWorldPosition(scout.currentPath[scout.pathIndex]);
+                    var typeOffset = new Vector3(desired.worldPosition.x - HexMetrics.HexToWorldPosition(scout.coordinate).x,
+                                                 desired.worldPosition.y - HexMetrics.HexToWorldPosition(scout.coordinate).y, 0f);
+                    var toPos = new Vector3(nextTileCenter.x + typeOffset.x, nextTileCenter.y + typeOffset.y, ZPosition);
+                    float t = Mathf.Clamp01((float)scout.movementProgress);
+                    var interpolatedPos = Vector3.Lerp(fromPos, toPos, t);
+
+                    desired.worldPosition = interpolatedPos;
+                    desiredStates[scout.id] = desired;
+                }
+            }
+
             // Clean up movement states and timer labels for entities that stopped moving
             toRemove.Clear();
             foreach (var id in movementStates.Keys)
@@ -589,6 +735,7 @@ namespace Sporefront.Visual
                 type = placement.type,
                 color = placement.color,
                 label = placement.label,
+                badgeLabel = placement.badgeLabel,
                 worldPosition = new Vector3(
                     tileCenter.x + offset.x,
                     tileCenter.y + offset.y,
@@ -728,6 +875,9 @@ namespace Sporefront.Visual
                 case EntityVisualType.Resource:
                     meshFilter.sharedMesh = triangleMesh;
                     break;
+                case EntityVisualType.Scout:
+                    meshFilter.sharedMesh = smallCircleMesh;
+                    break;
             }
 
             meshRenderer.sharedMaterial = sharedMaterial;
@@ -742,6 +892,12 @@ namespace Sporefront.Visual
             if (state.label != null)
             {
                 CreateLabel(go.transform, state.label, state.color);
+            }
+
+            // Badge label (garrison count on buildings)
+            if (state.badgeLabel != null)
+            {
+                CreateBadgeLabel(state.id, go, state.badgeLabel);
             }
 
             // Progress/HP bars for buildings
@@ -773,6 +929,56 @@ namespace Sporefront.Visual
 
             var meshRenderer = labelGO.GetComponent<MeshRenderer>();
             meshRenderer.sortingOrder = 7;
+        }
+
+        // ================================================================
+        // Badge Labels (garrison count)
+        // ================================================================
+
+        private void CreateBadgeLabel(Guid id, GameObject parent, string text)
+        {
+            var badgeGO = new GameObject("Badge");
+            badgeGO.transform.SetParent(parent.transform, false);
+            // Position offset to upper-right of building
+            badgeGO.transform.localPosition = new Vector3(
+                BuildingSize * 0.7f, BuildingSize * 0.5f * HexMetrics.IsometricYScale, -0.01f);
+
+            var textMesh = badgeGO.AddComponent<TextMesh>();
+            textMesh.text = text;
+            textMesh.fontSize = 28;
+            textMesh.characterSize = 0.055f;
+            textMesh.anchor = TextAnchor.MiddleCenter;
+            textMesh.alignment = TextAlignment.Center;
+            textMesh.color = SporefrontColors.SporeAmber;
+
+            var meshRenderer = badgeGO.GetComponent<MeshRenderer>();
+            meshRenderer.sortingOrder = 8;
+
+            badgeLabels[id] = badgeGO;
+        }
+
+        private void UpdateBadgeLabel(Guid id, GameObject parent, string text, Color entityColor)
+        {
+            if (string.IsNullOrEmpty(text))
+            {
+                // Remove badge
+                if (badgeLabels.TryGetValue(id, out var oldBadge) && oldBadge != null)
+                    Destroy(oldBadge);
+                badgeLabels.Remove(id);
+                return;
+            }
+
+            if (badgeLabels.TryGetValue(id, out var badgeGO) && badgeGO != null)
+            {
+                // Update existing
+                var textMesh = badgeGO.GetComponent<TextMesh>();
+                if (textMesh != null) textMesh.text = text;
+            }
+            else
+            {
+                // Create new
+                CreateBadgeLabel(id, parent, text);
+            }
         }
 
         // ================================================================
@@ -932,6 +1138,9 @@ namespace Sporefront.Visual
                     case EntityVisualType.Villager:
                         bottomOffset = VillagerSize * HexMetrics.IsometricYScale;
                         break;
+                    case EntityVisualType.Scout:
+                        bottomOffset = VillagerSize * HexMetrics.IsometricYScale;
+                        break;
                 }
             }
 
@@ -1086,6 +1295,39 @@ namespace Sporefront.Visual
             }
         }
 
+        private string GetVillagerTaskIcon(VillagerGroupData group)
+        {
+            if (group.currentTask == null || group.currentTask.IsIdle)
+                return null; // no icon for idle — visually distinct as "unlabeled"
+
+            if (group.currentTask is BuildingTask || group.currentTask is UpgradingTask
+                || group.currentTask is DemolishingTask || group.currentTask is RepairingTask)
+                return "Bld";
+
+            if (group.currentTask is GatheringTask gt)
+            {
+                switch (gt.GatherResourceType)
+                {
+                    case ResourceType.Wood: return "W";
+                    case ResourceType.Food: return "F";
+                    case ResourceType.Stone: return "S";
+                    case ResourceType.Ore: return "O";
+                    default: return "G";
+                }
+            }
+
+            if (group.currentTask is GatheringResourceTask)
+                return "G";
+
+            if (group.currentTask is HuntingTask)
+                return "H";
+
+            if (group.currentTask is MovingTask)
+                return ">";
+
+            return "*";
+        }
+
         private string GetResourceLabel(ResourcePointType type)
         {
             switch (type)
@@ -1113,6 +1355,7 @@ namespace Sporefront.Visual
             movementStates.Clear();
             smoothedETAs.Clear();
             timerLabels.Clear();
+            badgeLabels.Clear();
             buildingBars.Clear();
         }
 
@@ -1125,7 +1368,8 @@ namespace Sporefront.Visual
             Building,
             Army,
             Villager,
-            Resource
+            Resource,
+            Scout
         }
 
         private struct EntityPlacement
@@ -1134,6 +1378,7 @@ namespace Sporefront.Visual
             public EntityVisualType type;
             public Color color;
             public string label;
+            public string badgeLabel; // secondary label (garrison count for buildings)
             public bool isEntrenched;
             public bool isEntrenching;
         }
@@ -1144,6 +1389,7 @@ namespace Sporefront.Visual
             public EntityVisualType type;
             public Color color;
             public string label;
+            public string badgeLabel;
             public Vector3 worldPosition;
             public bool isEntrenched;
             public bool isEntrenching;

--- a/Sporefront/Assets/Scripts/Visual/GameSceneManager.cs
+++ b/Sporefront/Assets/Scripts/Visual/GameSceneManager.cs
@@ -41,14 +41,16 @@ namespace Sporefront.Visual
         private const float DragThreshold = 5f; // pixels
 
         // Selected entity for drag-to-move
+        private enum EntityKind { Villager, Army, Scout }
+
         private Guid? selectedEntityID;
-        private bool selectedEntityIsArmy;
+        private EntityKind selectedEntityKind;
 
         // Multi-selection (drag-select box)
         private struct SelectedEntity
         {
             public Guid id;
-            public bool isArmy;
+            public EntityKind kind;
         }
         private List<SelectedEntity> selectedEntities = new List<SelectedEntity>();
         private bool isDragSelecting;
@@ -57,9 +59,16 @@ namespace Sporefront.Visual
         // Drag preview entity IDs (for per-frame tendril updates)
         private HashSet<Guid> dragPreviewEntityIDs = new HashSet<Guid>();
 
+        // Wall draw mode — drag to place a line of walls
+        private bool isWallDrawMode;
+        private HexCoordinate? wallDrawStart;
+        private HexCoordinate? lastWallDrawHex;
+        private List<HexCoordinate> wallDrawPreview = new List<HexCoordinate>();
+        private const int MaxWallSegments = 20;
+
         // Focused entity (from clicking a card in SelectedEntitiesPanel)
         private Guid? focusedEntityID;
-        private bool focusedEntityIsArmy;
+        private EntityKind focusedEntityKind;
 
         // Auto-save state
         private const double AutoSaveIntervalGameTime = 300.0; // 5 minutes game time
@@ -164,6 +173,25 @@ namespace Sporefront.Visual
                 HandleTileInteraction();
                 HandleRightClick();
 
+                // Period key — cycle to next idle villager
+                if (Keyboard.current != null && Keyboard.current.periodKey.wasPressedThisFrame)
+                    uiManager?.CycleToNextIdleVillager();
+
+                // R key — rotate building in placement preview
+                if (Keyboard.current != null && Keyboard.current.rKey.wasPressedThisFrame)
+                    uiManager?.RotateBuilding();
+
+                // Left click confirms rotation preview
+                if (uiManager != null && uiManager.IsRotatePreviewActive)
+                {
+                    var mouse = Mouse.current;
+                    if (mouse != null && mouse.leftButton.wasPressedThisFrame
+                        && !uiManager.IsPointerOverUI())
+                    {
+                        uiManager.ConfirmRotatePreview();
+                    }
+                }
+
                 // Auto-save check (offline only — online uses cloud snapshots)
                 if (!isOnlineGame && gameState != null && !gameState.isPaused &&
                     gameState.currentTime - lastAutoSaveGameTime >= AutoSaveIntervalGameTime)
@@ -220,13 +248,16 @@ namespace Sporefront.Visual
             uiManager.OnPlayArenaGame += StartArenaGame;
             uiManager.OnLoadGame += LoadGame;
 
+            // Wall draw mode
+            uiManager.OnWallDrawRequested += (coord) => EnterWallDrawMode(coord);
+
             // 4. Listen for entity focus from SelectedEntitiesPanel card click
             uiManager.OnEntityFocused += (id, isArmy) =>
             {
                 focusedEntityID = id;
-                focusedEntityIsArmy = isArmy;
+                focusedEntityKind = isArmy ? EntityKind.Army : EntityKind.Villager;
                 selectedEntityID = id;
-                selectedEntityIsArmy = isArmy;
+                selectedEntityKind = focusedEntityKind;
             };
 
             // 5. Listen for surrender request from in-game menu
@@ -329,7 +360,7 @@ namespace Sporefront.Visual
 
             // 5. Place starting resources and city centers
             var startPositions = generator.GetStartingPositions();
-            PlaceStartingEntities(startPositions, human, ai, generator, config.startingResources);
+            PlaceStartingEntities(startPositions, human, ai, generator, config.startingResources, config.startingCCLevel);
 
             // 5b. Place neutral resources across the map (trees, minerals, animals)
             var startCoords = new List<HexCoordinate>();
@@ -463,7 +494,7 @@ namespace Sporefront.Visual
 
             // 4. Place starting entities for both players
             var startPositions = generator.GetStartingPositions();
-            PlaceStartingEntities(startPositions, localPlayer, opponent, generator, config.startingResources);
+            PlaceStartingEntities(startPositions, localPlayer, opponent, generator, config.startingResources, config.startingCCLevel);
 
             var startCoords = new List<HexCoordinate>();
             foreach (var pos in startPositions)
@@ -821,7 +852,7 @@ namespace Sporefront.Visual
 
             // 5. Place starting resources and city centers
             var startPositions = generator.GetStartingPositions();
-            PlaceStartingEntities(startPositions, human, ai, generator, config.startingResources);
+            PlaceStartingEntities(startPositions, human, ai, generator, config.startingResources, config.startingCCLevel);
 
             var startCoords = new List<HexCoordinate>();
             foreach (var pos in startPositions)
@@ -1640,7 +1671,8 @@ namespace Sporefront.Visual
             PlayerState human,
             PlayerState ai,
             MapGeneratorBase generator,
-            StartingResources startingResources = StartingResources.Medium)
+            StartingResources startingResources = StartingResources.Medium,
+            int startingCCLevel = 1)
         {
             // Determine resource amounts based on tier
             int food, wood, ore, stone;
@@ -1652,10 +1684,15 @@ namespace Sporefront.Visual
                 case StartingResources.Large:
                     food = 500; wood = 500; ore = 300; stone = 300;
                     break;
+                case StartingResources.VeryHigh:
+                    food = 9999; wood = 9999; ore = 9999; stone = 9999;
+                    break;
                 default: // Medium
                     food = 300; wood = 300; ore = 200; stone = 200;
                     break;
             }
+
+            int ccLevel = System.Math.Max(1, System.Math.Min(10, startingCCLevel));
 
             var playerList = new List<PlayerState> { human, ai };
 
@@ -1671,6 +1708,7 @@ namespace Sporefront.Visual
                     player.id
                 );
                 cc.state = BuildingState.Completed;
+                cc.level = ccLevel;
                 cc.health = cc.maxHealth;
                 gameState.AddBuilding(cc);
 
@@ -1698,6 +1736,21 @@ namespace Sporefront.Visual
                 var villagerCoord = spawnCoord ?? pos.coordinate;
                 var villagers = new VillagerGroupData("Villagers", villagerCoord, 5, player.id);
                 gameState.AddVillagerGroup(villagers);
+
+                // Spawn starting scout (1 per player) — 1 tile from CC, not on the villager tile
+                HexCoordinate scoutSpawn = villagerCoord;
+                var ccNeighbors = pos.coordinate.Neighbors();
+                foreach (var neighbor in ccNeighbors)
+                {
+                    if (!neighbor.Equals(villagerCoord) && gameState.mapData.IsValidCoordinate(neighbor)
+                        && gameState.mapData.IsWalkable(neighbor))
+                    {
+                        scoutSpawn = neighbor;
+                        break;
+                    }
+                }
+                var scout = new ScoutData(scoutSpawn, player.id);
+                gameState.AddScout(scout);
             }
         }
 
@@ -1858,11 +1911,74 @@ namespace Sporefront.Visual
         {
             // Only block new interactions when pointer is over UI; allow ongoing drags to continue
             bool pointerOverUI = uiManager != null && uiManager.IsPointerOverUI();
-            if (pointerOverUI && !mouseIsDown) return;
+            if (pointerOverUI && !mouseIsDown && !isWallDrawMode) return;
             var mouse = Mouse.current;
             if (mouse == null) return;
 
             Vector3 mousePos = mouse.position.ReadValue();
+
+            // ── Wall draw mode ──────────────────────────────────────────
+            if (isWallDrawMode)
+            {
+                // Cancel on right-click or Escape
+                if ((mouse.rightButton != null && mouse.rightButton.wasPressedThisFrame)
+                    || (Keyboard.current != null && Keyboard.current.escapeKey.wasPressedThisFrame))
+                {
+                    ExitWallDrawMode();
+                    return;
+                }
+
+                Vector3 mouseWorld = Camera.main.ScreenToWorldPoint(mousePos);
+                mouseWorld.z = 0f;
+                var currentHex = HexMetrics.WorldToHex(mouseWorld);
+
+                if (mouse.leftButton.wasPressedThisFrame && !pointerOverUI)
+                {
+                    wallDrawStart = currentHex;
+                }
+
+                if (mouse.leftButton.isPressed && wallDrawStart.HasValue)
+                {
+                    // Only recompute when mouse moves to a different hex tile
+                    if (!lastWallDrawHex.HasValue || !lastWallDrawHex.Value.Equals(currentHex))
+                    {
+                        lastWallDrawHex = currentHex;
+                        wallDrawPreview = wallDrawStart.Value.LineTo(currentHex);
+                        if (wallDrawPreview.Count > MaxWallSegments)
+                            wallDrawPreview = wallDrawPreview.GetRange(0, MaxWallSegments);
+
+                        var localID = gameState.localPlayerID ?? Guid.Empty;
+                        bool allValid = true;
+                        foreach (var hex in wallDrawPreview)
+                        {
+                            if (!gameState.CanBuildAt(hex, localID))
+                            {
+                                allValid = false;
+                                break;
+                            }
+                        }
+                        uiManager.SelectionRenderer.ShowBuildPreview(wallDrawPreview, allValid);
+                    }
+                }
+
+                if (mouse.leftButton.wasReleasedThisFrame && wallDrawStart.HasValue)
+                {
+                    // Place walls for each valid hex in the line
+                    var localID = gameState.localPlayerID ?? Guid.Empty;
+                    foreach (var hex in wallDrawPreview)
+                    {
+                        if (gameState.CanBuildAt(hex, localID))
+                        {
+                            var cmd = new BuildCommand(localID, BuildingType.Wall, hex, 0);
+                            UIManager.ExecutePlayerCommand(cmd);
+                        }
+                    }
+                    ExitWallDrawMode();
+                }
+                return;
+            }
+
+            // ── Normal interaction ──────────────────────────────────────
 
             // Track left mouse button press (#13)
             if (mouse.leftButton.wasPressedThisFrame)
@@ -1931,14 +2047,32 @@ namespace Sporefront.Visual
                     if (view != null && releaseCoord != mouseDownTile.Value)
                     {
                         var localID = gameState.localPlayerID ?? Guid.Empty;
-                        var cmd = new MoveCommand(localID, selectedEntityID.Value,
-                            releaseCoord, selectedEntityIsArmy);
-                        UIManager.ExecutePlayerCommand(cmd);
+                        IssueMoveCommand(localID, selectedEntityID.Value, releaseCoord, selectedEntityKind);
                     }
                 }
 
                 mouseDownTile = null;
             }
+        }
+
+        // ================================================================
+        // Wall Draw Mode
+        // ================================================================
+
+        public void EnterWallDrawMode(HexCoordinate startCoord)
+        {
+            isWallDrawMode = true;
+            wallDrawStart = null;
+            wallDrawPreview.Clear();
+        }
+
+        private void ExitWallDrawMode()
+        {
+            isWallDrawMode = false;
+            wallDrawStart = null;
+            lastWallDrawHex = null;
+            wallDrawPreview.Clear();
+            uiManager.SelectionRenderer.ClearBuildPreview();
         }
 
         private void HandleTileClick(HexCoordinate coord)
@@ -1972,7 +2106,7 @@ namespace Sporefront.Visual
                 if (tileEntities.Count > 1)
                     uiManager.UpdateSelectedEntitiesPanel(null, false, tileEntities);
                 else
-                    uiManager.UpdateSelectedEntitiesPanel(selectedEntityID, selectedEntityIsArmy, null);
+                    uiManager.UpdateSelectedEntitiesPanel(selectedEntityID, selectedEntityKind == EntityKind.Army, null);
             }
 
             Debug.Log($"[GameSceneManager] Selected tile ({coord.q},{coord.r}) — {view.TerrainType}");
@@ -1984,7 +2118,7 @@ namespace Sporefront.Visual
         private void UpdateSelectedEntity(HexCoordinate coord)
         {
             selectedEntityID = null;
-            selectedEntityIsArmy = false;
+            selectedEntityKind = EntityKind.Villager;
 
             var localID = gameState.localPlayerID ?? Guid.Empty;
 
@@ -1997,7 +2131,7 @@ namespace Sporefront.Visual
                     if (army.ownerID.HasValue && army.ownerID.Value == localID && !army.isInCombat)
                     {
                         selectedEntityID = army.id;
-                        selectedEntityIsArmy = true;
+                        selectedEntityKind = EntityKind.Army;
                         return;
                     }
                 }
@@ -2012,9 +2146,22 @@ namespace Sporefront.Visual
                     if (group.ownerID.HasValue && group.ownerID.Value == localID)
                     {
                         selectedEntityID = group.id;
-                        selectedEntityIsArmy = false;
+                        selectedEntityKind = EntityKind.Villager;
                         return;
                     }
+                }
+            }
+
+            // Then scouts
+            var scoutID = gameState.mapData.GetScoutID(coord);
+            if (scoutID.HasValue)
+            {
+                var scout = gameState.GetScout(scoutID.Value);
+                if (scout != null && scout.ownerID.HasValue && scout.ownerID.Value == localID)
+                {
+                    selectedEntityID = scout.id;
+                    selectedEntityKind = EntityKind.Scout;
+                    return;
                 }
             }
         }
@@ -2059,7 +2206,7 @@ namespace Sporefront.Visual
                 // Attack with selected armies (villagers can't attack)
                 foreach (var entity in entities)
                 {
-                    if (entity.isArmy)
+                    if (entity.kind == EntityKind.Army)
                     {
                         var cmd = new AttackCommand(localID, entity.id, targetCoord);
                         UIManager.ExecutePlayerCommand(cmd);
@@ -2071,8 +2218,7 @@ namespace Sporefront.Visual
                 // Move each selected entity
                 foreach (var entity in entities)
                 {
-                    var cmd = new MoveCommand(localID, entity.id, targetCoord, entity.isArmy);
-                    UIManager.ExecutePlayerCommand(cmd);
+                    IssueMoveCommand(localID, entity.id, targetCoord, entity.kind);
                 }
             }
 
@@ -2095,7 +2241,7 @@ namespace Sporefront.Visual
             bool hasArmy = false, hasVillager = false;
             foreach (var e in entities)
             {
-                if (e.isArmy) hasArmy = true;
+                if (e.kind == EntityKind.Army) hasArmy = true;
                 else hasVillager = true;
             }
 
@@ -2144,18 +2290,32 @@ namespace Sporefront.Visual
         // Multi-Select Helpers
         // ================================================================
 
+        private void IssueMoveCommand(Guid playerID, Guid entityID, HexCoordinate destination, EntityKind kind)
+        {
+            if (kind == EntityKind.Scout)
+            {
+                var cmd = new MoveScoutCommand(playerID, entityID, destination);
+                UIManager.ExecutePlayerCommand(cmd);
+            }
+            else
+            {
+                var cmd = new MoveCommand(playerID, entityID, destination, kind == EntityKind.Army);
+                UIManager.ExecutePlayerCommand(cmd);
+            }
+        }
+
         private List<SelectedEntity> GetSelectedEntities()
         {
             // Focused entity takes priority (card clicked in SelectedEntitiesPanel)
             if (focusedEntityID.HasValue)
-                return new List<SelectedEntity> { new SelectedEntity { id = focusedEntityID.Value, isArmy = focusedEntityIsArmy } };
+                return new List<SelectedEntity> { new SelectedEntity { id = focusedEntityID.Value, kind = focusedEntityKind } };
 
             if (selectedEntities.Count > 0)
                 return selectedEntities;
 
             // Fall back to single selected entity
             if (selectedEntityID.HasValue)
-                return new List<SelectedEntity> { new SelectedEntity { id = selectedEntityID.Value, isArmy = selectedEntityIsArmy } };
+                return new List<SelectedEntity> { new SelectedEntity { id = selectedEntityID.Value, kind = selectedEntityKind } };
 
             return new List<SelectedEntity>();
         }
@@ -2214,7 +2374,7 @@ namespace Sporefront.Visual
 
             foreach (var entity in entities)
             {
-                if (!entity.isArmy)
+                if (entity.kind == EntityKind.Villager)
                 {
                     // Villagers get gather/hunt commands
                     if (isHuntable)
@@ -2286,7 +2446,7 @@ namespace Sporefront.Visual
                 Vector3 screenPos = cam.WorldToScreenPoint(worldPos);
 
                 if (screenRect.Contains(new Vector2(screenPos.x, screenPos.y)))
-                    selectedEntities.Add(new SelectedEntity { id = army.id, isArmy = true });
+                    selectedEntities.Add(new SelectedEntity { id = army.id, kind = EntityKind.Army });
             }
 
             // Select owned villager groups
@@ -2299,7 +2459,7 @@ namespace Sporefront.Visual
                 Vector3 screenPos = cam.WorldToScreenPoint(worldPos);
 
                 if (screenRect.Contains(new Vector2(screenPos.x, screenPos.y)))
-                    selectedEntities.Add(new SelectedEntity { id = group.id, isArmy = false });
+                    selectedEntities.Add(new SelectedEntity { id = group.id, kind = EntityKind.Villager });
             }
 
             if (selectedEntities.Count > 0)
@@ -2309,7 +2469,7 @@ namespace Sporefront.Visual
                 foreach (var entity in selectedEntities)
                 {
                     entityIDs.Add(entity.id);
-                    entityList.Add((entity.id, entity.isArmy));
+                    entityList.Add((entity.id, entity.kind == EntityKind.Army));
                 }
                 uiManager.OnMultiSelect(entityIDs);
                 uiManager.UpdateSelectedEntitiesPanel(null, false, entityList);
@@ -2389,6 +2549,14 @@ namespace Sporefront.Visual
                     if (group.ownerID.HasValue && group.ownerID.Value == localID)
                         result.Add((group.id, false));
                 }
+            }
+
+            var scoutID = gameState.mapData.GetScoutID(coord);
+            if (scoutID.HasValue)
+            {
+                var scout = gameState.GetScout(scoutID.Value);
+                if (scout != null && scout.ownerID.HasValue && scout.ownerID.Value == localID)
+                    result.Add((scout.id, false));
             }
 
             return result;

--- a/Sporefront/Assets/Scripts/Visual/GameSetupPanel.cs
+++ b/Sporefront/Assets/Scripts/Visual/GameSetupPanel.cs
@@ -31,6 +31,7 @@ namespace Sporefront.Visual
         public FactionType playerFaction;
         public FactionType aiFaction;
         public bool isOnlineMode;
+        public int startingCCLevel;
 
         // Matchmaking fields (empty for offline games)
         public string matchGameID;
@@ -49,14 +50,15 @@ namespace Sporefront.Visual
             startingResources = StartingResources.Medium,
             visibilityMode = VisibilityMode.Normal,
             playerFaction = FactionType.Morel,
-            aiFaction = FactionType.Muscaria
+            aiFaction = FactionType.Muscaria,
+            startingCCLevel = 1
         };
     }
 
     public enum MapType { Arabia, MountainValley, GoldRush, Random, Arena }
     public enum MapSize { Small, Medium, Large, Huge }
     public enum ResourceDensity { Sparse, Normal, Abundant }
-    public enum StartingResources { Small, Medium, Large }
+    public enum StartingResources { Small, Medium, Large, VeryHigh }
 
     [Serializable]
     public struct ArenaConfig
@@ -123,6 +125,7 @@ namespace Sporefront.Visual
         private VisibilityMode selectedVisibility = VisibilityMode.Normal;
         private FactionType selectedFaction = FactionType.Morel;
         private FactionType selectedAIFaction = FactionType.Muscaria;
+        private int selectedCCLevel = 1;
 
         // Arena config
         private ArenaScenarioConfig arenaScenario = ArenaScenarioConfig.Default;
@@ -600,6 +603,8 @@ namespace Sporefront.Visual
             BuildMapSizeSection(leftCol.transform);
             UIHelper.CreateDivider(leftCol.transform, softDivider);
             BuildStartingResourcesSection(leftCol.transform);
+            UIHelper.CreateDivider(leftCol.transform, softDivider);
+            BuildCCLevelSection(leftCol.transform);
 
             // Right column: Resource Density, Visibility
             var rightCol = new GameObject("RightColumn", typeof(RectTransform),
@@ -1086,7 +1091,7 @@ namespace Sporefront.Visual
             var row = UIHelper.CreateHorizontalRow(parent, 40f, 4f);
             var buttons = new List<Button>();
 
-            string[] names = { "Small", "Medium", "Large" };
+            string[] names = { "Small", "Medium", "Large", "Very High" };
             for (int i = 0; i < names.Length; i++)
             {
                 int idx = i;
@@ -1096,7 +1101,7 @@ namespace Sporefront.Visual
                     UpdateSegmentSelection("startingResources", idx);
                 });
                 var btnLE = btn.gameObject.AddComponent<LayoutElement>();
-                btnLE.preferredWidth = 120;
+                btnLE.preferredWidth = 100;
                 btnLE.preferredHeight = 40;
                 buttons.Add(btn);
             }
@@ -1105,6 +1110,52 @@ namespace Sporefront.Visual
             segmentBorders["startingResources"] = AddSegmentBottomBorders(buttons);
             segmentSelections["startingResources"] = (int)selectedStartingResources;
             UpdateSegmentColors("startingResources");
+        }
+
+        // ================================================================
+        // City Center Level
+        // ================================================================
+
+        private void BuildCCLevelSection(Transform parent)
+        {
+            var sectionLabel = UIHelper.CreateLabel(parent, "Starting CC Level",
+                UIConstants.FontHeader, SporefrontColors.InkDark,
+                TextAnchor.MiddleLeft, true);
+            var sectionLE = sectionLabel.gameObject.AddComponent<LayoutElement>();
+            sectionLE.preferredHeight = 28;
+
+            var descLabel = UIHelper.CreateLabel(parent,
+                "City Center level both players start with. Higher levels unlock more buildings and research.",
+                UIConstants.FontBody, SporefrontColors.InkLight,
+                TextAnchor.UpperLeft, false);
+            descLabel.horizontalOverflow = HorizontalWrapMode.Wrap;
+            var descLE = descLabel.gameObject.AddComponent<LayoutElement>();
+            descLE.preferredHeight = 32;
+
+            var row = UIHelper.CreateHorizontalRow(parent, 40f, 4f);
+            var buttons = new List<Button>();
+
+            string[] names = { "1", "2", "3", "4", "5", "6", "7", "8", "9", "10" };
+            for (int i = 0; i < names.Length; i++)
+            {
+                int level = i + 1;
+                var btn = UIHelper.CreateButton(row.transform, names[i], null, null, UIConstants.FontBody, () =>
+                {
+                    selectedCCLevel = level;
+                    UpdateSegmentSelection("ccLevel", level - 1);
+                });
+                var label = UIHelper.GetButtonLabel(btn);
+                UIHelper.EnableAutoFit(label, 10, UIConstants.FontBody);
+                var btnLE = btn.gameObject.AddComponent<LayoutElement>();
+                btnLE.preferredWidth = 36;
+                btnLE.preferredHeight = 36;
+                buttons.Add(btn);
+            }
+
+            segmentGroups["ccLevel"] = buttons;
+            segmentBorders["ccLevel"] = AddSegmentBottomBorders(buttons);
+            segmentSelections["ccLevel"] = selectedCCLevel - 1;
+            UpdateSegmentColors("ccLevel");
         }
 
         // ================================================================
@@ -1183,7 +1234,8 @@ namespace Sporefront.Visual
                     visibilityMode = selectedVisibility,
                     playerFaction = selectedFaction,
                     aiFaction = selectedAIFaction,
-                    isOnlineMode = isOnlineMode
+                    isOnlineMode = isOnlineMode,
+                    startingCCLevel = selectedCCLevel
                 };
                 OnStartGame?.Invoke(config);
             });
@@ -1290,7 +1342,7 @@ namespace Sporefront.Visual
                 {
                     var inkDark = SporefrontColors.InkDark;
                     var inkMid = SporefrontColors.InkMid;
-                    label.color = isSel ? inkDark : new Color(inkMid.r, inkMid.g, inkMid.b, 0.5f);
+                    label.color = isSel ? inkDark : new Color(inkMid.r, inkMid.g, inkMid.b, 0.7f);
                 }
 
                 buttons[i].colors = UIHelper.CardButtonColors(Color.clear);

--- a/Sporefront/Assets/Scripts/Visual/InGameMenuPanel.cs
+++ b/Sporefront/Assets/Scripts/Visual/InGameMenuPanel.cs
@@ -24,6 +24,7 @@ namespace Sporefront.Visual
         public event Action OnSettings;
         public event Action OnQuitToMainMenu;
         public event Action OnSurrender;
+        public event Action OnCombatLog;
 
         // ================================================================
         // State
@@ -204,6 +205,15 @@ namespace Sporefront.Visual
                 () =>
                 {
                     OnSettings?.Invoke();
+                });
+
+            // Combat Log
+            CreateMenuButton(buttonsArea.transform, "Combat Log",
+                SporefrontColors.ParchmentDeep, UIHelper.InkBodyText,
+                () =>
+                {
+                    Hide();
+                    OnCombatLog?.Invoke();
                 });
 
             // Surrender (online games only)

--- a/Sporefront/Assets/Scripts/Visual/ResourceBarPanel.cs
+++ b/Sporefront/Assets/Scripts/Visual/ResourceBarPanel.cs
@@ -41,6 +41,7 @@ namespace Sporefront.Visual
         public event Action OnCombatLogClicked;
         public event Action OnSettingsClicked;
         public event Action OnMainMenuClicked;
+        public event Action OnIdleVillagerClicked;
 
         // ================================================================
         // Per-resource UI struct
@@ -83,9 +84,14 @@ namespace Sporefront.Visual
         private Text badgeText;
         private GameObject badgeGO;
 
+        // Idle villager
+        private Button idleVillagerButton;
+        private Text idleVillagerBadgeText;
+        private GameObject idleVillagerBadgeGO;
+
         // Ellipsis
         private Button ellipsisButton;
-        private GameObject ellipsisDropdown;
+        // ellipsisDropdown removed — button now opens InGameMenuPanel directly
         private Transform canvasRoot;
 
         // Warning pulse animation
@@ -148,14 +154,14 @@ namespace Sporefront.Visual
             // Game speed indicator (hidden at 1x)
             CreateSpeedIndicator(strip.transform);
 
+            // Idle villager button
+            CreateIdleVillagerButton(strip.transform);
+
             // Notification bell
             CreateNotificationButton(strip.transform);
 
             // Ellipsis menu
             CreateEllipsisButton(strip.transform);
-
-            // Dropdown (parented to canvas for z-ordering)
-            CreateEllipsisDropdown();
 
             gameObject.transform.SetParent(panel.transform, false);
             panel.SetActive(false);
@@ -252,20 +258,7 @@ namespace Sporefront.Visual
                 }
             }
 
-            // Dismiss ellipsis dropdown on outside click
-            if (ellipsisDropdown != null && ellipsisDropdown.activeSelf
-                && Mouse.current != null && Mouse.current.leftButton.wasPressedThisFrame)
-            {
-                var dropdownRT = ellipsisDropdown.GetComponent<RectTransform>();
-                var ellipsisBtnRT = ellipsisButton.GetComponent<RectTransform>();
-                Vector2 mousePos = Mouse.current.position.ReadValue();
-
-                if (!RectTransformUtility.RectangleContainsScreenPoint(dropdownRT, mousePos)
-                    && !RectTransformUtility.RectangleContainsScreenPoint(ellipsisBtnRT, mousePos))
-                {
-                    ellipsisDropdown.SetActive(false);
-                }
-            }
+            // (Ellipsis dropdown removed — button now opens InGameMenuPanel directly)
         }
 
         // ================================================================
@@ -712,6 +705,79 @@ namespace Sporefront.Visual
         // Notification Button
         // ================================================================
 
+        private void CreateIdleVillagerButton(Transform parent)
+        {
+            var btnGO = new GameObject("IdleVillagerBtn", typeof(RectTransform), typeof(Image),
+                typeof(Button), typeof(LayoutElement));
+            btnGO.transform.SetParent(parent, false);
+
+            var img = btnGO.GetComponent<Image>();
+            img.color = Color.clear;
+            img.sprite = UIHelper.GetRoundedRectSprite(UIHelper.SmallCornerRadius);
+            img.type = Image.Type.Sliced;
+
+            idleVillagerButton = btnGO.GetComponent<Button>();
+            idleVillagerButton.colors = HoverButtonColors();
+            idleVillagerButton.onClick.AddListener(() => OnIdleVillagerClicked?.Invoke());
+
+            var le = btnGO.GetComponent<LayoutElement>();
+            le.preferredWidth = 36;
+            le.preferredHeight = 36;
+
+            // "V" label for villager
+            var label = CreateThemedLabel(btnGO.transform, "V", 14,
+                SporefrontColors.InkMid, false);
+            label.alignment = TextAnchor.MiddleCenter;
+            var labelRT = label.GetComponent<RectTransform>();
+            labelRT.anchorMin = Vector2.zero;
+            labelRT.anchorMax = Vector2.one;
+            labelRT.offsetMin = Vector2.zero;
+            labelRT.offsetMax = Vector2.zero;
+            label.raycastTarget = false;
+
+            // Badge (red circle with count)
+            idleVillagerBadgeGO = new GameObject("IdleBadge", typeof(RectTransform), typeof(Image));
+            idleVillagerBadgeGO.transform.SetParent(btnGO.transform, false);
+            var badgeImg = idleVillagerBadgeGO.GetComponent<Image>();
+            badgeImg.color = SporefrontColors.SporeRed;
+            badgeImg.sprite = UIHelper.GetRoundedRectSprite(10);
+            badgeImg.type = Image.Type.Sliced;
+
+            var badgeRT = idleVillagerBadgeGO.GetComponent<RectTransform>();
+            badgeRT.anchorMin = new Vector2(1, 1);
+            badgeRT.anchorMax = new Vector2(1, 1);
+            badgeRT.pivot = new Vector2(1, 1);
+            badgeRT.anchoredPosition = new Vector2(4, 4);
+            badgeRT.sizeDelta = new Vector2(18, 18);
+
+            var badgeTextGO = new GameObject("BadgeText", typeof(RectTransform), typeof(Text));
+            badgeTextGO.transform.SetParent(idleVillagerBadgeGO.transform, false);
+            idleVillagerBadgeText = badgeTextGO.GetComponent<Text>();
+            idleVillagerBadgeText.text = "0";
+            idleVillagerBadgeText.fontSize = 9;
+            idleVillagerBadgeText.fontStyle = FontStyle.Bold;
+            idleVillagerBadgeText.color = Color.white;
+            idleVillagerBadgeText.alignment = TextAnchor.MiddleCenter;
+            idleVillagerBadgeText.font = UIHelper.BodyFont;
+            UIHelper.StretchFull(badgeTextGO.GetComponent<RectTransform>());
+
+            idleVillagerBadgeGO.SetActive(false);
+        }
+
+        public void UpdateIdleVillagerBadge(int count)
+        {
+            if (idleVillagerBadgeGO == null) return;
+            if (count <= 0)
+            {
+                idleVillagerBadgeGO.SetActive(false);
+            }
+            else
+            {
+                idleVillagerBadgeGO.SetActive(true);
+                idleVillagerBadgeText.text = count > 99 ? "99+" : count.ToString();
+            }
+        }
+
         private void CreateNotificationButton(Transform parent)
         {
             var btnGO = new GameObject("NotifBtn", typeof(RectTransform), typeof(Image),
@@ -795,13 +861,7 @@ namespace Sporefront.Visual
             ellipsisButton.colors = menuColors;
             ellipsisButton.onClick.AddListener(() =>
             {
-                if (ellipsisDropdown != null)
-                {
-                    bool show = !ellipsisDropdown.activeSelf;
-                    ellipsisDropdown.SetActive(show);
-                    if (show)
-                        ellipsisDropdown.transform.SetAsLastSibling();
-                }
+                OnMainMenuClicked?.Invoke();
             });
 
             var le = btnGO.GetComponent<LayoutElement>();
@@ -819,57 +879,7 @@ namespace Sporefront.Visual
             dotsLabel.raycastTarget = false;
         }
 
-        private void CreateEllipsisDropdown()
-        {
-            ellipsisDropdown = UIHelper.CreatePanel(canvasRoot, "EllipsisDropdown", UIHelper.PanelBg);
-            var rt = ellipsisDropdown.GetComponent<RectTransform>();
-            rt.anchorMin = new Vector2(1, 1);
-            rt.anchorMax = new Vector2(1, 1);
-            rt.pivot = new Vector2(1, 1);
-            rt.anchoredPosition = new Vector2(-8, -84);
-            rt.sizeDelta = new Vector2(180, 0);
-
-            var vlg = ellipsisDropdown.AddComponent<VerticalLayoutGroup>();
-            vlg.padding = new RectOffset(6, 6, 6, 6);
-            vlg.spacing = 4;
-            vlg.childForceExpandWidth = true;
-            vlg.childForceExpandHeight = false;
-
-            var csf = ellipsisDropdown.AddComponent<ContentSizeFitter>();
-            csf.verticalFit = ContentSizeFitter.FitMode.PreferredSize;
-
-            // Combat Log
-            var combatLogBtn = UIHelper.CreateButton(ellipsisDropdown.transform, "Combat Log",
-                SporefrontColors.BgSurface, SporefrontColors.ParchmentMid, 14, () =>
-                {
-                    ellipsisDropdown.SetActive(false);
-                    OnCombatLogClicked?.Invoke();
-                });
-            var clLE = combatLogBtn.gameObject.AddComponent<LayoutElement>();
-            clLE.preferredHeight = 38;
-
-            // Settings
-            var settingsBtn = UIHelper.CreateButton(ellipsisDropdown.transform, "Settings",
-                SporefrontColors.BgSurface, SporefrontColors.ParchmentMid, 14, () =>
-                {
-                    ellipsisDropdown.SetActive(false);
-                    OnSettingsClicked?.Invoke();
-                });
-            var sLE = settingsBtn.gameObject.AddComponent<LayoutElement>();
-            sLE.preferredHeight = 38;
-
-            // Main Menu
-            var menuBtn = UIHelper.CreateButton(ellipsisDropdown.transform, "Main Menu",
-                SporefrontColors.BgSurface, SporefrontColors.ParchmentMid, 14, () =>
-                {
-                    ellipsisDropdown.SetActive(false);
-                    OnMainMenuClicked?.Invoke();
-                });
-            var mLE = menuBtn.gameObject.AddComponent<LayoutElement>();
-            mLE.preferredHeight = 38;
-
-            ellipsisDropdown.SetActive(false);
-        }
+        // CreateEllipsisDropdown removed — ☰ button now opens InGameMenuPanel directly
 
         // ================================================================
         // Label Helper

--- a/Sporefront/Assets/Scripts/Visual/TileInfoPanel.cs
+++ b/Sporefront/Assets/Scripts/Visual/TileInfoPanel.cs
@@ -269,6 +269,18 @@ namespace Sporefront.Visual
                 UIHelper.CreateDivider(contentRT);
             }
 
+            // 4b. Scouts section
+            var scoutID = gameState.mapData.GetScoutID(coord);
+            if (scoutID.HasValue)
+            {
+                var scout = gameState.GetScout(scoutID.Value);
+                if (scout != null)
+                {
+                    BuildScoutSection(scout, coord, gameState);
+                    UIHelper.CreateDivider(contentRT);
+                }
+            }
+
             // 5. Resource point section
             var rp = gameState.GetResourcePoint(coord);
             if (rp != null && !rp.IsDepleted())
@@ -486,8 +498,10 @@ namespace Sporefront.Visual
                 var trainBtn = UIHelper.CreateButton(contentRT, btnLabel,
                     SporefrontColors.SporeGreen, UIHelper.ButtonText, UIConstants.FontBody,
                     () => OnTrainVillagerRequested?.Invoke(capturedBuildingID));
+                var trainLabel = UIHelper.GetButtonLabel(trainBtn);
+                UIHelper.EnableAutoFit(trainLabel, 11, UIConstants.FontBody);
                 var trainBtnLE = trainBtn.gameObject.AddComponent<LayoutElement>();
-                trainBtnLE.preferredHeight = 34;
+                trainBtnLE.preferredHeight = 36;
             }
 
             // Quick deploy villagers button
@@ -499,8 +513,10 @@ namespace Sporefront.Visual
                     $"Deploy Villagers ({building.villagerGarrison})",
                     SporefrontColors.SporeGreen, UIHelper.ButtonText, UIConstants.FontBody,
                     () => OnDeployVillagersRequested?.Invoke(capturedBuildingID, capturedCount));
+                var deployLabel = UIHelper.GetButtonLabel(deployBtn);
+                UIHelper.EnableAutoFit(deployLabel, 11, UIConstants.FontBody);
                 var deployBtnLE = deployBtn.gameObject.AddComponent<LayoutElement>();
-                deployBtnLE.preferredHeight = 34;
+                deployBtnLE.preferredHeight = 36;
             }
 
             // Quick upgrade button (all building types)
@@ -519,8 +535,10 @@ namespace Sporefront.Visual
                     UIConstants.FontBody,
                     () => OnUpgradeBuildingRequested?.Invoke(capturedBuildingID));
                 upgradeBtn.interactable = canAfford;
+                var upgradeLabel = UIHelper.GetButtonLabel(upgradeBtn);
+                UIHelper.EnableAutoFit(upgradeLabel, 11, UIConstants.FontBody);
                 var upgradeBtnLE = upgradeBtn.gameObject.AddComponent<LayoutElement>();
-                upgradeBtnLE.preferredHeight = 34;
+                upgradeBtnLE.preferredHeight = 36;
             }
         }
 
@@ -735,6 +753,51 @@ namespace Sporefront.Visual
                         cancelLE.preferredHeight = 28;
                     }
                 }
+            }
+        }
+
+        private void BuildScoutSection(ScoutData scout, HexCoordinate coord, GameState gameState)
+        {
+            var sectionHeader = UIHelper.CreateLabel(contentRT, "Mycelium Scout",
+                UIConstants.FontSubheader, UIHelper.InkHeaderText,
+                TextAnchor.MiddleLeft, true);
+            var headerLE = sectionHeader.gameObject.AddComponent<LayoutElement>();
+            headerLE.preferredHeight = 28;
+
+            bool isOwned = scout.ownerID.HasValue && scout.ownerID.Value == localPlayerID;
+
+            // Stats row
+            var statsRow = UIHelper.CreateHorizontalRow(contentRT, 22f, 4f);
+            var hpLabel = UIHelper.CreateLabel(statsRow.transform,
+                $"HP: {(int)scout.hp}/{(int)scout.maxHp}", UIConstants.FontCaption, UIHelper.InkBodyText);
+            var hpLE = hpLabel.gameObject.AddComponent<LayoutElement>();
+            hpLE.flexibleWidth = 1;
+
+            var staminaLabel = UIHelper.CreateLabel(statsRow.transform,
+                $"Stamina: {(int)scout.stamina}/{(int)scout.maxStamina}", UIConstants.FontCaption, UIHelper.InkBodyText);
+            var staminaLE = staminaLabel.gameObject.AddComponent<LayoutElement>();
+            staminaLE.flexibleWidth = 1;
+
+            var visionLabel = UIHelper.CreateLabel(statsRow.transform,
+                $"Vision: {scout.visionRange}", UIConstants.FontCaption, UIHelper.InkMutedText);
+            var visionLE = visionLabel.gameObject.AddComponent<LayoutElement>();
+            visionLE.preferredWidth = 60;
+
+            if (isOwned)
+            {
+                var capturedScoutID = scout.id;
+                var actionRow = UIHelper.CreateHorizontalRow(contentRT, 28f, 4f);
+                var spacer = new GameObject("Spacer");
+                spacer.transform.SetParent(actionRow.transform, false);
+                var spacerLE = spacer.AddComponent<LayoutElement>();
+                spacerLE.flexibleWidth = 1;
+
+                var moveBtn = UIHelper.CreateButton(actionRow.transform, "Move",
+                    SporefrontColors.ParchmentDeep, UIHelper.InkBodyText, UIConstants.FontBody,
+                    () => OnMoveRequested?.Invoke(capturedScoutID, coord));
+                var moveBtnLE = moveBtn.gameObject.AddComponent<LayoutElement>();
+                moveBtnLE.preferredWidth = 50;
+                moveBtnLE.preferredHeight = 28;
             }
         }
 
@@ -974,7 +1037,85 @@ namespace Sporefront.Visual
                 }
             }
 
-            if (!hasArmies && !hasVillagers)
+            // Scouts section — sorted by distance
+            var allScouts = gameState.GetScoutsForPlayer(localPlayerID);
+            bool hasScouts = false;
+            if (allScouts != null && allScouts.Count > 0)
+            {
+                var sortedScouts = new List<ScoutData>(allScouts);
+                sortedScouts.Sort((a, b) =>
+                    a.coordinate.Distance(coord).CompareTo(b.coordinate.Distance(coord)));
+
+                foreach (var scout in sortedScouts)
+                {
+                    if (!hasScouts)
+                    {
+                        if (hasArmies || hasVillagers) UIHelper.CreateDivider(contentRT);
+                        var sectionHeader = UIHelper.CreateLabel(contentRT, "Scouts",
+                            UIConstants.FontSubheader, UIHelper.InkHeaderText,
+                            TextAnchor.MiddleLeft, true);
+                        var shLE = sectionHeader.gameObject.AddComponent<LayoutElement>();
+                        shLE.preferredHeight = 28;
+                        hasScouts = true;
+                    }
+
+                    int distance = scout.coordinate.Distance(coord);
+                    bool isSelected = previewedEntityID.HasValue && previewedEntityID.Value == scout.id;
+
+                    Color rowBg = isSelected
+                        ? Color.Lerp(Color.clear, SporefrontColors.SporeTeal, 0.12f)
+                        : Color.clear;
+                    var row = UIHelper.CreatePanel(contentRT, "ScoutRow", rowBg);
+                    var rowLE = row.AddComponent<LayoutElement>();
+                    rowLE.preferredHeight = 56;
+
+                    var vlg = row.AddComponent<VerticalLayoutGroup>();
+                    vlg.spacing = 2;
+                    vlg.padding = new RectOffset(8, 8, 2, 2);
+                    vlg.childForceExpandWidth = true;
+                    vlg.childForceExpandHeight = false;
+
+                    var nameRow = UIHelper.CreateHorizontalRow(row.transform, 20f, 4f);
+                    var nameLabel = UIHelper.CreateLabel(nameRow.transform,
+                        "Mycelium Scout", UIConstants.FontBody, UIHelper.InkBodyText);
+                    var nameLE = nameLabel.gameObject.AddComponent<LayoutElement>();
+                    nameLE.flexibleWidth = 1;
+
+                    var distLabel = UIHelper.CreateLabel(nameRow.transform,
+                        $"{distance} tiles", UIConstants.FontCaption, UIHelper.InkMutedText);
+                    var distLE = distLabel.gameObject.AddComponent<LayoutElement>();
+                    distLE.preferredWidth = 55;
+
+                    var infoRow = UIHelper.CreateHorizontalRow(row.transform, 20f, 4f);
+                    var staminaLabel = UIHelper.CreateLabel(infoRow.transform,
+                        $"Stamina: {(int)scout.stamina}/{(int)scout.maxStamina}", UIConstants.FontCaption, UIHelper.InkMutedText);
+                    var staminaLE = staminaLabel.gameObject.AddComponent<LayoutElement>();
+                    staminaLE.flexibleWidth = 1;
+
+                    var actionRow = UIHelper.CreateHorizontalRow(row.transform, 24f, 4f);
+                    var spacer = new GameObject("Spacer");
+                    spacer.transform.SetParent(actionRow.transform, false);
+                    var spacerLE = spacer.AddComponent<LayoutElement>();
+                    spacerLE.flexibleWidth = 1;
+
+                    var capturedID = scout.id;
+                    var selectBtn = UIHelper.CreateButton(actionRow.transform,
+                        isSelected ? "Selected" : "Select",
+                        SporefrontColors.ParchmentDeep, UIHelper.ButtonText, UIConstants.FontBody,
+                        () =>
+                        {
+                            previewedEntityID = capturedID;
+                            previewIsArmy = false;
+                            OnPreviewPathRequested?.Invoke(capturedID, coord, false, false);
+                            Rebuild(cachedGameState);
+                        });
+                    var btnLE = selectBtn.gameObject.AddComponent<LayoutElement>();
+                    btnLE.preferredWidth = 70;
+                    btnLE.preferredHeight = 24;
+                }
+            }
+
+            if (!hasArmies && !hasVillagers && !hasScouts)
             {
                 var emptyLabel = UIHelper.CreateLabel(contentRT, "No movable entities",
                     UIConstants.FontBody, null, TextAnchor.MiddleCenter);

--- a/Sporefront/Assets/Scripts/Visual/TileInfoPopup.cs
+++ b/Sporefront/Assets/Scripts/Visual/TileInfoPopup.cs
@@ -54,6 +54,8 @@ namespace Sporefront.Visual
         private Text armyLabel;
         private GameObject villagerRow;
         private Text villagerLabel;
+        private GameObject scoutRow;
+        private Text scoutLabel;
         private GameObject resourceRow;
         private Text resourceLabel;
 
@@ -149,6 +151,8 @@ namespace Sporefront.Visual
             armyRow = CreateLabelRow(contentGO.transform, out armyLabel,
                 UIConstants.FontBody, false);
             villagerRow = CreateLabelRow(contentGO.transform, out villagerLabel,
+                UIConstants.FontBody, false);
+            scoutRow = CreateLabelRow(contentGO.transform, out scoutLabel,
                 UIConstants.FontBody, false);
             resourceRow = CreateLabelRow(contentGO.transform, out resourceLabel,
                 UIConstants.FontBody, false);
@@ -396,6 +400,26 @@ namespace Sporefront.Visual
             else
             {
                 villagerRow.SetActive(false);
+            }
+
+            // Scouts
+            var scoutID = gameState.mapData.GetScoutID(coord);
+            if (scoutID.HasValue)
+            {
+                var scout = gameState.GetScout(scoutID.Value);
+                if (scout != null)
+                {
+                    scoutLabel.text = $"Scout — Stamina: {(int)scout.stamina}/{(int)scout.maxStamina}";
+                    scoutRow.SetActive(true);
+                }
+                else
+                {
+                    scoutRow.SetActive(false);
+                }
+            }
+            else
+            {
+                scoutRow.SetActive(false);
             }
 
             // Resource
@@ -693,10 +717,11 @@ namespace Sporefront.Visual
             Color bgColor, out Text label, Action onClick)
         {
             var btn = UIHelper.CreateButton(parent, text,
-                bgColor, UIHelper.ButtonText, UIConstants.FontBody, onClick);
+                bgColor, UIHelper.ButtonText, UIConstants.FontCaption, onClick);
             var le = btn.gameObject.AddComponent<LayoutElement>();
             le.preferredHeight = 30f;
             label = btn.GetComponentInChildren<Text>();
+            UIHelper.EnableAutoFit(label, 10, UIConstants.FontCaption);
             var go = btn.gameObject;
             go.SetActive(false);
             return go;
@@ -707,6 +732,8 @@ namespace Sporefront.Visual
         {
             var btn = UIHelper.CreateButton(parent, text,
                 bgColor, UIHelper.HudTextColor, UIConstants.FontSmall, onClick);
+            var label = UIHelper.GetButtonLabel(btn);
+            UIHelper.EnableAutoFit(label, 9, UIConstants.FontSmall);
             var le = btn.gameObject.AddComponent<LayoutElement>();
             le.preferredWidth = 82f;
             le.preferredHeight = 40f;

--- a/Sporefront/Assets/Scripts/Visual/UIHelper.cs
+++ b/Sporefront/Assets/Scripts/Visual/UIHelper.cs
@@ -87,8 +87,8 @@ namespace Sporefront.Visual
 
         public static readonly Color ButtonBg = SporefrontColors.BgSurface;
         public static readonly Color ButtonText = SporefrontColors.ParchmentMid;
-        public static readonly Color BodyTextColor = SporefrontColors.ParchmentMid;
-        public static readonly Color HeaderTextColor = SporefrontColors.ParchmentLight;
+        public static readonly Color BodyTextColor = SporefrontColors.InkDark;
+        public static readonly Color HeaderTextColor = SporefrontColors.InkBlack;
         public static readonly Color HudTextColor = SporefrontColors.ParchmentLight;
 
         // ================================================================
@@ -241,6 +241,28 @@ namespace Sporefront.Visual
             t.verticalOverflow = VerticalWrapMode.Truncate;
             t.raycastTarget = false;
             return t;
+        }
+
+        /// <summary>
+        /// Enables Best Fit on a Text component so it auto-shrinks to fit its container.
+        /// Call after CreateLabel or on the label inside CreateButton.
+        /// </summary>
+        public static void EnableAutoFit(Text text, int minSize = 10, int maxSize = -1)
+        {
+            if (text == null) return;
+            text.resizeTextForBestFit = true;
+            text.resizeTextMinSize = minSize;
+            text.resizeTextMaxSize = maxSize > 0 ? maxSize : text.fontSize;
+            text.verticalOverflow = VerticalWrapMode.Truncate;
+            text.horizontalOverflow = HorizontalWrapMode.Wrap;
+        }
+
+        /// <summary>
+        /// Returns the Text component of the label inside a Button created by CreateButton.
+        /// </summary>
+        public static Text GetButtonLabel(Button btn)
+        {
+            return btn != null ? btn.GetComponentInChildren<Text>() : null;
         }
 
         public static Button CreateButton(Transform parent, string text,

--- a/Sporefront/Assets/Scripts/Visual/UIManager.cs
+++ b/Sporefront/Assets/Scripts/Visual/UIManager.cs
@@ -31,6 +31,7 @@ namespace Sporefront.Visual
         public event Action<Guid, bool> OnEntityFocused; // (entityID, isArmy)
         public event Action OnSurrenderRequested;
         public event Action OnRejoinGame;
+        public event Action<HexCoordinate> OnWallDrawRequested;
 
         // ================================================================
         // Core HUD Panels
@@ -143,6 +144,9 @@ namespace Sporefront.Visual
         private Guid localPlayerID;
         private HexCoordinate? selectedCoord;
         private HexCoordinate? pendingBuildCoord;
+
+        // Idle villager cycling
+        private int idleVillagerCycleIndex;
 
         // Thread-safe queue for callbacks from background threads (e.g., ArenaSimulator)
         private readonly ConcurrentQueue<Action> mainThreadActions = new ConcurrentQueue<Action>();
@@ -489,8 +493,11 @@ namespace Sporefront.Visual
             };
             tileInfo.OnMoveEntityToTile += (entityID, destination, isArmy) =>
             {
-                var cmd = new MoveCommand(localPlayerID, entityID, destination, isArmy);
-                ExecutePlayerCommand(cmd);
+                var scout = gameState.GetScout(entityID);
+                if (scout != null)
+                    ExecutePlayerCommand(new MoveScoutCommand(localPlayerID, entityID, destination));
+                else
+                    ExecutePlayerCommand(new MoveCommand(localPlayerID, entityID, destination, isArmy));
             };
             tileInfo.OnAttackEntityToTile += (armyID, targetCoordinate) =>
             {
@@ -510,6 +517,11 @@ namespace Sporefront.Visual
                 {
                     var vg = gameState.GetVillagerGroup(entityID);
                     if (vg != null) entityCoord = vg.coordinate;
+                    else
+                    {
+                        var sc = gameState.GetScout(entityID);
+                        if (sc != null) entityCoord = sc.coordinate;
+                    }
                 }
                 if (!entityCoord.HasValue) return;
 
@@ -559,6 +571,10 @@ namespace Sporefront.Visual
                 selectionRenderer.ClearBuildPreview();
                 ClearMultiSelectHighlights();
                 selectedEntitiesPanel?.Hide();
+            };
+            actionPanel.OnWallDrawRequested += (coord) =>
+            {
+                OnWallDrawRequested?.Invoke(coord);
             };
             actionPanel.OnBuildTypeSelected += (buildingType, coord, rotation) =>
             {
@@ -670,6 +686,7 @@ namespace Sporefront.Visual
             };
 
             // ---- ResourceBarPanel (top-right buttons) ----
+            resourceBar.OnIdleVillagerClicked += CycleToNextIdleVillager;
             resourceBar.OnNotificationClicked += () => notificationInbox.Show();
             resourceBar.OnCombatLogClicked += () => ShowCombatHistory();
             resourceBar.OnSettingsClicked += () => settings.Show();
@@ -679,6 +696,7 @@ namespace Sporefront.Visual
             };
 
             // ---- InGameMenuPanel ----
+            inGameMenu.OnCombatLog += () => ShowCombatHistory();
             inGameMenu.OnSaveGame += () =>
             {
                 saveLoad.ShowSave();
@@ -808,6 +826,11 @@ namespace Sporefront.Visual
                     armyDetail.Show(id, gameState);
                 else
                     buildingDetail.Show(id, gameState);
+            };
+
+            entitiesOverview.OnScoutSelected += (scoutID) =>
+            {
+                entitiesOverview.Hide();
             };
 
             trainingOverview.OnBuildingSelected += (id) =>
@@ -1120,6 +1143,10 @@ namespace Sporefront.Visual
         public bool IsActionModeActive => actionPanel.IsActive;
 
         public SelectionBoxRenderer SelectionBox => selectionBoxRenderer;
+        public SelectionRenderer SelectionRenderer => selectionRenderer;
+        public bool IsRotatePreviewActive => actionPanel.CurrentMode == ActionPanel.ActionMode.RotatePreview;
+        public void RotateBuilding() => actionPanel.RotateBuilding();
+        public void ConfirmRotatePreview() => actionPanel.ConfirmRotatePreview();
 
         public void OnMultiSelect(List<Guid> entityIDs)
         {
@@ -1200,6 +1227,7 @@ namespace Sporefront.Visual
             // 2. Show essential HUD immediately
             resourceBar.Show();
             resourceBar.Refresh(state, localPlayerID);
+            resourceBar.UpdateIdleVillagerBadge(CountIdleVillagers());
             tendrilWheelHUD.Show();
 
             // Show faction banner with actual player faction
@@ -1390,6 +1418,9 @@ namespace Sporefront.Visual
             if ((flags & resourceFlags) != 0)
                 resourceBar.Refresh(gameState, localPlayerID);
 
+            if ((flags & (StateChangeFlags.Villagers | StateChangeFlags.Movement)) != 0)
+                resourceBar.UpdateIdleVillagerBadge(CountIdleVillagers());
+
             // Core info panels — refresh on broad entity/building/fog changes
             const StateChangeFlags tileFlags = StateChangeFlags.Buildings | StateChangeFlags.Armies
                 | StateChangeFlags.Villagers | StateChangeFlags.FogOfWar | StateChangeFlags.Combat
@@ -1451,7 +1482,8 @@ namespace Sporefront.Visual
             }
 
             if ((flags & (StateChangeFlags.Armies | StateChangeFlags.Buildings
-                | StateChangeFlags.Villagers | StateChangeFlags.FogOfWar)) != 0)
+                | StateChangeFlags.Villagers | StateChangeFlags.FogOfWar
+                | StateChangeFlags.Scouts)) != 0)
                 entityRenderer.UpdateEntities(gameState);
 
             if ((flags & StateChangeFlags.Entrenchment) != 0)
@@ -1651,6 +1683,52 @@ namespace Sporefront.Visual
                     }
                 }
             }
+        }
+
+        // ================================================================
+        // Idle Villager Cycling
+        // ================================================================
+
+        public void CycleToNextIdleVillager()
+        {
+            if (gameState == null) return;
+
+            var groups = gameState.GetVillagerGroupsForPlayer(localPlayerID);
+            if (groups == null) return;
+
+            var idle = new List<VillagerGroupData>();
+            foreach (var g in groups)
+            {
+                if (g.currentTask.IsIdle && !g.HasPath() && g.HasVillagers())
+                    idle.Add(g);
+            }
+
+            if (idle.Count == 0)
+            {
+                ShowCommandFailure("No idle villagers");
+                return;
+            }
+
+            if (idleVillagerCycleIndex >= idle.Count)
+                idleVillagerCycleIndex = 0;
+
+            var target = idle[idleVillagerCycleIndex];
+            idleVillagerCycleIndex = (idleVillagerCycleIndex + 1) % idle.Count;
+
+            cameraController.FocusOn(target.coordinate, -1f, true);
+            OnEntityFocused?.Invoke(target.id, false);
+        }
+
+        private int CountIdleVillagers()
+        {
+            if (gameState == null) return 0;
+            var groups = gameState.GetVillagerGroupsForPlayer(localPlayerID);
+            if (groups == null) return 0;
+            int count = 0;
+            foreach (var g in groups)
+                if (g.currentTask.IsIdle && !g.HasPath() && g.HasVillagers())
+                    count++;
+            return count;
         }
 
         // ================================================================


### PR DESCRIPTION
## Summary
- **Mycelium Scout** — new trainable entity from City Center with stamina-based fast movement, vision range, and pathfinding. Includes training UI, entities overview panel integration, and online command serialization.
- **Wall drag-to-build** — hold left-click to draw a line of walls with live hex-line preview and validation. Up to 20 segments per drag.
- **Battlefield visual indicators** — army unit count labels, villager task icons (W/F/S/O/G/Bld/H/>), and garrison count badges on buildings for at-a-glance battlefield readability.
- **UI text fitting** — `EnableAutoFit` utility applied across all panels (game setup CC level selector, rotation banner, tile info buttons, building detail, popups) to prevent text overflow.
- **Code quality** — extracted 8 shared map generator helpers into `MapGeneratorBase` (~500 lines deduplication), replaced `SelectedEntity` boolean flags with `EntityKind` enum, added `IssueMoveCommand` helper, fixed `Guid.NewGuid()` churn on secondary building tiles, added `StateChangeFlags.Scouts` to renderer trigger, O(1) scout coordinate lookup, and hex-change guard on wall preview.

## Test plan
- [ ] Train a scout from City Center, verify it spawns adjacent to CC (not on villager tile)
- [ ] Move scout across map, verify stamina drains and regenerates, vision updates
- [ ] Scout killed by enemy army on same tile
- [ ] Wall drag-to-build: draw walls, verify preview highlights, walls placed on release
- [ ] Army unit count labels visible on army circles
- [ ] Villager task icons update when gathering/building/idle
- [ ] Garrison badges appear on buildings with garrisoned units
- [ ] CC level selector readable on game setup screen
- [ ] Castle rotation banner shows Rotate/Confirm/Cancel buttons
- [ ] Multi-tile buildings (Castle, Fort) don't flicker/recreate every frame
- [ ] Online play: scout commands stream correctly between clients

🤖 Generated with [Claude Code](https://claude.com/claude-code)