### PR TITLE
Add game modes and VS loading screen

### DIFF
--- a/Sporefront/Assets/Scripts/Data/ControlZoneData.cs
+++ b/Sporefront/Assets/Scripts/Data/ControlZoneData.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using Sporefront.Models;
+
+namespace Sporefront.Data
+{
+    [System.Serializable]
+    public class ControlZoneData
+    {
+        public string label;
+        public HexCoordinate center;
+        public List<HexCoordinate> tiles;
+        public Guid? controllingPlayerID;
+        public Dictionary<Guid, int> presenceCount;
+        public double pointsMultiplier = 1.0;
+
+        public ControlZoneData(string label, HexCoordinate center, List<HexCoordinate> tiles, double pointsMultiplier = 1.0)
+        {
+            this.label = label;
+            this.center = center;
+            this.tiles = tiles;
+            this.controllingPlayerID = null;
+            this.presenceCount = new Dictionary<Guid, int>();
+            this.pointsMultiplier = pointsMultiplier;
+        }
+
+        // Default constructor for deserialization
+        public ControlZoneData()
+        {
+            this.tiles = new List<HexCoordinate>();
+            this.presenceCount = new Dictionary<Guid, int>();
+            this.pointsMultiplier = 1.0;
+        }
+    }
+}

--- a/Sporefront/Assets/Scripts/Data/GameState.cs
+++ b/Sporefront/Assets/Scripts/Data/GameState.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Sporefront.Models;
 using Sporefront.Engine;
+using GameMode = Sporefront.Models.GameMode;
 
 namespace Sporefront.Data
 {
@@ -35,6 +36,13 @@ namespace Sporefront.Data
 
         // Scouts (Mycelium Scouts)
         public Dictionary<Guid, ScoutData> scouts = new Dictionary<Guid, ScoutData>();
+
+        // Game Mode
+        public GameMode gameMode = GameMode.Conquest;
+
+        // Domination Mode
+        public List<ControlZoneData> controlZones = new List<ControlZoneData>();
+        public Dictionary<Guid, double> dominationScores = new Dictionary<Guid, double>();
 
         // Time
         public double currentTime;
@@ -1353,6 +1361,9 @@ namespace Sporefront.Data
         public List<CommanderData> commanders;
         public List<ScoutData> scouts;
         public Guid? localPlayerID;
+        public GameMode gameMode;
+        public List<ControlZoneData> controlZones;
+        public Dictionary<Guid, double> dominationScores;
 
         // Default constructor for deserialization
         public GameStateSnapshot() { }
@@ -1370,6 +1381,9 @@ namespace Sporefront.Data
             this.commanders = new List<CommanderData>(gameState.commanders.Values);
             this.scouts = new List<ScoutData>(gameState.scouts.Values);
             this.localPlayerID = gameState.localPlayerID;
+            this.gameMode = gameState.gameMode;
+            this.controlZones = new List<ControlZoneData>(gameState.controlZones);
+            this.dominationScores = new Dictionary<Guid, double>(gameState.dominationScores);
         }
 
         public GameState Restore()
@@ -1405,6 +1419,13 @@ namespace Sporefront.Data
             foreach (var commander in commanders) gameState.AddCommander(commander);
             if (scouts != null)
                 foreach (var scout in scouts) gameState.AddScout(scout);
+
+            // Restore game mode and domination state
+            gameState.gameMode = gameMode;
+            if (controlZones != null)
+                gameState.controlZones = new List<ControlZoneData>(controlZones);
+            if (dominationScores != null)
+                gameState.dominationScores = new Dictionary<Guid, double>(dominationScores);
 
             return gameState;
         }

--- a/Sporefront/Assets/Scripts/Data/StateChange.cs
+++ b/Sporefront/Assets/Scripts/Data/StateChange.cs
@@ -23,6 +23,7 @@ namespace Sporefront.Data
         Entrenchment  = 1 << 11,
         UnitUpgrade   = 1 << 12,
         Scouts        = 1 << 13,
+        Domination    = 1 << 14,
     }
 
     // Base class for all state changes
@@ -158,6 +159,12 @@ namespace Sporefront.Data
                     return StateChangeFlags.Scouts;
                 case ScoutMovedChange _:
                     return StateChangeFlags.Scouts | StateChangeFlags.Movement;
+
+                // Domination
+                case ZoneControlChange _:
+                case DominationScoreChange _:
+                case DominationVictoryChange _:
+                    return StateChangeFlags.Domination;
 
                 // Diplomacy
                 case DiplomacyChangedChange _:
@@ -447,6 +454,27 @@ namespace Sporefront.Data
     public class ScoutTrainingStartedChange : StateChange { public Guid buildingID; public double startTime; }
     public class ScoutTrainingCompletedChange : StateChange { public Guid buildingID; public Guid scoutID; public HexCoordinate coordinate; }
     public class ScoutTrainingProgressChange : StateChange { public Guid buildingID; public int entryIndex; public double progress; }
+
+    // ================================================================
+    // Domination Changes
+    // ================================================================
+
+    public class ZoneControlChange : StateChange
+    {
+        public string zoneLabel;
+        public Guid? oldControllerID;
+        public Guid? newControllerID;
+    }
+    public class DominationScoreChange : StateChange
+    {
+        public Guid playerID;
+        public double newScore;
+        public double delta;
+    }
+    public class DominationVictoryChange : StateChange
+    {
+        public Guid winnerID;
+    }
 
     [System.Serializable]
     public class StateChangeBatch

--- a/Sporefront/Assets/Scripts/Engine/DominationEngine.cs
+++ b/Sporefront/Assets/Scripts/Engine/DominationEngine.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Sporefront.Data;
+using Sporefront.Models;
+
+namespace Sporefront.Engine
+{
+    public class DominationEngine
+    {
+        private GameState gameState;
+
+        public void Setup(GameState gameState)
+        {
+            this.gameState = gameState;
+        }
+
+        public List<StateChange> Update(double currentTime)
+        {
+            if (gameState == null || gameState.controlZones == null || gameState.controlZones.Count == 0)
+                return StateChange.EmptyChanges;
+
+            var changes = new List<StateChange>();
+
+            // Build a lookup of army coordinate → (ownerID, unit count) for fast zone checking
+            var armyPositions = new Dictionary<HexCoordinate, List<(Guid ownerID, int unitCount)>>();
+            foreach (var army in gameState.armies.Values)
+            {
+                if (!army.ownerID.HasValue) continue;
+                List<(Guid, int)> list;
+                if (!armyPositions.TryGetValue(army.coordinate, out list))
+                {
+                    list = new List<(Guid, int)>();
+                    armyPositions[army.coordinate] = list;
+                }
+                int totalUnits = 0;
+                foreach (var count in army.composition.Values)
+                    totalUnits += count;
+                list.Add((army.ownerID.Value, totalUnits));
+            }
+
+            // Evaluate each control zone
+            foreach (var zone in gameState.controlZones)
+            {
+                // Count troops per player in this zone
+                var playerTroops = new Dictionary<Guid, int>();
+                foreach (var tile in zone.tiles)
+                {
+                    List<(Guid ownerID, int unitCount)> armiesOnTile;
+                    if (armyPositions.TryGetValue(tile, out armiesOnTile))
+                    {
+                        foreach (var entry in armiesOnTile)
+                        {
+                            int existing;
+                            playerTroops.TryGetValue(entry.ownerID, out existing);
+                            playerTroops[entry.ownerID] = existing + entry.unitCount;
+                        }
+                    }
+                }
+
+                zone.presenceCount = playerTroops;
+
+                // Determine controller: player with strictly more troops
+                Guid? newController = null;
+                int maxTroops = 0;
+                bool tied = false;
+                foreach (var kvp in playerTroops)
+                {
+                    if (kvp.Value > maxTroops)
+                    {
+                        maxTroops = kvp.Value;
+                        newController = kvp.Key;
+                        tied = false;
+                    }
+                    else if (kvp.Value == maxTroops && kvp.Value > 0)
+                    {
+                        tied = true;
+                    }
+                }
+                if (tied) newController = null;
+
+                if (newController != zone.controllingPlayerID)
+                {
+                    changes.Add(new ZoneControlChange
+                    {
+                        zoneLabel = zone.label,
+                        oldControllerID = zone.controllingPlayerID,
+                        newControllerID = newController
+                    });
+                    zone.controllingPlayerID = newController;
+                }
+            }
+
+            // Award points for controlled zones (using per-zone pointsMultiplier)
+            var multiplierPerPlayer = new Dictionary<Guid, double>();
+            foreach (var zone in gameState.controlZones)
+            {
+                if (zone.controllingPlayerID.HasValue)
+                {
+                    double current;
+                    multiplierPerPlayer.TryGetValue(zone.controllingPlayerID.Value, out current);
+                    multiplierPerPlayer[zone.controllingPlayerID.Value] = current + zone.pointsMultiplier;
+                }
+            }
+
+            foreach (var kvp in multiplierPerPlayer)
+            {
+                double delta = GameConfig.Domination.PointsPerSecond * kvp.Value * GameConfig.Domination.UpdateInterval;
+                double oldScore;
+                gameState.dominationScores.TryGetValue(kvp.Key, out oldScore);
+                double newScore = oldScore + delta;
+                gameState.dominationScores[kvp.Key] = newScore;
+
+                changes.Add(new DominationScoreChange
+                {
+                    playerID = kvp.Key,
+                    newScore = newScore,
+                    delta = delta
+                });
+            }
+
+            // Check for victory
+            foreach (var kvp in gameState.dominationScores)
+            {
+                if (kvp.Value >= GameConfig.Domination.ScoreToWin)
+                {
+                    gameState.isGameOver = true;
+                    changes.Add(new DominationVictoryChange { winnerID = kvp.Key });
+                    changes.Add(new GameOverChange
+                    {
+                        reason = GameOverReason.DominationVictory.DisplayMessage(),
+                        winnerID = kvp.Key,
+                        reasonType = GameOverReason.DominationVictory
+                    });
+                    break;
+                }
+            }
+
+            return changes;
+        }
+    }
+}

--- a/Sporefront/Assets/Scripts/Engine/GameConfig.cs
+++ b/Sporefront/Assets/Scripts/Engine/GameConfig.cs
@@ -238,6 +238,24 @@ namespace Sporefront.Engine
             public const int BurnAreasFoodPerLevel = 25;
         }
 
+        public static class Domination
+        {
+            public const int ZoneCount = 3;
+            public const int ZoneRadius = 2;
+            public const double PointsPerSecond = 1.0;
+            public const double ScoreToWin = 300.0;
+            public const double UpdateInterval = 1.0;
+
+            // Crooked Domination — how far A/C zones shift toward each player
+            public const double CrookedAxisOffset = 0.3;
+
+            // Ring — concentric circles at map center
+            public const int RingInnerRadius = 2;
+            public const int RingOuterRadius = 4;
+            public const double RingInnerMultiplier = 2.0;
+            public const double RingOuterMultiplier = 1.0;
+        }
+
         public static class MapDimensions
         {
             public const int Small = 25;

--- a/Sporefront/Assets/Scripts/Engine/GameEngine.cs
+++ b/Sporefront/Assets/Scripts/Engine/GameEngine.cs
@@ -65,6 +65,7 @@ namespace Sporefront.Engine
         public readonly ConstructionEngine constructionEngine;
         public readonly TrainingEngine trainingEngine;
         public readonly VisionEngine visionEngine;
+        public readonly DominationEngine dominationEngine;
 
         private AIController aiController;
 
@@ -99,6 +100,7 @@ namespace Sporefront.Engine
         private double lastEntrenchmentUpdate;
         private double lastResearchCheck;
         private double lastWinConditionCheck;
+        private double lastDominationUpdate;
 
         // Starvation tracking: per-player accumulated time with zero food
         private Dictionary<Guid, double> starvationTimers = new Dictionary<Guid, double>();
@@ -130,6 +132,7 @@ namespace Sporefront.Engine
             constructionEngine = new ConstructionEngine();
             trainingEngine = new TrainingEngine();
             visionEngine = new VisionEngine();
+            dominationEngine = new DominationEngine();
         }
 
         // ================================================================
@@ -152,6 +155,10 @@ namespace Sporefront.Engine
             constructionEngine.Setup(gameState);
             trainingEngine.Setup(gameState);
             visionEngine.Setup(gameState);
+
+            // Initialize domination engine if in domination mode
+            if (gameState.gameMode.UsesControlZones())
+                dominationEngine.Setup(gameState);
 
             // Initialize AI controller
             aiController = AIController.Instance;
@@ -271,6 +278,7 @@ namespace Sporefront.Engine
             lastEntrenchmentUpdate = 0;
             lastResearchCheck = 0;
             lastWinConditionCheck = 0;
+            lastDominationUpdate = 0;
             starvationTimers.Clear();
 
             // Reset online mode state
@@ -445,6 +453,15 @@ namespace Sporefront.Engine
                 allChanges.AddRange(unitUpgradeChanges);
 
                 lastResearchCheck = adjustedTime;
+            }
+
+            // Domination updates (1x per second, only in domination mode)
+            if (gameState.gameMode.UsesControlZones() &&
+                adjustedTime - lastDominationUpdate >= GameConfig.Domination.UpdateInterval)
+            {
+                var dominationChanges = dominationEngine.Update(adjustedTime);
+                allChanges.AddRange(dominationChanges);
+                lastDominationUpdate = adjustedTime;
             }
 
             // Win condition checks (1x per second)
@@ -640,26 +657,29 @@ namespace Sporefront.Engine
             // Need at least 2 players for win conditions
             if (allPlayers.Count < 2) return StateChange.EmptyChanges;
 
-            // --- City Center Destroyed ---
-            foreach (var player in allPlayers)
+            // --- City Center Destroyed (Conquest mode only) ---
+            if (gameState.gameMode == GameMode.Conquest)
             {
-                var cityCenter = gameState.GetCityCenter(player.id);
-                if (cityCenter == null)
+                foreach (var player in allPlayers)
                 {
-                    // This player's city center is destroyed — find the opponent
-                    var opponent = allPlayers.FirstOrDefault(p => p.id != player.id);
-                    if (opponent != null)
+                    var cityCenter = gameState.GetCityCenter(player.id);
+                    if (cityCenter == null)
                     {
-                        gameState.isGameOver = true;
-                        return new List<StateChange>
+                        // This player's city center is destroyed — find the opponent
+                        var opponent = allPlayers.FirstOrDefault(p => p.id != player.id);
+                        if (opponent != null)
                         {
-                            new GameOverChange
+                            gameState.isGameOver = true;
+                            return new List<StateChange>
                             {
-                                reason = GameOverReason.CityCenterDestroyed.DisplayMessage(),
-                                winnerID = opponent.id,
-                                reasonType = GameOverReason.CityCenterDestroyed
-                            }
-                        };
+                                new GameOverChange
+                                {
+                                    reason = GameOverReason.CityCenterDestroyed.DisplayMessage(),
+                                    winnerID = opponent.id,
+                                    reasonType = GameOverReason.CityCenterDestroyed
+                                }
+                            };
+                        }
                     }
                 }
             }

--- a/Sporefront/Assets/Scripts/Engine/MapGenerator.cs
+++ b/Sporefront/Assets/Scripts/Engine/MapGenerator.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Sporefront.Data;
 using Sporefront.Models;
 
@@ -375,6 +376,271 @@ namespace Sporefront.Engine
             }
 
             return hillCoords;
+        }
+
+        // ================================================================
+        // Domination Zone Placement
+        // ================================================================
+
+        public virtual List<ControlZoneData> GenerateControlZones(
+            List<HexCoordinate> startPositions,
+            Dictionary<HexCoordinate, TerrainGenerationData> terrain)
+        {
+            if (startPositions.Count < 2 || Seed == null)
+                return new List<ControlZoneData>();
+
+            var rng = new SeededRandom(Seed.Value ^ 0xD0D0D0D0D0D0UL);
+            var posA = startPositions[0];
+            var posB = startPositions[1];
+
+            // Compute midpoint between the two starting positions
+            double midQ = (posA.q + posB.q) / 2.0;
+            double midR = (posA.r + posB.r) / 2.0;
+
+            // Axis from A to B
+            double axisQ = posB.q - posA.q;
+            double axisR = posB.r - posA.r;
+
+            // Perpendicular direction (rotate 90°)
+            double perpQ = -axisR;
+            double perpR = axisQ;
+
+            // Normalize perpendicular
+            double perpLen = Math.Sqrt(perpQ * perpQ + perpR * perpR);
+            if (perpLen > 0)
+            {
+                perpQ /= perpLen;
+                perpR /= perpLen;
+            }
+
+            // Spacing: spread zones along perpendicular axis
+            double spacing = Math.Min(Width, Height) / 4.0;
+
+            string[] labels = { "A", "B", "C" };
+            double[] offsets = { -spacing, 0.0, spacing };
+            var zones = new List<ControlZoneData>();
+            int zoneRadius = GameConfig.Domination.ZoneRadius;
+
+            for (int i = 0; i < GameConfig.Domination.ZoneCount; i++)
+            {
+                // Base position along perpendicular
+                double baseQ = midQ + perpQ * offsets[i];
+                double baseR = midR + perpR * offsets[i];
+
+                // Random jitter ±2 hexes
+                int jitterQ = rng.NextInt(-2, 2);
+                int jitterR = rng.NextInt(-2, 2);
+                int centerQ = Math.Max(zoneRadius, Math.Min(Width - 1 - zoneRadius, (int)Math.Round(baseQ) + jitterQ));
+                int centerR = Math.Max(zoneRadius, Math.Min(Height - 1 - zoneRadius, (int)Math.Round(baseR) + jitterR));
+
+                var center = new HexCoordinate(centerQ, centerR);
+
+                // Snap to nearest walkable tile if center is unwalkable
+                TerrainGenerationData centerTerrain;
+                if (terrain.TryGetValue(center, out centerTerrain) && !centerTerrain.terrain.IsWalkable())
+                {
+                    center = FindNearestWalkable(center, terrain, zoneRadius + 3) ?? center;
+                }
+
+                // Expand zone tiles within radius, filtering non-walkable
+                var tiles = new List<HexCoordinate>();
+                for (int q = -zoneRadius; q <= zoneRadius; q++)
+                {
+                    for (int r = -zoneRadius; r <= zoneRadius; r++)
+                    {
+                        var coord = new HexCoordinate(center.q + q, center.r + r);
+                        if (coord.Distance(center) > zoneRadius) continue;
+                        if (coord.q < 0 || coord.q >= Width || coord.r < 0 || coord.r >= Height) continue;
+                        TerrainGenerationData td;
+                        if (terrain.TryGetValue(coord, out td) && td.terrain.IsWalkable())
+                            tiles.Add(coord);
+                    }
+                }
+
+                zones.Add(new ControlZoneData(labels[i], center, tiles));
+            }
+
+            return zones;
+        }
+
+        protected HexCoordinate? FindNearestWalkable(
+            HexCoordinate center,
+            Dictionary<HexCoordinate, TerrainGenerationData> terrain,
+            int searchRadius)
+        {
+            for (int dist = 1; dist <= searchRadius; dist++)
+            {
+                for (int q = -dist; q <= dist; q++)
+                {
+                    for (int r = -dist; r <= dist; r++)
+                    {
+                        var coord = new HexCoordinate(center.q + q, center.r + r);
+                        if (coord.Distance(center) != dist) continue;
+                        TerrainGenerationData td;
+                        if (terrain.TryGetValue(coord, out td) && td.terrain.IsWalkable())
+                            return coord;
+                    }
+                }
+            }
+            return null;
+        }
+
+        // ================================================================
+        // Zone Dispatch
+        // ================================================================
+
+        public virtual List<ControlZoneData> GenerateZonesForMode(
+            GameMode mode,
+            List<HexCoordinate> startPositions,
+            Dictionary<HexCoordinate, TerrainGenerationData> terrain)
+        {
+            switch (mode)
+            {
+                case GameMode.Domination:
+                    return GenerateControlZones(startPositions, terrain);
+                case GameMode.CrookedDomination:
+                    return GenerateCrookedZones(startPositions, terrain);
+                case GameMode.Ring:
+                    return GenerateRingZones(startPositions, terrain);
+                default:
+                    return new List<ControlZoneData>();
+            }
+        }
+
+        // ================================================================
+        // Crooked Domination Zone Placement
+        // ================================================================
+
+        public virtual List<ControlZoneData> GenerateCrookedZones(
+            List<HexCoordinate> startPositions,
+            Dictionary<HexCoordinate, TerrainGenerationData> terrain)
+        {
+            if (startPositions.Count < 2 || Seed == null)
+                return new List<ControlZoneData>();
+
+            var rng = new SeededRandom(Seed.Value ^ 0xC200CED000UL);
+            var posA = startPositions[0];
+            var posB = startPositions[1];
+
+            double midQ = (posA.q + posB.q) / 2.0;
+            double midR = (posA.r + posB.r) / 2.0;
+
+            // Axis from A to B (normalized)
+            double axisQ = posB.q - posA.q;
+            double axisR = posB.r - posA.r;
+            double axisLen = Math.Sqrt(axisQ * axisQ + axisR * axisR);
+            if (axisLen > 0) { axisQ /= axisLen; axisR /= axisLen; }
+
+            // Perpendicular (for jitter)
+            double perpQ = -axisR;
+            double perpR = axisQ;
+
+            double offset = GameConfig.Domination.CrookedAxisOffset * axisLen;
+            int zoneRadius = GameConfig.Domination.ZoneRadius;
+
+            // Zone A: offset toward player A
+            // Zone B: at midpoint
+            // Zone C: offset toward player B
+            var zoneDefs = new[]
+            {
+                (label: "A", qBase: midQ - axisQ * offset, rBase: midR - axisR * offset),
+                (label: "B", qBase: midQ, rBase: midR),
+                (label: "C", qBase: midQ + axisQ * offset, rBase: midR + axisR * offset),
+            };
+
+            var zones = new List<ControlZoneData>();
+            foreach (var def in zoneDefs)
+            {
+                // Jitter on perpendicular axis only (the axis offset is intentional)
+                int jitterQ = (int)Math.Round(perpQ * rng.NextInt(-2, 2));
+                int jitterR = (int)Math.Round(perpR * rng.NextInt(-2, 2));
+                int centerQ = Math.Max(zoneRadius, Math.Min(Width - 1 - zoneRadius, (int)Math.Round(def.qBase) + jitterQ));
+                int centerR = Math.Max(zoneRadius, Math.Min(Height - 1 - zoneRadius, (int)Math.Round(def.rBase) + jitterR));
+
+                var center = new HexCoordinate(centerQ, centerR);
+
+                TerrainGenerationData centerTerrain;
+                if (terrain.TryGetValue(center, out centerTerrain) && !centerTerrain.terrain.IsWalkable())
+                    center = FindNearestWalkable(center, terrain, zoneRadius + 3) ?? center;
+
+                var tiles = ExpandZoneTiles(center, zoneRadius, terrain);
+                zones.Add(new ControlZoneData(def.label, center, tiles));
+            }
+
+            return zones;
+        }
+
+        // ================================================================
+        // Ring Zone Placement
+        // ================================================================
+
+        public virtual List<ControlZoneData> GenerateRingZones(
+            List<HexCoordinate> startPositions,
+            Dictionary<HexCoordinate, TerrainGenerationData> terrain)
+        {
+            if (Seed == null)
+                return new List<ControlZoneData>();
+
+            int centerQ = Width / 2;
+            int centerR = Height / 2;
+            var mapCenter = new HexCoordinate(centerQ, centerR);
+
+            // Snap to walkable if needed
+            TerrainGenerationData centerTerrain;
+            if (terrain.TryGetValue(mapCenter, out centerTerrain) && !centerTerrain.terrain.IsWalkable())
+                mapCenter = FindNearestWalkable(mapCenter, terrain, 5) ?? mapCenter;
+
+            int innerRadius = GameConfig.Domination.RingInnerRadius;
+            int outerRadius = GameConfig.Domination.RingOuterRadius;
+
+            // Inner zone: all tiles within innerRadius
+            var innerTiles = ExpandZoneTiles(mapCenter, innerRadius, terrain);
+
+            // Outer zone: ring of tiles from innerRadius+1 to outerRadius
+            var outerTiles = new List<HexCoordinate>();
+            for (int q = -outerRadius; q <= outerRadius; q++)
+            {
+                for (int r = -outerRadius; r <= outerRadius; r++)
+                {
+                    var coord = new HexCoordinate(mapCenter.q + q, mapCenter.r + r);
+                    int dist = coord.Distance(mapCenter);
+                    if (dist <= innerRadius || dist > outerRadius) continue;
+                    if (coord.q < 0 || coord.q >= Width || coord.r < 0 || coord.r >= Height) continue;
+                    TerrainGenerationData td;
+                    if (terrain.TryGetValue(coord, out td) && td.terrain.IsWalkable())
+                        outerTiles.Add(coord);
+                }
+            }
+
+            var zones = new List<ControlZoneData>();
+            zones.Add(new ControlZoneData("Inner", mapCenter, innerTiles, GameConfig.Domination.RingInnerMultiplier));
+            zones.Add(new ControlZoneData("Outer", mapCenter, outerTiles, GameConfig.Domination.RingOuterMultiplier));
+
+            return zones;
+        }
+
+        // ================================================================
+        // Shared Zone Tile Expansion
+        // ================================================================
+
+        protected List<HexCoordinate> ExpandZoneTiles(
+            HexCoordinate center, int radius,
+            Dictionary<HexCoordinate, TerrainGenerationData> terrain)
+        {
+            var tiles = new List<HexCoordinate>();
+            for (int q = -radius; q <= radius; q++)
+            {
+                for (int r = -radius; r <= radius; r++)
+                {
+                    var coord = new HexCoordinate(center.q + q, center.r + r);
+                    if (coord.Distance(center) > radius) continue;
+                    if (coord.q < 0 || coord.q >= Width || coord.r < 0 || coord.r >= Height) continue;
+                    TerrainGenerationData td;
+                    if (terrain.TryGetValue(coord, out td) && td.terrain.IsWalkable())
+                        tiles.Add(coord);
+                }
+            }
+            return tiles;
         }
     }
 }

--- a/Sporefront/Assets/Scripts/Models/GameMode.cs
+++ b/Sporefront/Assets/Scripts/Models/GameMode.cs
@@ -1,0 +1,20 @@
+namespace Sporefront.Models
+{
+    public enum GameMode
+    {
+        Conquest,
+        Domination,
+        CrookedDomination,
+        Ring
+    }
+
+    public static class GameModeExtensions
+    {
+        public static bool UsesControlZones(this GameMode mode)
+        {
+            return mode == GameMode.Domination
+                || mode == GameMode.CrookedDomination
+                || mode == GameMode.Ring;
+        }
+    }
+}

--- a/Sporefront/Assets/Scripts/Models/GameOverReason.cs
+++ b/Sporefront/Assets/Scripts/Models/GameOverReason.cs
@@ -6,7 +6,8 @@ namespace Sporefront.Models
         Resignation,
         Conquest,
         CityCenterDestroyed,
-        Disconnected
+        Disconnected,
+        DominationVictory
     }
 
     public static class GameOverReasonExtensions
@@ -38,6 +39,10 @@ namespace Sporefront.Models
                     return isVictory
                         ? "Your opponent has abandoned the game."
                         : "You have been disconnected from the game.";
+                case GameOverReason.DominationVictory:
+                    return isVictory
+                        ? "You have achieved domination!\nYour forces control the map."
+                        : "Your opponent has achieved domination.\nThey control the map.";
                 default:
                     return "";
             }

--- a/Sporefront/Assets/Scripts/Visual/GameSceneManager.cs
+++ b/Sporefront/Assets/Scripts/Visual/GameSceneManager.cs
@@ -278,8 +278,18 @@ namespace Sporefront.Visual
         // Phase 2: Start Game — populate world, start engine
         // ================================================================
 
+        private bool gameInitializing;
+
         private void StartNewGame(GameSetupConfig config)
         {
+            // Guard: prevent duplicate initialization during VS loading screen
+            if (gameInitializing || gameStarted)
+            {
+                Debug.LogWarning("[GameSceneManager] StartNewGame rejected — already initializing or started");
+                return;
+            }
+            gameInitializing = true;
+
             // 1. Create game state with configured dimensions
             var (width, height) = GetMapDimensions(config.mapSize);
             gameState = new GameState(width, height);
@@ -376,6 +386,16 @@ namespace Sporefront.Visual
                 gameState.mapData.resourcePointCoordinates[rp.id] = placement.coordinate;
             }
 
+            // 5c. Set game mode and generate domination zones if applicable
+            gameState.gameMode = config.gameMode;
+            if (config.gameMode.UsesControlZones())
+            {
+                var zones = generator.GenerateZonesForMode(config.gameMode, startCoords, terrain);
+                gameState.controlZones = zones;
+                foreach (var player in gameState.players.Values)
+                    gameState.dominationScores[player.id] = 0.0;
+            }
+
             // 6. Initialize engine
             gameState.visibilityMode = config.visibilityMode;
             GameEngine.Instance.Setup(gameState);
@@ -387,6 +407,10 @@ namespace Sporefront.Visual
             // 7. Build visual grid
             gridRenderer.BuildGrid(gameState.mapData);
 
+            // 7b. Apply domination zone overlays
+            if (config.gameMode.UsesControlZones())
+                gridRenderer.ApplyZoneOverlays(gameState);
+
             // 8. Set camera bounds and focus on player start
             cameraController.SetMapBounds(width, height);
             if (startPositions.Count > 0)
@@ -397,14 +421,38 @@ namespace Sporefront.Visual
             // 9. Subscribe to state changes
             GameEngine.Instance.OnStateChangesProduced += HandleStateChanges;
 
-            // 10. Transition UI from main menu to gameplay
-            uiManager.OnGameStarted(gameState);
+            // 10. Show VS loading screen, then transition to gameplay
+            string mapLabel = VSLoadingPanel.FormatMapLabel(
+                resolvedMapType.ToString(), config.mapSize.ToString());
+            string modeLabel = VSLoadingPanel.FormatGameMode(config.gameMode);
 
-            // 11. Game is now running
-            ResetOnlineFlags();
-            gameStarted = true;
-
-            Debug.Log($"[GameSceneManager] Game started — seed: {seed}, map: {width}x{height}, tiles: {terrain.Count}");
+            var canvas = GetComponentInChildren<Canvas>();
+            if (canvas != null)
+            {
+                VSLoadingPanel.Show(
+                    canvas.transform,
+                    "Player 1", config.playerFaction, "3A5E8B",
+                    "AI Opponent", config.aiFaction, "8B3A3A",
+                    mapLabel, modeLabel,
+                    () =>
+                    {
+                        // Called when VS screen finishes — activate gameplay
+                        uiManager.OnGameStarted(gameState);
+                        ResetOnlineFlags();
+                        gameInitializing = false;
+                        gameStarted = true;
+                        Debug.Log($"[GameSceneManager] Game started — seed: {seed}, map: {width}x{height}, tiles: {terrain.Count}");
+                    });
+            }
+            else
+            {
+                // Fallback: no canvas, start immediately
+                uiManager.OnGameStarted(gameState);
+                ResetOnlineFlags();
+                gameInitializing = false;
+                gameStarted = true;
+                Debug.Log($"[GameSceneManager] Game started (no VS screen) — seed: {seed}, map: {width}x{height}, tiles: {terrain.Count}");
+            }
         }
 
         private (int width, int height) GetMapDimensions(MapSize size)
@@ -508,6 +556,16 @@ namespace Sporefront.Visual
                 gameState.mapData.resourcePointCoordinates[rp.id] = placement.coordinate;
             }
 
+            // 4b. Set game mode and generate domination zones if applicable
+            gameState.gameMode = config.gameMode;
+            if (config.gameMode.UsesControlZones())
+            {
+                var zones = generator.GenerateZonesForMode(config.gameMode, startCoords, terrain);
+                gameState.controlZones = zones;
+                foreach (var player in gameState.players.Values)
+                    gameState.dominationScores[player.id] = 0.0;
+            }
+
             // 5. Create online session with both human players
             var sessionMapConfig = new Data.MapGenerationConfig("arabia", seed, width, height);
             var aiPlayersList = new List<(string displayName, Guid playerID, string colorHex, string faction)>();
@@ -565,6 +623,8 @@ namespace Sporefront.Visual
 
                 // 9. Build visual
                 gridRenderer.BuildGrid(gameState.mapData);
+                if (gameState.gameMode.UsesControlZones())
+                    gridRenderer.ApplyZoneOverlays(gameState);
                 cameraController.SetMapBounds(width, height);
                 if (startPositions.Count > 0)
                     cameraController.FocusOn(startPositions[0].coordinate, 8f, false);
@@ -681,6 +741,8 @@ namespace Sporefront.Visual
 
                 // Build visual
                 gridRenderer.BuildGrid(gameState.mapData);
+                if (gameState.gameMode.UsesControlZones())
+                    gridRenderer.ApplyZoneOverlays(gameState);
                 int width = gameState.mapData.width;
                 int height = gameState.mapData.height;
                 cameraController.SetMapBounds(width, height);
@@ -866,6 +928,16 @@ namespace Sporefront.Visual
                 gameState.mapData.resourcePointCoordinates[rp.id] = placement.coordinate;
             }
 
+            // 5c. Set game mode and generate domination zones if applicable
+            gameState.gameMode = config.gameMode;
+            if (config.gameMode.UsesControlZones())
+            {
+                var zones = generator.GenerateZonesForMode(config.gameMode, startCoords, terrain);
+                gameState.controlZones = zones;
+                foreach (var player in gameState.players.Values)
+                    gameState.dominationScores[player.id] = 0.0;
+            }
+
             // 6. Create online session
             var sessionMapConfig = new Data.MapGenerationConfig(
                 resolvedMapType.ToString().ToLower(), seed, width, height);
@@ -921,6 +993,8 @@ namespace Sporefront.Visual
 
                 // 10. Build visual grid
                 gridRenderer.BuildGrid(gameState.mapData);
+                if (gameState.gameMode.UsesControlZones())
+                    gridRenderer.ApplyZoneOverlays(gameState);
 
                 // 11. Set camera
                 cameraController.SetMapBounds(width, height);
@@ -1359,6 +1433,8 @@ namespace Sporefront.Visual
 
                 // Build visual grid
                 gridRenderer.BuildGrid(gameState.mapData);
+                if (gameState.gameMode.UsesControlZones())
+                    gridRenderer.ApplyZoneOverlays(gameState);
                 int width = gameState.mapData.width;
                 int height = gameState.mapData.height;
                 cameraController.SetMapBounds(width, height);
@@ -1635,6 +1711,8 @@ namespace Sporefront.Visual
 
             // Rebuild visual grid
             gridRenderer.BuildGrid(gameState.mapData);
+            if (gameState.gameMode.UsesControlZones())
+                gridRenderer.ApplyZoneOverlays(gameState);
 
             // Set camera bounds
             cameraController.SetMapBounds(gameState.mapData.width, gameState.mapData.height);

--- a/Sporefront/Assets/Scripts/Visual/GameSetupPanel.cs
+++ b/Sporefront/Assets/Scripts/Visual/GameSetupPanel.cs
@@ -12,6 +12,7 @@ using UnityEngine.EventSystems;
 using UnityEngine.UI;
 using Sporefront.Data;
 using Sporefront.Models;
+using GameMode = Sporefront.Models.GameMode;
 using TendrilBranch = Sporefront.Visual.UITendrilRenderer.TendrilBranch;
 
 namespace Sporefront.Visual
@@ -32,6 +33,7 @@ namespace Sporefront.Visual
         public FactionType aiFaction;
         public bool isOnlineMode;
         public int startingCCLevel;
+        public GameMode gameMode;
 
         // Matchmaking fields (empty for offline games)
         public string matchGameID;
@@ -51,7 +53,8 @@ namespace Sporefront.Visual
             visibilityMode = VisibilityMode.Normal,
             playerFaction = FactionType.Morel,
             aiFaction = FactionType.Muscaria,
-            startingCCLevel = 1
+            startingCCLevel = 1,
+            gameMode = GameMode.Conquest
         };
     }
 
@@ -126,6 +129,7 @@ namespace Sporefront.Visual
         private FactionType selectedFaction = FactionType.Morel;
         private FactionType selectedAIFaction = FactionType.Muscaria;
         private int selectedCCLevel = 1;
+        private GameMode selectedGameMode = GameMode.Conquest;
 
         // Arena config
         private ArenaScenarioConfig arenaScenario = ArenaScenarioConfig.Default;
@@ -620,6 +624,8 @@ namespace Sporefront.Visual
             rightColVLG.childControlWidth = true;
             rightColVLG.childControlHeight = false;
 
+            BuildGameModeSection(rightCol.transform);
+            UIHelper.CreateDivider(rightCol.transform, softDivider);
             BuildResourceDensitySection(rightCol.transform);
             UIHelper.CreateDivider(rightCol.transform, softDivider);
             BuildVisibilitySection(rightCol.transform);
@@ -1025,6 +1031,51 @@ namespace Sporefront.Visual
         }
 
         // ================================================================
+        // Game Mode
+        // ================================================================
+
+        private void BuildGameModeSection(Transform parent)
+        {
+            var sectionLabel = UIHelper.CreateLabel(parent, "Game Mode",
+                UIConstants.FontHeader, SporefrontColors.InkDark,
+                TextAnchor.MiddleLeft, true);
+            var sectionLE = sectionLabel.gameObject.AddComponent<LayoutElement>();
+            sectionLE.preferredHeight = 28;
+
+            var descLabel = UIHelper.CreateLabel(parent,
+                "Conquest: destroy all. Domination: 3 zones. Crooked: offset zones. Ring: concentric circles.",
+                UIConstants.FontBody, SporefrontColors.InkLight,
+                TextAnchor.UpperLeft, false);
+            descLabel.horizontalOverflow = HorizontalWrapMode.Wrap;
+            var descLE = descLabel.gameObject.AddComponent<LayoutElement>();
+            descLE.preferredHeight = 32;
+
+            var row = UIHelper.CreateHorizontalRow(parent, 40f, 4f);
+            var buttons = new List<Button>();
+
+            string[] names = { "Conquest", "Domination", "Crooked", "Ring" };
+            GameMode[] modes = { GameMode.Conquest, GameMode.Domination, GameMode.CrookedDomination, GameMode.Ring };
+            for (int i = 0; i < names.Length; i++)
+            {
+                int idx = i;
+                var btn = UIHelper.CreateButton(row.transform, names[i], null, null, UIConstants.FontSubheader, () =>
+                {
+                    selectedGameMode = modes[idx];
+                    UpdateSegmentSelection("gameMode", idx);
+                });
+                var btnLE = btn.gameObject.AddComponent<LayoutElement>();
+                btnLE.preferredWidth = 110;
+                btnLE.preferredHeight = 40;
+                buttons.Add(btn);
+            }
+
+            segmentGroups["gameMode"] = buttons;
+            segmentBorders["gameMode"] = AddSegmentBottomBorders(buttons);
+            segmentSelections["gameMode"] = (int)selectedGameMode;
+            UpdateSegmentColors("gameMode");
+        }
+
+        // ================================================================
         // Resource Density
         // ================================================================
 
@@ -1235,7 +1286,8 @@ namespace Sporefront.Visual
                     playerFaction = selectedFaction,
                     aiFaction = selectedAIFaction,
                     isOnlineMode = isOnlineMode,
-                    startingCCLevel = selectedCCLevel
+                    startingCCLevel = selectedCCLevel,
+                    gameMode = selectedGameMode
                 };
                 OnStartGame?.Invoke(config);
             });

--- a/Sporefront/Assets/Scripts/Visual/HexGridRenderer.cs
+++ b/Sporefront/Assets/Scripts/Visual/HexGridRenderer.cs
@@ -4,11 +4,13 @@
 //          Shared meshes + MaterialPropertyBlock for SRP Batcher efficiency
 // ============================================================================
 
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Rendering;
 using Sporefront.Data;
 using Sporefront.Models;
+using GameMode = Sporefront.Models.GameMode;
 
 namespace Sporefront.Visual
 {
@@ -147,6 +149,73 @@ namespace Sporefront.Visual
             HexTileView view;
             if (tileViews.TryGetValue(coord, out view))
                 view.SetVisibility(level);
+        }
+
+        // ================================================================
+        // Domination Zone Overlays
+        // ================================================================
+
+        // Base zone colors for Domination / Crooked (A, B, C)
+        private static readonly Color[] ZoneBaseColors =
+        {
+            new Color(0.9f, 0.3f, 0.3f, 0.25f),   // A — warm red
+            new Color(0.3f, 0.6f, 0.9f, 0.25f),   // B — cool blue
+            new Color(0.3f, 0.9f, 0.4f, 0.25f)    // C — green
+        };
+
+        // Ring zone colors: inner (gold/amber, high-value), outer (silver/gray)
+        private static readonly Color RingInnerColor = new Color(0.95f, 0.75f, 0.2f, 0.3f);
+        private static readonly Color RingOuterColor = new Color(0.7f, 0.7f, 0.75f, 0.2f);
+
+        public void ApplyZoneOverlays(GameState gameState)
+        {
+            // Clear all existing zone overlays
+            foreach (var view in tileViews.Values)
+                view.SetZoneOverlay(null);
+
+            if (!gameState.gameMode.UsesControlZones() || gameState.controlZones == null)
+                return;
+
+            bool isRing = gameState.gameMode == GameMode.Ring;
+
+            for (int i = 0; i < gameState.controlZones.Count; i++)
+            {
+                var zone = gameState.controlZones[i];
+
+                // Pick base color depending on mode
+                Color baseColor;
+                if (isRing)
+                    baseColor = zone.pointsMultiplier > 1.0 ? RingInnerColor : RingOuterColor;
+                else
+                    baseColor = i < ZoneBaseColors.Length ? ZoneBaseColors[i] : ZoneBaseColors[0];
+
+                // Use player color if controlled, base zone color if uncontrolled
+                Color overlayColor;
+                if (zone.controllingPlayerID.HasValue)
+                {
+                    var owner = gameState.GetPlayer(zone.controllingPlayerID.Value);
+                    if (owner != null)
+                    {
+                        var pColor = SporefrontColors.ParsePlayerColor(owner.colorHex);
+                        overlayColor = new Color(pColor.r, pColor.g, pColor.b, 0.25f);
+                    }
+                    else
+                    {
+                        overlayColor = baseColor;
+                    }
+                }
+                else
+                {
+                    overlayColor = baseColor;
+                }
+
+                foreach (var tile in zone.tiles)
+                {
+                    HexTileView view;
+                    if (tileViews.TryGetValue(tile, out view))
+                        view.SetZoneOverlay(overlayColor);
+                }
+            }
         }
 
         // ================================================================

--- a/Sporefront/Assets/Scripts/Visual/HexTileView.cs
+++ b/Sporefront/Assets/Scripts/Visual/HexTileView.cs
@@ -23,6 +23,7 @@ namespace Sporefront.Visual
         private bool _isSelected;
         private bool _isHovered;
         private VisibilityLevel _visibilityLevel = VisibilityLevel.Visible;
+        private Color? _zoneOverlay;
 
         private MeshRenderer fillRenderer;
         private MeshRenderer borderRenderer;
@@ -106,6 +107,13 @@ namespace Sporefront.Visual
 
         public VisibilityLevel CurrentVisibility => _visibilityLevel;
 
+        public void SetZoneOverlay(Color? color)
+        {
+            if (_zoneOverlay == color) return;
+            _zoneOverlay = color;
+            UpdateVisuals();
+        }
+
         // ================================================================
         // Visual Update
         // ================================================================
@@ -125,6 +133,10 @@ namespace Sporefront.Visual
                     break;
                 // Visible: full baseColor, no change
             }
+
+            // Zone overlay tint (domination control zones)
+            if (_zoneOverlay.HasValue)
+                color = Color.Lerp(color, _zoneOverlay.Value, _zoneOverlay.Value.a);
 
             // Selection visuals delegated to SelectionRenderer with glow effect (#15)
             // Only apply hover tinting here; suppress hover on non-visible tiles

--- a/Sporefront/Assets/Scripts/Visual/MiniMapPanel.cs
+++ b/Sporefront/Assets/Scripts/Visual/MiniMapPanel.cs
@@ -12,6 +12,7 @@ using UnityEngine.EventSystems;
 using UnityEngine.UI;
 using Sporefront.Data;
 using Sporefront.Models;
+using GameMode = Sporefront.Models.GameMode;
 
 namespace Sporefront.Visual
 {
@@ -428,8 +429,62 @@ namespace Sporefront.Visual
         // Entity Painting
         // ================================================================
 
+        // Zone colors (semi-transparent overlays for A, B, C)
+        private static readonly Color ZoneColorA = new Color(0.9f, 0.3f, 0.3f, 0.5f);
+        private static readonly Color ZoneColorB = new Color(0.3f, 0.6f, 0.9f, 0.5f);
+        private static readonly Color ZoneColorC = new Color(0.3f, 0.9f, 0.4f, 0.5f);
+        private static readonly Color ZoneColorNeutral = new Color(0.6f, 0.6f, 0.6f, 0.4f);
+
+        // Ring zone colors: inner (gold), outer (silver)
+        private static readonly Color RingInnerColor = new Color(0.95f, 0.75f, 0.2f, 0.55f);
+        private static readonly Color RingOuterColor = new Color(0.7f, 0.7f, 0.75f, 0.4f);
+
         private void PaintEntities(GameState gameState, PlayerState localPlayer, bool hasFog)
         {
+            // Paint domination zones (under entities)
+            if (gameState.gameMode.UsesControlZones() && gameState.controlZones != null)
+            {
+                bool isRing = gameState.gameMode == GameMode.Ring;
+                Color[] zoneBaseColors = { ZoneColorA, ZoneColorB, ZoneColorC };
+                for (int i = 0; i < gameState.controlZones.Count; i++)
+                {
+                    var zone = gameState.controlZones[i];
+
+                    // Pick base color depending on mode
+                    Color baseColor;
+                    if (isRing)
+                        baseColor = zone.pointsMultiplier > 1.0 ? RingInnerColor : RingOuterColor;
+                    else
+                        baseColor = i < zoneBaseColors.Length ? zoneBaseColors[i] : ZoneColorNeutral;
+
+                    Color zoneColor;
+                    if (zone.controllingPlayerID.HasValue)
+                    {
+                        var owner = gameState.GetPlayer(zone.controllingPlayerID.Value);
+                        if (owner != null)
+                        {
+                            var pColor = SporefrontColors.ParsePlayerColor(owner.colorHex);
+                            zoneColor = new Color(pColor.r, pColor.g, pColor.b, 0.55f);
+                        }
+                        else
+                            zoneColor = baseColor;
+                    }
+                    else
+                    {
+                        zoneColor = baseColor;
+                    }
+
+                    foreach (var tile in zone.tiles)
+                    {
+                        PaintDot(displayPixels, tile.q, tile.r, zoneColor, pixelsPerHex);
+                    }
+
+                    // Paint center brighter
+                    PaintDot(displayPixels, zone.center.q, zone.center.r,
+                        Color.Lerp(zoneColor, Color.white, 0.3f), pixelsPerHex + 1);
+                }
+            }
+
             // Paint buildings
             foreach (var kvp in gameState.mapData.buildingCoordinates)
             {

--- a/Sporefront/Assets/Scripts/Visual/ResourceBarPanel.cs
+++ b/Sporefront/Assets/Scripts/Visual/ResourceBarPanel.cs
@@ -13,6 +13,7 @@ using UnityEngine.InputSystem;
 using UnityEngine.UI;
 using Sporefront.Data;
 using Sporefront.Models;
+using GameMode = Sporefront.Models.GameMode;
 
 namespace Sporefront.Visual
 {
@@ -94,6 +95,11 @@ namespace Sporefront.Visual
         // ellipsisDropdown removed — button now opens InGameMenuPanel directly
         private Transform canvasRoot;
 
+        // Domination score
+        private GameObject dominationScoreContainer;
+        private Text dominationLocalScoreLabel;
+        private Text dominationOpponentScoreLabel;
+
         // Warning pulse animation
         private readonly List<Image> warningIcons = new List<Image>();
         private float warningTimer;
@@ -147,6 +153,9 @@ namespace Sporefront.Visual
 
             // Population
             CreatePopulationEntry(strip.transform);
+
+            // Domination score section (hidden until domination mode)
+            CreateDominationScoreSection(strip.transform);
 
             // Section divider before right-side controls
             CreateSectionDivider(strip.transform);
@@ -216,6 +225,9 @@ namespace Sporefront.Visual
             speedContainer.SetActive(showSpeed);
             if (showSpeed)
                 speedLabel.text = $"{gameState.gameSpeed:0.#}x";
+
+            // Domination score
+            UpdateDominationScores(gameState, localPlayerID);
         }
 
         // ================================================================
@@ -948,6 +960,106 @@ namespace Sporefront.Visual
             colors.pressedColor = new Color(HoverBg.r, HoverBg.g, HoverBg.b, 0.4f);
             colors.disabledColor = Color.clear;
             return colors;
+        }
+
+        // ================================================================
+        // Domination Score Section
+        // ================================================================
+
+        private void CreateDominationScoreSection(Transform parent)
+        {
+            // Container (hidden by default — only shown in domination mode)
+            dominationScoreContainer = new GameObject("DominationScore", typeof(RectTransform),
+                typeof(HorizontalLayoutGroup), typeof(LayoutElement));
+            dominationScoreContainer.transform.SetParent(parent, false);
+
+            var hlg = dominationScoreContainer.GetComponent<HorizontalLayoutGroup>();
+            hlg.padding = new RectOffset(8, 8, 5, 5);
+            hlg.spacing = 6;
+            hlg.childAlignment = TextAnchor.MiddleCenter;
+            hlg.childForceExpandWidth = false;
+            hlg.childForceExpandHeight = false;
+            hlg.childControlWidth = true;
+            hlg.childControlHeight = true;
+
+            // Divider before score
+            CreateSectionDivider(parent);
+
+            // Trophy icon
+            var trophyLabel = CreateThemedLabel(dominationScoreContainer.transform, "\u2605", 18,
+                SporefrontColors.SporeAmber, false);
+            var trophyLE = trophyLabel.gameObject.AddComponent<LayoutElement>();
+            trophyLE.preferredHeight = 20;
+
+            // Local player score
+            dominationLocalScoreLabel = CreateThemedLabel(dominationScoreContainer.transform, "0", 19,
+                SporefrontColors.SporeGreen, true);
+            var localLE = dominationLocalScoreLabel.gameObject.AddComponent<LayoutElement>();
+            localLE.preferredHeight = 22;
+
+            // Separator
+            var sepLabel = CreateThemedLabel(dominationScoreContainer.transform, "/", 16,
+                SporefrontColors.InkFaded, false);
+            var sepLE = sepLabel.gameObject.AddComponent<LayoutElement>();
+            sepLE.preferredHeight = 22;
+
+            // Target score
+            var targetLabel = CreateThemedLabel(dominationScoreContainer.transform,
+                ((int)Engine.GameConfig.Domination.ScoreToWin).ToString(), 16,
+                SporefrontColors.InkLight, false);
+            var targetLE = targetLabel.gameObject.AddComponent<LayoutElement>();
+            targetLE.preferredHeight = 22;
+
+            // Dash separator
+            var dashLabel = CreateThemedLabel(dominationScoreContainer.transform, " \u2014 ", 14,
+                SporefrontColors.InkFaded, false);
+            var dashLE = dashLabel.gameObject.AddComponent<LayoutElement>();
+            dashLE.preferredHeight = 22;
+
+            // Opponent score
+            dominationOpponentScoreLabel = CreateThemedLabel(dominationScoreContainer.transform, "0", 19,
+                SporefrontColors.SporeRed, true);
+            var oppLE = dominationOpponentScoreLabel.gameObject.AddComponent<LayoutElement>();
+            oppLE.preferredHeight = 22;
+
+            // Opponent target
+            var sepLabel2 = CreateThemedLabel(dominationScoreContainer.transform, "/", 16,
+                SporefrontColors.InkFaded, false);
+            var sepLE2 = sepLabel2.gameObject.AddComponent<LayoutElement>();
+            sepLE2.preferredHeight = 22;
+
+            var targetLabel2 = CreateThemedLabel(dominationScoreContainer.transform,
+                ((int)Engine.GameConfig.Domination.ScoreToWin).ToString(), 16,
+                SporefrontColors.InkLight, false);
+            var targetLE2 = targetLabel2.gameObject.AddComponent<LayoutElement>();
+            targetLE2.preferredHeight = 22;
+
+            dominationScoreContainer.SetActive(false);
+        }
+
+        private void UpdateDominationScores(GameState gameState, Guid localPlayerID)
+        {
+            if (dominationScoreContainer == null) return;
+
+            bool isDomination = gameState.gameMode.UsesControlZones();
+            dominationScoreContainer.SetActive(isDomination);
+            if (!isDomination) return;
+
+            double localScore;
+            gameState.dominationScores.TryGetValue(localPlayerID, out localScore);
+            dominationLocalScoreLabel.text = ((int)localScore).ToString();
+
+            // Find opponent score
+            double opponentScore = 0;
+            foreach (var kvp in gameState.dominationScores)
+            {
+                if (kvp.Key != localPlayerID)
+                {
+                    opponentScore = kvp.Value;
+                    break;
+                }
+            }
+            dominationOpponentScoreLabel.text = ((int)opponentScore).ToString();
         }
     }
 }

--- a/Sporefront/Assets/Scripts/Visual/UIManager.cs
+++ b/Sporefront/Assets/Scripts/Visual/UIManager.cs
@@ -1489,11 +1489,18 @@ namespace Sporefront.Visual
             if ((flags & StateChangeFlags.Entrenchment) != 0)
                 entrenchmentRenderer?.UpdateEntrenchment(gameState, localPlayerID);
 
+            // Domination zone overlays + score refresh
+            if ((flags & StateChangeFlags.Domination) != 0)
+            {
+                gridRenderer.ApplyZoneOverlays(gameState);
+                resourceBar.Refresh(gameState, localPlayerID);
+            }
+
             // Mini map — incremental refresh
             if (miniMap.IsVisible)
             {
                 bool hasEntityChange = (flags & (StateChangeFlags.Armies | StateChangeFlags.Buildings
-                    | StateChangeFlags.Villagers)) != 0;
+                    | StateChangeFlags.Villagers | StateChangeFlags.Domination)) != 0;
                 bool hasFogChange = (flags & StateChangeFlags.FogOfWar) != 0;
                 if (hasEntityChange || hasFogChange)
                     miniMap.RefreshIncremental(gameState, hasEntityChange, hasFogChange);

--- a/Sporefront/Assets/Scripts/Visual/VSLoadingPanel.cs
+++ b/Sporefront/Assets/Scripts/Visual/VSLoadingPanel.cs
@@ -1,0 +1,490 @@
+// ============================================================================
+// FILE: Visual/VSLoadingPanel.cs
+// PURPOSE: Full-screen "Player vs Opponent" loading splash shown before each
+//          game. Displays faction matchup, map info, and game mode with an
+//          animated tendril divider down the center.
+// ============================================================================
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+using Sporefront.Models;
+
+namespace Sporefront.Visual
+{
+    public class VSLoadingPanel : MonoBehaviour
+    {
+        // ================================================================
+        // Config
+        // ================================================================
+
+        private const float DisplayDuration = 5.0f;
+        private const float FadeOutDuration = 0.5f;
+        private const float TendrilGrowDuration = 2.5f;
+        private const float ContentFadeInDelay = 0.6f;
+        private const float ContentFadeInDuration = 0.8f;
+
+        // ================================================================
+        // State
+        // ================================================================
+
+        private UITendrilRenderer tendrilRenderer;
+        private CanvasGroup panelCanvasGroup;
+        private CanvasGroup contentGroup;
+        private RectTransform panelRT;
+        private Action onComplete;
+
+        private readonly List<BranchTiming> branchTimings = new List<BranchTiming>();
+        private float animationTime;
+        private bool animating;
+
+        private struct BranchTiming
+        {
+            public UITendrilRenderer.TendrilBranch branch;
+            public float startDelay;
+            public float duration;
+        }
+
+        // ================================================================
+        // Static Factory
+        // ================================================================
+
+        /// <summary>
+        /// Creates and shows the VS loading panel on the given canvas.
+        /// Calls onComplete when the display duration elapses and the panel fades out.
+        /// </summary>
+        public static VSLoadingPanel Show(
+            Transform canvasTransform,
+            string playerName,
+            FactionType playerFaction,
+            string playerColorHex,
+            string opponentName,
+            FactionType opponentFaction,
+            string opponentColorHex,
+            string mapLabel,
+            string gameModeLabel,
+            Action onComplete)
+        {
+            // Root panel — full screen, on top of everything
+            var go = new GameObject("VSLoadingPanel", typeof(RectTransform), typeof(CanvasRenderer));
+            var rt = (RectTransform)go.transform;
+            rt.SetParent(canvasTransform, false);
+            UIHelper.StretchFull(rt);
+            go.transform.SetAsLastSibling();
+
+            // Override sorting so it renders above all other UI
+            var overrideCanvas = go.AddComponent<Canvas>();
+            overrideCanvas.overrideSorting = true;
+            overrideCanvas.sortingOrder = 200;
+            go.AddComponent<GraphicRaycaster>();
+
+            // Background
+            var bgImage = go.AddComponent<Image>();
+            bgImage.color = SporefrontColors.BgDeep;
+
+            // Canvas group for fade-out
+            var cg = go.AddComponent<CanvasGroup>();
+            cg.alpha = 1f;
+
+            var panel = go.AddComponent<VSLoadingPanel>();
+            panel.panelRT = rt;
+            panel.panelCanvasGroup = cg;
+            panel.onComplete = onComplete;
+
+            panel.BuildLayout(
+                playerName, playerFaction, playerColorHex,
+                opponentName, opponentFaction, opponentColorHex,
+                mapLabel, gameModeLabel);
+
+            panel.StartCoroutine(panel.RunSequence());
+            return panel;
+        }
+
+        // ================================================================
+        // Layout
+        // ================================================================
+
+        private void BuildLayout(
+            string playerName, FactionType playerFaction, string playerColorHex,
+            string opponentName, FactionType opponentFaction, string opponentColorHex,
+            string mapLabel, string gameModeLabel)
+        {
+            // Content container (fades in with delay)
+            var contentGO = new GameObject("Content", typeof(RectTransform));
+            var contentRT = (RectTransform)contentGO.transform;
+            contentRT.SetParent(panelRT, false);
+            UIHelper.StretchFull(contentRT);
+            contentGroup = contentGO.AddComponent<CanvasGroup>();
+            contentGroup.alpha = 0f;
+
+            Color playerColor = SporefrontColors.ParsePlayerColor(playerColorHex);
+            Color opponentColor = SporefrontColors.ParsePlayerColor(opponentColorHex);
+
+            // ---- Left side: Player ----
+            BuildPlayerCard(contentRT, true, playerName, playerFaction, playerColor);
+
+            // ---- Right side: Opponent ----
+            BuildPlayerCard(contentRT, false, opponentName, opponentFaction, opponentColor);
+
+            // ---- Center: VS text ----
+            BuildVSBadge(contentRT);
+
+            // ---- Bottom strip: map + mode info ----
+            BuildInfoStrip(contentRT, mapLabel, gameModeLabel);
+
+            // ---- Center tendril divider (behind content, but on top of BG) ----
+            BuildTendrilDivider();
+        }
+
+        private void BuildPlayerCard(RectTransform parent, bool isLeft,
+            string playerName, FactionType faction, Color playerColor)
+        {
+            var cardGO = new GameObject(isLeft ? "LeftCard" : "RightCard", typeof(RectTransform));
+            var cardRT = (RectTransform)cardGO.transform;
+            cardRT.SetParent(parent, false);
+
+            // Position: left or right half, vertically centered
+            cardRT.anchorMin = isLeft ? new Vector2(0.02f, 0.25f) : new Vector2(0.52f, 0.25f);
+            cardRT.anchorMax = isLeft ? new Vector2(0.48f, 0.85f) : new Vector2(0.98f, 0.85f);
+            cardRT.offsetMin = Vector2.zero;
+            cardRT.offsetMax = Vector2.zero;
+
+            // Vertical layout
+            var vlg = cardGO.AddComponent<VerticalLayoutGroup>();
+            vlg.childAlignment = isLeft ? TextAnchor.MiddleRight : TextAnchor.MiddleLeft;
+            vlg.spacing = 12f;
+            vlg.childForceExpandWidth = true;
+            vlg.childForceExpandHeight = false;
+            vlg.childControlWidth = true;
+            vlg.childControlHeight = true;
+
+            // Color accent bar
+            var barGO = new GameObject("ColorBar", typeof(RectTransform), typeof(Image));
+            barGO.transform.SetParent(cardRT, false);
+            var barImg = barGO.GetComponent<Image>();
+            barImg.color = new Color(playerColor.r, playerColor.g, playerColor.b, 0.7f);
+            var barLE = barGO.AddComponent<LayoutElement>();
+            barLE.preferredHeight = 6f;
+
+            // Player name
+            var nameLabel = UIHelper.CreateLabel(cardRT, playerName,
+                UIConstants.FontTitle, SporefrontColors.ParchmentLight,
+                isLeft ? TextAnchor.MiddleRight : TextAnchor.MiddleLeft, true);
+            var nameLE = nameLabel.gameObject.AddComponent<LayoutElement>();
+            nameLE.preferredHeight = 44f;
+
+            // Faction name
+            var factionLabel = UIHelper.CreateLabel(cardRT, faction.DisplayName(),
+                UIConstants.FontHeader,
+                new Color(playerColor.r, playerColor.g, playerColor.b, 0.9f),
+                isLeft ? TextAnchor.MiddleRight : TextAnchor.MiddleLeft, true);
+            var factionLE = factionLabel.gameObject.AddComponent<LayoutElement>();
+            factionLE.preferredHeight = 36f;
+
+            // Faction description
+            var descLabel = UIHelper.CreateLabel(cardRT, faction.Description(),
+                UIConstants.FontSmall, SporefrontColors.ParchmentDeep,
+                isLeft ? TextAnchor.UpperRight : TextAnchor.UpperLeft, false);
+            descLabel.horizontalOverflow = HorizontalWrapMode.Wrap;
+            descLabel.verticalOverflow = VerticalWrapMode.Truncate;
+            var descLE = descLabel.gameObject.AddComponent<LayoutElement>();
+            descLE.preferredHeight = 80f;
+
+            // Faction bonuses
+            var bonusLabel = UIHelper.CreateLabel(cardRT, faction.StartingBonusDescription(),
+                UIConstants.FontCaption, SporefrontColors.ParchmentDark,
+                isLeft ? TextAnchor.UpperRight : TextAnchor.UpperLeft, false);
+            bonusLabel.horizontalOverflow = HorizontalWrapMode.Wrap;
+            bonusLabel.verticalOverflow = VerticalWrapMode.Truncate;
+            var bonusLE = bonusLabel.gameObject.AddComponent<LayoutElement>();
+            bonusLE.preferredHeight = 70f;
+        }
+
+        private void BuildVSBadge(RectTransform parent)
+        {
+            var vsGO = new GameObject("VSBadge", typeof(RectTransform));
+            var vsRT = (RectTransform)vsGO.transform;
+            vsRT.SetParent(parent, false);
+            vsRT.anchorMin = new Vector2(0.4f, 0.42f);
+            vsRT.anchorMax = new Vector2(0.6f, 0.62f);
+            vsRT.offsetMin = Vector2.zero;
+            vsRT.offsetMax = Vector2.zero;
+
+            // Dark circle behind VS text
+            var circleImg = vsGO.AddComponent<Image>();
+            circleImg.color = new Color(SporefrontColors.BgDeep.r, SporefrontColors.BgDeep.g,
+                SporefrontColors.BgDeep.b, 0.85f);
+
+            var vsLabel = UIHelper.CreateLabel(vsRT, "VS",
+                40, SporefrontColors.SporeRed,
+                TextAnchor.MiddleCenter, true);
+        }
+
+        private void BuildInfoStrip(RectTransform parent, string mapLabel, string gameModeLabel)
+        {
+            var stripGO = new GameObject("InfoStrip", typeof(RectTransform));
+            var stripRT = (RectTransform)stripGO.transform;
+            stripRT.SetParent(parent, false);
+            stripRT.anchorMin = new Vector2(0.1f, 0.08f);
+            stripRT.anchorMax = new Vector2(0.9f, 0.20f);
+            stripRT.offsetMin = Vector2.zero;
+            stripRT.offsetMax = Vector2.zero;
+
+            // Horizontal layout for info items
+            var hlg = stripGO.AddComponent<HorizontalLayoutGroup>();
+            hlg.childAlignment = TextAnchor.MiddleCenter;
+            hlg.spacing = 40f;
+            hlg.childForceExpandWidth = true;
+            hlg.childForceExpandHeight = true;
+
+            // Map info
+            var mapInfoLabel = UIHelper.CreateLabel(stripRT, mapLabel,
+                UIConstants.FontSubheader, SporefrontColors.ParchmentMid,
+                TextAnchor.MiddleCenter, false);
+
+            // Separator
+            var sepGO = new GameObject("Sep", typeof(RectTransform), typeof(Image));
+            sepGO.transform.SetParent(stripRT, false);
+            var sepImg = sepGO.GetComponent<Image>();
+            sepImg.color = SporefrontColors.InkFaded;
+            var sepLE = sepGO.AddComponent<LayoutElement>();
+            sepLE.preferredWidth = 2f;
+            sepLE.preferredHeight = 24f;
+
+            // Game mode
+            var modeLabel = UIHelper.CreateLabel(stripRT, gameModeLabel,
+                UIConstants.FontSubheader, SporefrontColors.ParchmentMid,
+                TextAnchor.MiddleCenter, false);
+        }
+
+        // ================================================================
+        // Tendril Divider — animated vertical growth down the center
+        // ================================================================
+
+        private void BuildTendrilDivider()
+        {
+            var tendrilGO = new GameObject("VSTendrils", typeof(RectTransform), typeof(CanvasRenderer));
+            var tendrilRT = (RectTransform)tendrilGO.transform;
+            tendrilRT.SetParent(panelRT, false);
+            UIHelper.StretchFull(tendrilRT);
+            tendrilRT.SetSiblingIndex(1); // Behind content, above BG
+
+            var layout = tendrilGO.AddComponent<LayoutElement>();
+            layout.ignoreLayout = true;
+
+            tendrilRenderer = tendrilGO.AddComponent<UITendrilRenderer>();
+            tendrilRenderer.raycastTarget = false;
+
+            var rect = panelRT.rect;
+            float w = rect.width > 0 ? rect.width : Screen.width;
+            float h = rect.height > 0 ? rect.height : Screen.height;
+
+            float centerX = w * 0.5f;
+
+            // Main trunk — vertical line from top to bottom
+            var trunkPoints = new List<Vector2>();
+            int segments = 10;
+            for (int i = 0; i <= segments; i++)
+            {
+                float t = (float)i / segments;
+                float y = h * (1f - t); // top to bottom
+                float wobble = Mathf.Sin(t * Mathf.PI * 2.5f) * 12f;
+                trunkPoints.Add(new Vector2(centerX + wobble, y));
+            }
+
+            var trunkStrandsRed = new List<UITendrilRenderer.StrandParams>
+            {
+                new UITendrilRenderer.StrandParams { width = 3.5f, alpha = 0.85f, waveFrequency = 1.2f, wavePhase = 0f },
+                new UITendrilRenderer.StrandParams { width = 2.0f, alpha = 0.65f, waveFrequency = 2.0f, wavePhase = 1.5f }
+            };
+            var trunkBranchRed = tendrilRenderer.AddBranch(trunkPoints, trunkStrandsRed, 8f, 0.1f);
+            trunkBranchRed.branchColor = SporefrontColors.InkRed;
+            trunkBranchRed.glowAlpha = 0.15f;
+            trunkBranchRed.growthProgress = 0f;
+            branchTimings.Add(new BranchTiming { branch = trunkBranchRed, startDelay = 0f, duration = TendrilGrowDuration });
+
+            var trunkStrandsGreen = new List<UITendrilRenderer.StrandParams>
+            {
+                new UITendrilRenderer.StrandParams { width = 3.0f, alpha = 0.80f, waveFrequency = 1.5f, wavePhase = 0.8f },
+                new UITendrilRenderer.StrandParams { width = 1.8f, alpha = 0.60f, waveFrequency = 2.5f, wavePhase = 2.2f }
+            };
+            var trunkBranchGreen = tendrilRenderer.AddBranch(trunkPoints, trunkStrandsGreen, 8f, 0.1f);
+            trunkBranchGreen.branchColor = SporefrontColors.InkGreen;
+            trunkBranchGreen.glowAlpha = 0.12f;
+            trunkBranchGreen.growthProgress = 0f;
+            branchTimings.Add(new BranchTiming { branch = trunkBranchGreen, startDelay = 0.15f, duration = TendrilGrowDuration });
+
+            // Side branches — grow outward from trunk at intervals
+            float[] branchFractions = { 0.15f, 0.30f, 0.45f, 0.60f, 0.75f, 0.90f };
+            for (int i = 0; i < branchFractions.Length; i++)
+            {
+                float frac = branchFractions[i];
+                float branchY = h * (1f - frac);
+                float baseX = centerX + Mathf.Sin(frac * Mathf.PI * 2.5f) * 12f;
+                bool goLeft = (i % 2 == 0);
+                float sign = goLeft ? -1f : 1f;
+
+                // Main limb
+                var limbPoints = new List<Vector2>();
+                int limbSegs = 6;
+                for (int j = 0; j <= limbSegs; j++)
+                {
+                    float lt = (float)j / limbSegs;
+                    float lx = baseX + sign * lt * w * 0.22f;
+                    float ly = branchY + Mathf.Sin(lt * Mathf.PI) * 25f * (goLeft ? 1f : -1f);
+                    limbPoints.Add(new Vector2(lx, ly));
+                }
+
+                var limbStrands = new List<UITendrilRenderer.StrandParams>
+                {
+                    new UITendrilRenderer.StrandParams { width = 2.2f, alpha = 0.7f, waveFrequency = 1.8f, wavePhase = i * 0.7f }
+                };
+                Color limbColor = (i % 2 == 0) ? SporefrontColors.InkRed : SporefrontColors.InkGreen;
+                var limb = tendrilRenderer.AddBranch(limbPoints, limbStrands, 6f, 0.2f);
+                limb.branchColor = limbColor;
+                limb.glowAlpha = 0.08f;
+                limb.growthProgress = 0f;
+
+                float limbDelay = frac * TendrilGrowDuration * 0.8f;
+                branchTimings.Add(new BranchTiming { branch = limb, startDelay = limbDelay, duration = 1.2f });
+
+                // Sub-tendrils off each limb
+                for (int s = 0; s < 3; s++)
+                {
+                    float st = 0.3f + s * 0.25f;
+                    int ptIdx = Mathf.Clamp(Mathf.RoundToInt(st * limbSegs), 0, limbSegs);
+                    Vector2 origin = limbPoints[ptIdx];
+                    float subSign = (s % 2 == 0) ? 1f : -1f;
+
+                    var subPoints = new List<Vector2>();
+                    int subSegs = 4;
+                    for (int k = 0; k <= subSegs; k++)
+                    {
+                        float kt = (float)k / subSegs;
+                        float sx = origin.x + sign * kt * w * 0.06f;
+                        float sy = origin.y + subSign * kt * 30f;
+                        subPoints.Add(new Vector2(sx, sy));
+                    }
+
+                    var subStrands = new List<UITendrilRenderer.StrandParams>
+                    {
+                        new UITendrilRenderer.StrandParams { width = 1.4f, alpha = 0.5f, waveFrequency = 2.5f, wavePhase = s * 1.2f }
+                    };
+                    var sub = tendrilRenderer.AddBranch(subPoints, subStrands, 4f, 0.25f);
+                    sub.branchColor = limbColor;
+                    sub.growthProgress = 0f;
+
+                    branchTimings.Add(new BranchTiming
+                    {
+                        branch = sub,
+                        startDelay = limbDelay + 0.5f + s * 0.2f,
+                        duration = 0.8f
+                    });
+                }
+            }
+
+            tendrilRenderer.MarkDirty();
+            animating = true;
+        }
+
+        // ================================================================
+        // Animation
+        // ================================================================
+
+        private void Update()
+        {
+            if (!animating) return;
+
+            animationTime += Time.unscaledDeltaTime;
+            bool allDone = true;
+
+            for (int i = 0; i < branchTimings.Count; i++)
+            {
+                var bt = branchTimings[i];
+                float elapsed = animationTime - bt.startDelay;
+                if (elapsed < 0f)
+                {
+                    bt.branch.growthProgress = 0f;
+                    allDone = false;
+                }
+                else if (elapsed < bt.duration)
+                {
+                    float t = elapsed / bt.duration;
+                    bt.branch.growthProgress = 1f - (1f - t) * (1f - t); // ease-out
+                    allDone = false;
+                }
+                else
+                {
+                    bt.branch.growthProgress = 1f;
+                }
+
+                // Idle pulse
+                bt.branch.idlePulsePhase = animationTime * 0.5f;
+            }
+
+            if (tendrilRenderer != null)
+                tendrilRenderer.MarkDirty();
+
+            if (allDone)
+                animating = false;
+        }
+
+        private IEnumerator RunSequence()
+        {
+            // Fade in content after tendrils start growing
+            float fadeInElapsed = 0f;
+            while (fadeInElapsed < ContentFadeInDelay + ContentFadeInDuration)
+            {
+                fadeInElapsed += Time.unscaledDeltaTime;
+                if (fadeInElapsed > ContentFadeInDelay)
+                {
+                    float t = (fadeInElapsed - ContentFadeInDelay) / ContentFadeInDuration;
+                    contentGroup.alpha = Mathf.Clamp01(t);
+                }
+                yield return null;
+            }
+            contentGroup.alpha = 1f;
+
+            // Wait remaining display time
+            float remaining = DisplayDuration - ContentFadeInDelay - ContentFadeInDuration;
+            if (remaining > 0f)
+                yield return new WaitForSecondsRealtime(remaining);
+
+            // Fade out entire panel
+            float fadeOut = 0f;
+            while (fadeOut < FadeOutDuration)
+            {
+                fadeOut += Time.unscaledDeltaTime;
+                panelCanvasGroup.alpha = 1f - Mathf.Clamp01(fadeOut / FadeOutDuration);
+                yield return null;
+            }
+            panelCanvasGroup.alpha = 0f;
+
+            onComplete?.Invoke();
+            Destroy(gameObject);
+        }
+
+        // ================================================================
+        // Helper — format game mode display name
+        // ================================================================
+
+        public static string FormatGameMode(GameMode mode)
+        {
+            switch (mode)
+            {
+                case GameMode.Conquest: return "Conquest";
+                case GameMode.Domination: return "Domination";
+                case GameMode.CrookedDomination: return "Crooked Domination";
+                case GameMode.Ring: return "Ring";
+                default: return mode.ToString();
+            }
+        }
+
+        public static string FormatMapLabel(string mapType, string mapSize)
+        {
+            return mapType + "  \u2022  " + mapSize;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- **4 game modes**: Conquest (existing behavior), Domination (3 equidistant control zones), Crooked Domination (zones offset toward each player), and Ring (concentric circles at map center with 2x inner multiplier)
- **DominationEngine**: New subsystem tracking zone control by troop presence, awarding points via per-zone `pointsMultiplier`, and triggering victory at 300 points
- **VS loading screen**: Full-screen "Boxer A vs Boxer B" splash with animated dual-color tendril divider (InkRed + InkGreen), faction matchup details, map/mode info — shown for 5 seconds before gameplay begins
- **`UsesControlZones()` extension**: Replaces 18 hardcoded `== GameMode.Domination` checks with a single extensible helper method
- **Zone visuals**: Hex grid overlays and minimap painting with mode-aware colors (gold/silver for Ring inner/outer, red/blue/green for Domination zones)

## Files changed (17 files, 4 new)
| Category | Files |
|----------|-------|
| New models | `GameMode.cs`, `ControlZoneData.cs` |
| New engine | `DominationEngine.cs` |
| New visual | `VSLoadingPanel.cs` |
| Engine | `GameConfig.cs`, `GameEngine.cs`, `MapGenerator.cs` |
| Data | `GameState.cs`, `StateChange.cs`, `GameOverReason.cs` |
| Visual | `GameSceneManager.cs`, `GameSetupPanel.cs`, `HexGridRenderer.cs`, `HexTileView.cs`, `MiniMapPanel.cs`, `ResourceBarPanel.cs`, `UIManager.cs` |

## Test plan
- [ ] Start Conquest game — verify existing behavior unchanged (CC destroyed ends game)
- [ ] Start Domination game — verify 3 zones appear on map and minimap, score HUD shows, controlling zones awards points, first to 300 wins
- [ ] Start Crooked Domination — verify zone A is closer to player 1, zone C closer to player 2, zone B centered
- [ ] Start Ring game — verify 2 concentric zones at map center, inner ring is gold, outer is silver, inner gives 2x points
- [ ] Verify VS loading screen appears for ~5 seconds with correct faction names, map type, and game mode before gameplay
- [ ] Verify tendril divider animates down center of VS screen
- [ ] Save and load a Domination game — verify zones and scores persist
- [ ] Verify game setup panel shows all 4 mode buttons and selection works

🤖 Generated with [Claude Code](https://claude.com/claude-code)