### PR TITLE
Refactor: data-driven enums, shared helpers, and code cleanup

### DIFF
--- a/Sporefront/Assets/Scripts/AI/AIController.cs
+++ b/Sporefront/Assets/Scripts/AI/AIController.cs
@@ -72,8 +72,7 @@ namespace Sporefront.AI
             if (evolvedGenome != null)
             {
                 genome = evolvedGenome;
-                DebugLog.Log(string.Format("AI Controller loaded evolved genome (gen {0}, fitness {1:F2})",
-                    evolvedGenome.generation, evolvedGenome.fitness));
+                DebugLog.Log($"AI Controller loaded evolved genome (gen {evolvedGenome.generation}, fitness {evolvedGenome.fitness:F2})");
             }
             else
             {
@@ -83,8 +82,7 @@ namespace Sporefront.AI
             DebugLog.Log("AI Controller setup - checking all players:");
             foreach (var player in gameState.players.Values)
             {
-                DebugLog.Log(string.Format("   Player: {0} (ID: {1}) - isAI: {2}",
-                    player.name, player.id, player.isAI));
+                DebugLog.Log($"   Player: {player.name} (ID: {player.id}) - isAI: {player.isAI}");
             }
 
             foreach (var player in gameState.GetAIPlayers())
@@ -94,22 +92,20 @@ namespace Sporefront.AI
                 var cityCenter = gameState.GetCityCenter(player.id);
                 if (cityCenter != null)
                 {
-                    DebugLog.Log(string.Format("AI Controller initialized for player: {0}", player.name));
-                    DebugLog.Log(string.Format("   City center at: ({0}, {1})", cityCenter.coordinate.q, cityCenter.coordinate.r));
+                    DebugLog.Log($"AI Controller initialized for player: {player.name}");
+                    DebugLog.Log($"   City center at: ({cityCenter.coordinate.q}, {cityCenter.coordinate.r})");
                 }
                 else
                 {
-                    DebugLog.Log(string.Format("WARNING: AI player {0} has NO city center!", player.name));
+                    DebugLog.Log($"WARNING: AI player {player.name} has NO city center!");
                     var allBuildings = gameState.GetBuildingsForPlayer(player.id);
-                    DebugLog.Log(string.Format("   Buildings owned: {0}", allBuildings.Count));
+                    DebugLog.Log($"   Buildings owned: {allBuildings.Count}");
                 }
 
-                DebugLog.Log(string.Format("   Resources: food={0}, wood={1}, stone={2}, ore={3}",
-                    player.GetResource(ResourceType.Food), player.GetResource(ResourceType.Wood),
-                    player.GetResource(ResourceType.Stone), player.GetResource(ResourceType.Ore)));
+                DebugLog.Log($"   Resources: food={player.GetResource(ResourceType.Food)}, wood={player.GetResource(ResourceType.Wood)}, stone={player.GetResource(ResourceType.Stone)}, ore={player.GetResource(ResourceType.Ore)}");
             }
 
-            DebugLog.Log(string.Format("Total AI players registered: {0}", aiPlayers.Count));
+            DebugLog.Log($"Total AI players registered: {aiPlayers.Count}");
         }
 
         public void Reset()
@@ -134,73 +130,7 @@ namespace Sporefront.AI
 
         public void ProcessHuntArrivals(GameState state)
         {
-            // Collect groups to process (avoid modifying collection during iteration)
-            var groups = state.villagerGroups.Values.ToList();
-
-            foreach (var group in groups)
-            {
-                var huntTask = group.currentTask as HuntingTask;
-                if (huntTask == null) continue;
-                if (group.currentPath != null) continue; // Still en route
-
-                var resourcePointID = huntTask.ResourcePointID;
-                var resource = state.GetResourcePoint(resourcePointID);
-                if (resource == null)
-                {
-                    group.ClearTask();
-                    continue;
-                }
-
-                if (!group.coordinate.Equals(resource.coordinate)) continue;
-
-                // At target — execute hunt combat
-                double villagerAttack = group.villagerCount * 25.0;
-                double damageToAnimal = Math.Max(1.0, villagerAttack - resource.resourceType.DefensePower());
-                resource.TakeDamage(damageToAnimal);
-
-                double animalAttack = resource.resourceType.AttackPower();
-                double damageToVillagers = Math.Max(0.0, animalAttack - group.villagerCount * 0.5);
-                int villagersLost = (int)(damageToVillagers / 5.0);
-                if (villagersLost > 0) group.RemoveVillagers(villagersLost);
-
-                if (resource.currentHealth <= 0)
-                {
-                    // Animal killed — create carcass and start gathering
-                    var carcass = resource.CreateCarcassData();
-                    if (carcass != null)
-                    {
-                        state.RemoveResourcePoint(resource.id);
-                        state.AddResourcePoint(carcass);
-
-                        bool registered = GameEngine.Instance.resourceEngine.StartGathering(
-                            group.id, carcass.id);
-                        if (registered)
-                        {
-                            GameEngine.Instance.resourceEngine.UpdateCollectionRates(
-                                group.ownerID ?? Guid.Empty);
-                        }
-                        else
-                        {
-                            group.ClearTask();
-                        }
-                    }
-                    else
-                    {
-                        group.ClearTask();
-                    }
-                }
-                else
-                {
-                    // Animal survived — clear task, AI will retry next cycle
-                    group.ClearTask();
-                }
-
-                if (group.villagerCount <= 0)
-                {
-                    GameEngine.Instance.resourceEngine.StopGathering(group.id);
-                    state.RemoveVillagerGroup(group.id);
-                }
-            }
+            AIHelper.ProcessHuntArrivals(state, GameEngine.Instance.resourceEngine);
         }
 
         // ================================================================
@@ -230,9 +160,7 @@ namespace Sporefront.AI
                 var cityCenter = gameState.GetCityCenter(playerID);
                 int villagerCount = gameState.GetVillagerCount(playerID);
                 int buildingCount = gameState.GetBuildingsForPlayer(playerID).Count;
-                DebugLog.Log(string.Format("AI Decision cycle: state={0}, cityCenter={1}, buildings={2}, villagers={3}, food={4}",
-                    aiState.currentState, cityCenter != null, buildingCount, villagerCount,
-                    player.GetResource(ResourceType.Food)));
+                DebugLog.Log($"AI Decision cycle: state={aiState.currentState}, cityCenter={cityCenter != null}, buildings={buildingCount}, villagers={villagerCount}, food={player.GetResource(ResourceType.Food)}");
 
                 // One-time strategic map analysis (chokepoints + map strategy)
                 if (!aiState.mapAnalyzed)
@@ -249,20 +177,16 @@ namespace Sporefront.AI
                         if (dipStatus == DiplomacyStatus.Enemy)
                         {
                             aiState.factionStrategy = AIStrategicAnalysis.GetFactionCounterStrategy(otherPlayer.faction);
-                            DebugLog.Log(string.Format("AI {0}: Faction counter-strategy — {1}",
-                                player.name, aiState.factionStrategy.Value.description));
+                            DebugLog.Log($"AI {player.name}: Faction counter-strategy — {aiState.factionStrategy.Value.description}");
                             break;
                         }
                     }
 
                     aiState.mapAnalyzed = true;
-                    DebugLog.Log(string.Format("AI {0}: Map analysis complete — strategy={1}, chokepoints={2}",
-                        player.name, AIStrategicAnalysis.DescribeStrategy(aiState.mapStrategy),
-                        aiState.cachedChokepoints.Count));
+                    DebugLog.Log($"AI {player.name}: Map analysis complete — strategy={AIStrategicAnalysis.DescribeStrategy(aiState.mapStrategy)}, chokepoints={aiState.cachedChokepoints.Count}");
                     foreach (var cp in aiState.cachedChokepoints)
                     {
-                        DebugLog.Log(string.Format("   Chokepoint at ({0},{1}), width={2}",
-                            cp.center.q, cp.center.r, cp.width));
+                        DebugLog.Log($"   Chokepoint at ({cp.center.q},{cp.center.r}), width={cp.width}");
                     }
                 }
 
@@ -284,23 +208,21 @@ namespace Sporefront.AI
                 militaryPlanner.UpdateEnemyAnalysis(aiState, gameState, currentTime);
 
                 // Feature 2: Analyze enemy strategy (greed detection) every 15 seconds
-                if (currentTime - aiState.lastEnemyStrategyTime >= 15.0)
+                if (AIHelper.ShouldExecute(ref aiState.lastEnemyStrategyTime, currentTime, 15.0))
                 {
                     var prevStrategy = aiState.enemyStrategy;
                     aiState.enemyStrategy = AIStrategicAnalysis.AnalyzeEnemyStrategy(gameState, playerID);
-                    aiState.lastEnemyStrategyTime = currentTime;
                     if (aiState.enemyStrategy != prevStrategy && aiState.enemyStrategy != EnemyStrategyRead.Unknown)
-                        DebugLog.Log(string.Format("AI {0}: Enemy strategy detected — {1}", player.name, aiState.enemyStrategy));
+                        DebugLog.Log($"AI {player.name}: Enemy strategy detected — {aiState.enemyStrategy}");
                 }
 
                 // Feature 4: Assess game position (comeback mechanics) every 15 seconds
-                if (currentTime - aiState.lastPositionAssessTime >= 15.0)
+                if (AIHelper.ShouldExecute(ref aiState.lastPositionAssessTime, currentTime, 15.0))
                 {
                     var prevPosition = aiState.gamePosition;
                     aiState.gamePosition = AIStrategicAnalysis.AssessGamePosition(gameState, playerID);
-                    aiState.lastPositionAssessTime = currentTime;
                     if (aiState.gamePosition != prevPosition)
-                        DebugLog.Log(string.Format("AI {0}: Game position — {1}", player.name, aiState.gamePosition));
+                        DebugLog.Log($"AI {player.name}: Game position — {aiState.gamePosition}");
                 }
 
                 // Round 4: Update exploration percentage
@@ -333,8 +255,7 @@ namespace Sporefront.AI
                 // Generate commands based on current state
                 var commands = GenerateCommands(aiState, gameState, currentTime);
 
-                DebugLog.Log(string.Format("AI {0}: Generated {1} commands in state {2}",
-                    player.name, commands.Count, aiState.currentState));
+                DebugLog.Log($"AI {player.name}: Generated {commands.Count} commands in state {aiState.currentState}");
 
                 allCommands.AddRange(commands);
 
@@ -400,7 +321,7 @@ namespace Sporefront.AI
                 aiState.attackStateEnteredTime = currentTime;
                 aiState.lastAttackProgressTime = currentTime;
                 aiState.lastKnownEnemyStrength = gameState.AnalyzeEnemyComposition(playerID)?.weightedStrength ?? 0;
-                DebugLog.Log(string.Format("AI {0}: -> Attack (PUNISHING GREEDY PLAY — enemy has no military)", playerID));
+                DebugLog.Log($"AI {playerID}: -> Attack (PUNISHING GREEDY PLAY — enemy has no military)");
             }
 
             // Feature 4: CriticallyBehind — force defensive posture
@@ -409,7 +330,7 @@ namespace Sporefront.AI
             {
                 aiState.currentState = AIState.Retreat;
                 aiState.persistentAttackTargetID = null;
-                DebugLog.Log(string.Format("AI {0}: Attack -> Retreat (critically behind — conserving forces)", playerID));
+                DebugLog.Log($"AI {playerID}: Attack -> Retreat (critically behind — conserving forces)");
             }
 
             switch (aiState.currentState)
@@ -418,12 +339,12 @@ namespace Sporefront.AI
                     if (nearbyEnemies.Count > 0)
                     {
                         aiState.currentState = AIState.Defense;
-                        DebugLog.Log(string.Format("AI {0}: Peace -> Defense (enemies nearby)", playerID));
+                        DebugLog.Log($"AI {playerID}: Peace -> Defense (enemies nearby)");
                     }
                     else if (threatLevel > aiState.difficulty.AlertThreshold())
                     {
                         aiState.currentState = AIState.Alert;
-                        DebugLog.Log(string.Format("AI {0}: Peace -> Alert (threat detected)", playerID));
+                        DebugLog.Log($"AI {playerID}: Peace -> Alert (threat detected)");
                     }
                     else if (ShouldAttack(aiState, gameState, ourStrength))
                     {
@@ -431,7 +352,7 @@ namespace Sporefront.AI
                         aiState.attackStateEnteredTime = currentTime;
                         aiState.lastAttackProgressTime = currentTime;
                         aiState.lastKnownEnemyStrength = gameState.AnalyzeEnemyComposition(playerID)?.weightedStrength ?? 0;
-                        DebugLog.Log(string.Format("AI {0}: Peace -> Attack (strong enough)", playerID));
+                        DebugLog.Log($"AI {playerID}: Peace -> Attack (strong enough)");
                     }
                     break;
 
@@ -439,12 +360,12 @@ namespace Sporefront.AI
                     if (nearbyEnemies.Count > 0)
                     {
                         aiState.currentState = AIState.Defense;
-                        DebugLog.Log(string.Format("AI {0}: Alert -> Defense (enemies nearby)", playerID));
+                        DebugLog.Log($"AI {playerID}: Alert -> Defense (enemies nearby)");
                     }
                     else if (threatLevel < aiState.difficulty.AlertThreshold() * 0.5)
                     {
                         aiState.currentState = AIState.Peace;
-                        DebugLog.Log(string.Format("AI {0}: Alert -> Peace (threat reduced)", playerID));
+                        DebugLog.Log($"AI {playerID}: Alert -> Peace (threat reduced)");
                     }
                     else if (ShouldAttack(aiState, gameState, ourStrength))
                     {
@@ -452,7 +373,7 @@ namespace Sporefront.AI
                         aiState.attackStateEnteredTime = currentTime;
                         aiState.lastAttackProgressTime = currentTime;
                         aiState.lastKnownEnemyStrength = gameState.AnalyzeEnemyComposition(playerID)?.weightedStrength ?? 0;
-                        DebugLog.Log(string.Format("AI {0}: Alert -> Attack (strong enough)", playerID));
+                        DebugLog.Log($"AI {playerID}: Alert -> Attack (strong enough)");
                     }
                     break;
 
@@ -467,12 +388,12 @@ namespace Sporefront.AI
                             aiState.attackStateEnteredTime = currentTime;
                             aiState.lastAttackProgressTime = currentTime;
                             aiState.lastKnownEnemyStrength = gameState.AnalyzeEnemyComposition(playerID)?.weightedStrength ?? 0;
-                            DebugLog.Log(string.Format("AI {0}: Defense -> Attack (counter-attack)", playerID));
+                            DebugLog.Log($"AI {playerID}: Defense -> Attack (counter-attack)");
                         }
                         else
                         {
                             aiState.currentState = AIState.Alert;
-                            DebugLog.Log(string.Format("AI {0}: Defense -> Alert (enemies gone)", playerID));
+                            DebugLog.Log($"AI {playerID}: Defense -> Alert (enemies gone)");
                         }
                     }
                     else if (ourWeightedStrength < 500 || armyNeedsRetreat)
@@ -488,7 +409,7 @@ namespace Sporefront.AI
                                 defeatCoord, nearbyEnemies[0].ownerID ?? Guid.Empty,
                                 enemyStrength, currentTime, true);
                         }
-                        DebugLog.Log(string.Format("AI {0}: Defense -> Retreat (too weak or outnumbered)", playerID));
+                        DebugLog.Log($"AI {playerID}: Defense -> Retreat (too weak or outnumbered)");
                     }
                     break;
 
@@ -506,20 +427,20 @@ namespace Sporefront.AI
                     {
                         aiState.currentState = AIState.Retreat;
                         aiState.persistentAttackTargetID = null;
-                        DebugLog.Log(string.Format("AI {0}: Attack -> Retreat (attack timeout, no progress)", playerID));
+                        DebugLog.Log($"AI {playerID}: Attack -> Retreat (attack timeout, no progress)");
                         break;
                     }
 
                     if (nearbyEnemies.Count > 0)
                     {
                         aiState.currentState = AIState.Defense;
-                        DebugLog.Log(string.Format("AI {0}: Attack -> Defense (base under attack)", playerID));
+                        DebugLog.Log($"AI {playerID}: Attack -> Defense (base under attack)");
                     }
                     else if (ourWeightedStrength < 1000)
                     {
                         aiState.currentState = AIState.Peace;
                         aiState.persistentAttackTargetID = null;
-                        DebugLog.Log(string.Format("AI {0}: Attack -> Peace (army depleted)", playerID));
+                        DebugLog.Log($"AI {playerID}: Attack -> Peace (army depleted)");
                     }
                     else if (armyNeedsRetreat)
                     {
@@ -530,7 +451,7 @@ namespace Sporefront.AI
                             aiState.threatMemory[aiState.lastAttackTarget.Value] = new ThreatMemoryEntry(
                                 aiState.lastAttackTarget.Value, Guid.Empty, 0, currentTime, true);
                         }
-                        DebugLog.Log(string.Format("AI {0}: Attack -> Retreat (army in danger)", playerID));
+                        DebugLog.Log($"AI {playerID}: Attack -> Retreat (army in danger)");
                     }
                     break;
 
@@ -539,7 +460,7 @@ namespace Sporefront.AI
                     {
                         aiState.currentState = AIState.Alert;
                         aiState.pendingArmyConvergence = null;
-                        DebugLog.Log(string.Format("AI {0}: Retreat -> Alert (regrouped)", playerID));
+                        DebugLog.Log($"AI {playerID}: Retreat -> Alert (regrouped)");
                     }
                     break;
             }
@@ -568,8 +489,7 @@ namespace Sporefront.AI
             var opportunity = militaryPlanner.FindOpportunityWindow(aiState, gameState, gameState.currentTime);
             if (opportunity.HasValue && ourWeightedStrength >= 1500)
             {
-                DebugLog.Log(string.Format("AI {0}: Opportunity window detected at ({1},{2}) — enemy moved away",
-                    playerID, opportunity.Value.q, opportunity.Value.r));
+                DebugLog.Log($"AI {playerID}: Opportunity window detected at ({opportunity.Value.q},{opportunity.Value.r}) — enemy moved away");
                 return true; // Attack even at lower threshold when enemy is out of position
             }
 
@@ -667,9 +587,8 @@ namespace Sporefront.AI
         {
             var playerID = aiState.playerID;
 
-            if (currentTime - aiState.lastUnitUpgradeCheckTime < GameConfig.AI.Intervals.UnitUpgradeCheck)
+            if (!AIHelper.ShouldExecute(ref aiState.lastUnitUpgradeCheckTime, currentTime, GameConfig.AI.Intervals.UnitUpgradeCheck))
                 return new List<IEngineCommand>();
-            aiState.lastUnitUpgradeCheckTime = currentTime;
 
             var player = gameState.GetPlayer(playerID);
             if (player == null) return new List<IEngineCommand>();
@@ -715,7 +634,7 @@ namespace Sporefront.AI
 
             if (building == null) return new List<IEngineCommand>();
 
-            DebugLog.Log(string.Format("AI starting unit upgrade: {0}", best.Value.DisplayName()));
+            DebugLog.Log($"AI starting unit upgrade: {best.Value.DisplayName()}");
             return new List<IEngineCommand> { new AIUpgradeUnitCommand(playerID, best.Value, building.id) };
         }
 

--- a/Sporefront/Assets/Scripts/AI/AIDefensePlanner.cs
+++ b/Sporefront/Assets/Scripts/AI/AIDefensePlanner.cs
@@ -59,8 +59,7 @@ namespace Sporefront.AI
             aiState.previousThreatLevel = threatLevel;
 
             int towerCount = gameState.GetBuildingCount(BuildingType.Tower, playerID);
-            bool hasBarracks = gameState.GetBuildingsForPlayer(playerID)
-                .Any(b => b.buildingType == BuildingType.Barracks && b.IsOperational);
+            bool hasBarracks = gameState.HasBuilding(playerID, BuildingType.Barracks, operationalOnly: true);
 
             // Comeback mechanic: CriticallyBehind lowers all thresholds and forces tower building
             bool isCriticallyBehind = aiState.gamePosition == GamePosition.CriticallyBehind;
@@ -158,18 +157,13 @@ namespace Sporefront.AI
             int ccLevel = cityCenter.level;
             if (ccLevel < buildingType.RequiredCityCenterLevel()) return null;
 
-            var cost = buildingType.BuildCost();
-            foreach (var kvp in cost)
-            {
-                if (!player.HasResource(kvp.Key, kvp.Value)) return null;
-            }
+            if (!player.CanAfford(buildingType.BuildCost())) return null;
 
             int maxDistance = buildingType == BuildingType.Tower ? 4 : 5;
             var location = FindDefenseBuildLocation(cityCenter.coordinate, maxDistance, gameState, playerID, buildingType, aiState.cachedChokepoints);
             if (!location.HasValue) return null;
 
-            DebugLog.Log(string.Format("AI building {0} at ({1}, {2}) for defense",
-                buildingType.DisplayName(), location.Value.q, location.Value.r));
+            DebugLog.Log($"AI building {buildingType.DisplayName()} at ({location.Value.q}, {location.Value.r}) for defense");
             return new AIBuildCommand(playerID, buildingType, location.Value, 0);
         }
 
@@ -177,6 +171,7 @@ namespace Sporefront.AI
         {
             var rng = new System.Random();
             var faction = gameState.GetPlayer(playerID)?.faction ?? FactionType.None;
+            var defConfig = FactionAIConfig.Get(faction);
 
             for (int distance = 2; distance <= maxDistance; distance++)
             {
@@ -207,18 +202,16 @@ namespace Sporefront.AI
                     // Chokepoint bonus: defensive buildings near chokepoints are much more effective
                     score += AIStrategicAnalysis.GetChokepointBonus(coord, chokepoints);
 
-                    // Faction terrain preferences for defensive buildings
-                    if (faction == FactionType.Muscaria)
-                    {
-                        var terrain = gameState.mapData.GetTerrain(coord);
-                        if (terrain == TerrainType.Mountain) score += 2.0;
-                        else if (terrain == TerrainType.Hill) score += 1.5;
-                    }
-                    else if (faction == FactionType.Morel)
+                    // Faction terrain preferences for defensive buildings (data-driven)
+                    var terrain = gameState.mapData.GetTerrain(coord);
+                    double terrainBonus;
+                    if (terrain.HasValue && defConfig.TowerTerrainBonus.TryGetValue(terrain.Value, out terrainBonus))
+                        score += terrainBonus;
+                    if (defConfig.TowerForestBonus)
                     {
                         var rp = gameState.GetResourcePoint(coord);
                         if (rp != null && rp.resourceType == ResourcePointType.Trees)
-                            score += 1.5; // Towers near forests support camouflaged armies
+                            score += 1.5;
                     }
 
                     valid.Add((coord, score));
@@ -242,8 +235,7 @@ namespace Sporefront.AI
             var commands = new List<IEngineCommand>();
             var playerID = aiState.playerID;
 
-            if (currentTime - aiState.lastGarrisonCheckTime < garrisonCheckInterval) return commands;
-            aiState.lastGarrisonCheckTime = currentTime;
+            if (!AIHelper.ShouldExecute(ref aiState.lastGarrisonCheckTime, currentTime, garrisonCheckInterval)) return commands;
 
             var defensiveTypes = new HashSet<BuildingType>
             {
@@ -259,8 +251,7 @@ namespace Sporefront.AI
             if (ungarrisonedDefenses.Count == 0) return commands;
 
             var idleArmies = gameState.GetArmiesForPlayer(playerID)
-                .Where(a => !a.isInCombat && a.currentPath == null && HasGarrisonableUnits(a))
-                .ToList();
+                .Where(a => !a.isInCombat && a.currentPath == null && HasGarrisonableUnits(a));
 
             var assignedBuildings = new HashSet<Guid>();
             foreach (var army in idleArmies)
@@ -273,7 +264,7 @@ namespace Sporefront.AI
                 {
                     commands.Add(new AIMoveCommand(playerID, army.id, targetBuilding.coordinate, true));
                     assignedBuildings.Add(targetBuilding.id);
-                    DebugLog.Log(string.Format("AI moving army to garrison {0}", targetBuilding.buildingType.DisplayName()));
+                    DebugLog.Log($"AI moving army to garrison {targetBuilding.buildingType.DisplayName()}");
                 }
             }
 
@@ -288,9 +279,8 @@ namespace Sporefront.AI
         {
             var playerID = aiState.playerID;
 
-            if (currentTime - aiState.lastEntrenchCheckTime < GameConfig.AI.Intervals.EntrenchCheck)
+            if (!AIHelper.ShouldExecute(ref aiState.lastEntrenchCheckTime, currentTime, GameConfig.AI.Intervals.EntrenchCheck))
                 return new List<IEngineCommand>();
-            aiState.lastEntrenchCheckTime = currentTime;
 
             var player = gameState.GetPlayer(playerID);
             if (player == null) return new List<IEngineCommand>();
@@ -315,31 +305,27 @@ namespace Sporefront.AI
             // Find idle armies near city center that could entrench
             // Faction-aware: prefer terrain that synergizes with faction bonuses
             var commands = new List<IEngineCommand>();
-            var faction = player.faction;
+            var entrenchConfig = FactionAIConfig.Get(player.faction);
             var candidates = armies
                 .Where(a => !a.isInCombat && a.currentPath == null && !a.isRetreating &&
                             !a.isEntrenched && !a.isEntrenching)
                 .Select(a => {
                     double score = -a.coordinate.Distance(cityCenter.coordinate); // Closer = higher
-                    if (faction == FactionType.Morel)
+                    // Faction terrain preferences for entrenchment (data-driven)
+                    double eTerrain;
+                    var eTile = gameState.mapData.GetTerrain(a.coordinate);
+                    if (eTile.HasValue && entrenchConfig.EntrenchTerrainBonus.TryGetValue(eTile.Value, out eTerrain))
+                        score += eTerrain;
+                    if (entrenchConfig.EntrenchForestBonus > 0)
                     {
-                        // Prefer forest tiles (camouflage + entrenchment = strong defense)
                         var rp = gameState.GetResourcePoint(a.coordinate);
                         if (rp != null && rp.resourceType == ResourcePointType.Trees)
-                            score += 3.0;
-                    }
-                    else if (faction == FactionType.Muscaria)
-                    {
-                        // Prefer mountain/hill (defense bonus + speed bonus for counterattack)
-                        var terrain = gameState.mapData.GetTerrain(a.coordinate);
-                        if (terrain == TerrainType.Mountain) score += 3.0;
-                        else if (terrain == TerrainType.Hill) score += 2.0;
+                            score += entrenchConfig.EntrenchForestBonus;
                     }
                     return (army: a, score: score);
                 })
                 .OrderByDescending(x => x.score)
-                .Select(x => x.army)
-                .ToList();
+                .Select(x => x.army);
 
             foreach (var army in candidates)
             {
@@ -352,8 +338,7 @@ namespace Sporefront.AI
                 if (alreadyEntrenched) continue;
 
                 commands.Add(new AIEntrenchCommand(playerID, army.id));
-                DebugLog.Log(string.Format("AI entrenching army {0} near city center (threat: {1})",
-                    army.name, (int)threatLevel));
+                DebugLog.Log($"AI entrenching army {army.name} near city center (threat: {(int)threatLevel})");
                 break; // One entrenchment command per cycle
             }
 

--- a/Sporefront/Assets/Scripts/AI/AIEconomyPlanner.cs
+++ b/Sporefront/Assets/Scripts/AI/AIEconomyPlanner.cs
@@ -131,7 +131,7 @@ namespace Sporefront.AI
                 if (aiState.siegeRequired && !aiState.siegeReady)
                 {
                     if (buildOrderTarget == BuildingType.SiegeWorkshop ||
-                        !gameState.GetBuildingsForPlayer(playerID).Any(b => b.buildingType == BuildingType.SiegeWorkshop && b.IsOperational))
+                        !gameState.HasBuilding(playerID, BuildingType.SiegeWorkshop, operationalOnly: true))
                         milWeight = Math.Max(milWeight, GameConfig.AI.Siege.WorkshopBuildPriority);
                 }
                 buildCandidates.Add((() => TryBuildMilitaryBuilding(playerID, gameState), milWeight, "Military"));
@@ -273,8 +273,7 @@ namespace Sporefront.AI
             var playerID = aiState.playerID;
 
             if (aiState.expansionCount >= GameConfig.AI.Expansion.MaxExpansions) return commands;
-            if (currentTime - aiState.lastExpansionCheckTime < GameConfig.AI.Expansion.CheckInterval) return commands;
-            aiState.lastExpansionCheckTime = currentTime;
+            if (!AIHelper.ShouldExecute(ref aiState.lastExpansionCheckTime, currentTime, GameConfig.AI.Expansion.CheckInterval)) return commands;
 
             if (gameState.currentTime < GameConfig.AI.Expansion.MinGameTime) return commands;
             if (aiState.gamePosition == GamePosition.CriticallyBehind) return commands;
@@ -300,11 +299,7 @@ namespace Sporefront.AI
             if (aiState.mapExplorationPercent < 0.4 && campCount < 2) return commands;
 
             // Can we afford a CC?
-            var ccCost = BuildingType.CityCenter.BuildCost();
-            foreach (var kvp in ccCost)
-            {
-                if (!player.HasResource(kvp.Key, kvp.Value)) return commands;
-            }
+            if (!player.CanAfford(BuildingType.CityCenter.BuildCost())) return commands;
 
             // Find or use cached expansion site
             if (!aiState.plannedExpansionSite.HasValue || !gameState.mapData.IsWalkable(aiState.plannedExpansionSite.Value))
@@ -328,8 +323,7 @@ namespace Sporefront.AI
             aiState.expansionPlanned = false;
             aiState.plannedExpansionSite = null;
 
-            DebugLog.Log(string.Format("AI {0}: Expanding — building second City Center at ({1},{2})",
-                playerID, site.q, site.r));
+            DebugLog.Log($"AI {playerID}: Expanding — building second City Center at ({site.q},{site.r})");
 
             return commands;
         }
@@ -390,8 +384,7 @@ namespace Sporefront.AI
             var playerID = aiState.playerID;
 
             if (!aiState.enemyBaseFound) return commands;
-            if (currentTime - aiState.lastMapControlCheckTime < GameConfig.AI.MapControl.CheckInterval) return commands;
-            aiState.lastMapControlCheckTime = currentTime;
+            if (!AIHelper.ShouldExecute(ref aiState.lastMapControlCheckTime, currentTime, GameConfig.AI.MapControl.CheckInterval)) return commands;
 
             var player = gameState.GetPlayer(playerID);
             if (player == null) return commands;
@@ -427,11 +420,7 @@ namespace Sporefront.AI
                 return commands; // Not a camp-able resource
 
             // Check affordability
-            var cost = campType.BuildCost();
-            foreach (var kvp in cost)
-            {
-                if (!player.HasResource(kvp.Key, kvp.Value)) return commands;
-            }
+            if (!player.CanAfford(campType.BuildCost())) return commands;
 
             // Find build location near the resource
             HexCoordinate? buildSite = null;
@@ -452,8 +441,7 @@ namespace Sporefront.AI
             if (!buildSite.HasValue) return commands;
 
             commands.Add(new AIBuildCommand(playerID, campType, buildSite.Value, 0));
-            DebugLog.Log(string.Format("AI {0}: Map control — building {1} at contested node ({2},{3})",
-                playerID, campType.DisplayName(), buildSite.Value.q, buildSite.Value.r));
+            DebugLog.Log($"AI {playerID}: Map control — building {campType.DisplayName()} at contested node ({buildSite.Value.q},{buildSite.Value.r})");
 
             return commands;
         }
@@ -525,8 +513,7 @@ namespace Sporefront.AI
                     urgency.TryGetValue(r.resourceType.ResourceYield(), out u);
                     return u;
                 })
-                .ThenBy(r => r.coordinate.Distance(cityCenter.coordinate))
-                .ToList();
+                .ThenBy(r => r.coordinate.Distance(cityCenter.coordinate));
 
             var assignedResources = new HashSet<Guid>();
             foreach (var villagerGroup in idleVillagers)
@@ -567,8 +554,7 @@ namespace Sporefront.AI
                 .ToList();
 
             var idleVillagers = gameState.GetVillagerGroupsForPlayer(playerID)
-                .Where(g => g.currentTask is IdleTask && g.currentPath == null)
-                .ToList();
+                .Where(g => g.currentTask is IdleTask && g.currentPath == null);
 
             var usedVillagers = new HashSet<Guid>();
             foreach (var animal in huntableAnimals)
@@ -620,19 +606,12 @@ namespace Sporefront.AI
                 urgency[resourceType] = Math.Max(0.0, Math.Min(2.0, score));
             }
 
-            // Faction resource urgency bias
-            var faction = player.faction;
-            if (faction == FactionType.Morel)
+            // Faction resource urgency bias (data-driven via FactionAIConfig)
+            var factionConfig = FactionAIConfig.Get(player.faction);
+            foreach (var kvp in factionConfig.ResourceUrgencyMultiplier)
             {
-                if (urgency.ContainsKey(ResourceType.Wood))
-                    urgency[ResourceType.Wood] = Math.Min(2.0, urgency[ResourceType.Wood] * 1.10);
-            }
-            else if (faction == FactionType.Muscaria)
-            {
-                if (urgency.ContainsKey(ResourceType.Stone))
-                    urgency[ResourceType.Stone] = Math.Min(2.0, urgency[ResourceType.Stone] * 1.10);
-                if (urgency.ContainsKey(ResourceType.Ore))
-                    urgency[ResourceType.Ore] = Math.Min(2.0, urgency[ResourceType.Ore] * 1.10);
+                if (urgency.ContainsKey(kvp.Key))
+                    urgency[kvp.Key] = Math.Min(2.0, urgency[kvp.Key] * kvp.Value);
             }
 
             return urgency;
@@ -745,8 +724,8 @@ namespace Sporefront.AI
 
         private HexCoordinate? FindFactionPreferredBuildLocation(HexCoordinate center, int maxDistance, GameState gameState, Guid playerID)
         {
-            var faction = gameState.GetPlayer(playerID)?.faction ?? FactionType.None;
-            if (faction != FactionType.Muscaria)
+            var factionBuildConfig = FactionAIConfig.Get(gameState.GetPlayer(playerID)?.faction ?? FactionType.None);
+            if (!factionBuildConfig.PreferHighlandBuilding)
                 return gameState.FindBuildLocation(center, maxDistance, playerID);
 
             // Muscaria: prefer mountain/hill tiles for -15% build cost reduction
@@ -776,117 +755,48 @@ namespace Sporefront.AI
         // Building Construction
         // ================================================================
 
-        private IEngineCommand TryBuildFarm(Guid playerID, GameState gameState)
+        /// <summary>
+        /// Generic building construction helper. Validates player/CC, checks optional preconditions
+        /// (CC level, singleton, max count), affordability, and finds a build location.
+        /// </summary>
+        private IEngineCommand TryBuildStructure(Guid playerID, GameState gameState, BuildingType type, int searchRadius,
+            bool requiresCCLevel = false, bool singleton = false, int? maxAllowed = null)
         {
             var cityCenter = gameState.GetCityCenter(playerID);
             if (cityCenter == null) return null;
             var player = gameState.GetPlayer(playerID);
             if (player == null) return null;
 
-            var farmCost = BuildingType.Farm.BuildCost();
-            foreach (var kvp in farmCost)
-            {
-                if (!player.HasResource(kvp.Key, kvp.Value)) return null;
-            }
+            if (requiresCCLevel && cityCenter.level < type.RequiredCityCenterLevel()) return null;
+            if (singleton && gameState.HasBuilding(playerID, type)) return null;
+            if (maxAllowed.HasValue && gameState.GetBuildingCount(type, playerID) >= maxAllowed.Value) return null;
 
-            var location = FindFactionPreferredBuildLocation(cityCenter.coordinate, 4, gameState, playerID);
+            if (!player.CanAfford(type.BuildCost())) return null;
+
+            var location = FindFactionPreferredBuildLocation(cityCenter.coordinate, searchRadius, gameState, playerID);
             if (!location.HasValue) return null;
 
-            return new AIBuildCommand(playerID, BuildingType.Farm, location.Value, 0);
+            return new AIBuildCommand(playerID, type, location.Value, 0);
         }
+
+        private IEngineCommand TryBuildFarm(Guid playerID, GameState gameState)
+            => TryBuildStructure(playerID, gameState, BuildingType.Farm, 4);
 
         private IEngineCommand TryBuildHouse(Guid playerID, GameState gameState, double currentTime, AIPlayerState aiState)
-        {
-            var cityCenter = gameState.GetCityCenter(playerID);
-            if (cityCenter == null) return null;
-            var player = gameState.GetPlayer(playerID);
-            if (player == null) return null;
-
-            var houseCost = BuildingType.Neighborhood.BuildCost();
-            foreach (var kvp in houseCost)
-            {
-                if (!player.HasResource(kvp.Key, kvp.Value)) return null;
-            }
-
-            var location = FindFactionPreferredBuildLocation(cityCenter.coordinate, 5, gameState, playerID);
-            if (!location.HasValue) return null;
-
-            return new AIBuildCommand(playerID, BuildingType.Neighborhood, location.Value, 0);
-        }
+            => TryBuildStructure(playerID, gameState, BuildingType.Neighborhood, 5);
 
         private IEngineCommand TryBuildStorage(Guid playerID, GameState gameState)
         {
-            var cityCenter = gameState.GetCityCenter(playerID);
-            if (cityCenter == null) return null;
-            var player = gameState.GetPlayer(playerID);
-            if (player == null) return null;
-
-            int ccLevel = cityCenter.level;
-            int currentWarehouses = gameState.GetBuildingCount(BuildingType.Warehouse, playerID);
-            int maxWarehouses = BuildingTypeExtensions.MaxWarehousesAllowed(ccLevel);
-
-            if (currentWarehouses >= maxWarehouses) return null;
-
-            var warehouseCost = BuildingType.Warehouse.BuildCost();
-            foreach (var kvp in warehouseCost)
-            {
-                if (!player.HasResource(kvp.Key, kvp.Value)) return null;
-            }
-
-            var location = FindFactionPreferredBuildLocation(cityCenter.coordinate, 5, gameState, playerID);
-            if (!location.HasValue) return null;
-
-            return new AIBuildCommand(playerID, BuildingType.Warehouse, location.Value, 0);
+            int ccLevel = gameState.GetCityCenter(playerID)?.level ?? 0;
+            return TryBuildStructure(playerID, gameState, BuildingType.Warehouse, 5,
+                maxAllowed: BuildingTypeExtensions.MaxWarehousesAllowed(ccLevel));
         }
 
         private IEngineCommand TryBuildLibrary(Guid playerID, GameState gameState)
-        {
-            var cityCenter = gameState.GetCityCenter(playerID);
-            if (cityCenter == null) return null;
-            var player = gameState.GetPlayer(playerID);
-            if (player == null) return null;
-
-            if (cityCenter.level < BuildingType.Library.RequiredCityCenterLevel()) return null;
-
-            bool existingLibrary = gameState.GetBuildingsForPlayer(playerID).Any(b => b.buildingType == BuildingType.Library);
-            if (existingLibrary) return null;
-
-            var libraryCost = BuildingType.Library.BuildCost();
-            foreach (var kvp in libraryCost)
-            {
-                if (!player.HasResource(kvp.Key, kvp.Value)) return null;
-            }
-
-            var location = FindFactionPreferredBuildLocation(cityCenter.coordinate, 4, gameState, playerID);
-            if (!location.HasValue) return null;
-
-            return new AIBuildCommand(playerID, BuildingType.Library, location.Value, 0);
-        }
+            => TryBuildStructure(playerID, gameState, BuildingType.Library, 4, requiresCCLevel: true, singleton: true);
 
         private IEngineCommand TryBuildBlacksmith(Guid playerID, GameState gameState)
-        {
-            var cityCenter = gameState.GetCityCenter(playerID);
-            if (cityCenter == null) return null;
-            var player = gameState.GetPlayer(playerID);
-            if (player == null) return null;
-
-            if (cityCenter.level < BuildingType.Blacksmith.RequiredCityCenterLevel()) return null;
-
-            bool existingBlacksmith = gameState.GetBuildingsForPlayer(playerID)
-                .Any(b => b.buildingType == BuildingType.Blacksmith);
-            if (existingBlacksmith) return null;
-
-            var cost = BuildingType.Blacksmith.BuildCost();
-            foreach (var kvp in cost)
-            {
-                if (!player.HasResource(kvp.Key, kvp.Value)) return null;
-            }
-
-            var location = FindFactionPreferredBuildLocation(cityCenter.coordinate, 4, gameState, playerID);
-            if (!location.HasValue) return null;
-
-            return new AIBuildCommand(playerID, BuildingType.Blacksmith, location.Value, 0);
-        }
+            => TryBuildStructure(playerID, gameState, BuildingType.Blacksmith, 4, requiresCCLevel: true, singleton: true);
 
         // ================================================================
         // Building Upgrades
@@ -896,8 +806,7 @@ namespace Sporefront.AI
         {
             var playerID = aiState.playerID;
 
-            if (currentTime - aiState.lastUpgradeCheckTime < GameConfig.AI.Intervals.UpgradeCheck) return new List<IEngineCommand>();
-            aiState.lastUpgradeCheckTime = currentTime;
+            if (!AIHelper.ShouldExecute(ref aiState.lastUpgradeCheckTime, currentTime, GameConfig.AI.Intervals.UpgradeCheck)) return new List<IEngineCommand>();
 
             var player = gameState.GetPlayer(playerID);
             if (player == null) return new List<IEngineCommand>();
@@ -907,7 +816,7 @@ namespace Sporefront.AI
             int currentlyUpgrading = buildings.Count(b => b.state == BuildingState.Upgrading);
 
             // Don't upgrade CC until we have a lumber camp or have wood income
-            bool hasLumber = buildings.Any(b => b.buildingType == BuildingType.LumberCamp && b.IsOperational);
+            bool hasLumber = gameState.HasBuilding(playerID, BuildingType.LumberCamp, operationalOnly: true);
             bool hasWoodIncome = player.GetCollectionRate(ResourceType.Wood) > 0;
             if (!hasLumber && !hasWoodIncome) return new List<IEngineCommand>();
 
@@ -933,16 +842,7 @@ namespace Sporefront.AI
                 var cost = building.GetUpgradeCost();
                 if (cost == null) continue;
 
-                bool canAfford = true;
-                foreach (var kvp in cost)
-                {
-                    if (!player.HasResource(kvp.Key, kvp.Value))
-                    {
-                        canAfford = false;
-                        break;
-                    }
-                }
-                if (!canAfford) continue;
+                if (!player.CanAfford(cost)) continue;
 
                 // Use genome upgrade priorities when available
                 var genome = AIController.Instance?.genome;
@@ -1049,43 +949,8 @@ namespace Sporefront.AI
             var buildings = gameState.GetBuildingsForPlayer(playerID);
 
             // Faction-specific military building priorities
-            var faction = player.faction;
-            (BuildingType type, int minCount, int maxCount)[] priorities;
-            if (faction == FactionType.Morel)
-            {
-                // Morel: infantry focus — second barracks earlier, deprioritize siege
-                priorities = new[]
-                {
-                    (type: BuildingType.Barracks, minCount: 0, maxCount: 1),
-                    (type: BuildingType.ArcheryRange, minCount: 0, maxCount: 1),
-                    (type: BuildingType.Barracks, minCount: 1, maxCount: 2),
-                    (type: BuildingType.Stable, minCount: 0, maxCount: 1),
-                    (type: BuildingType.SiegeWorkshop, minCount: 0, maxCount: 1),
-                };
-            }
-            else if (faction == FactionType.Muscaria)
-            {
-                // Muscaria: ranged/siege focus — siege workshop earlier
-                priorities = new[]
-                {
-                    (type: BuildingType.Barracks, minCount: 0, maxCount: 1),
-                    (type: BuildingType.ArcheryRange, minCount: 0, maxCount: 1),
-                    (type: BuildingType.SiegeWorkshop, minCount: 0, maxCount: 1),
-                    (type: BuildingType.Stable, minCount: 0, maxCount: 1),
-                    (type: BuildingType.Barracks, minCount: 1, maxCount: 2),
-                };
-            }
-            else
-            {
-                priorities = new[]
-                {
-                    (type: BuildingType.Barracks, minCount: 0, maxCount: 1),
-                    (type: BuildingType.ArcheryRange, minCount: 0, maxCount: 1),
-                    (type: BuildingType.Stable, minCount: 0, maxCount: 1),
-                    (type: BuildingType.Barracks, minCount: 1, maxCount: 2),
-                    (type: BuildingType.SiegeWorkshop, minCount: 0, maxCount: 1),
-                };
-            }
+            // Faction-specific military building priorities (data-driven via FactionAIConfig)
+            var priorities = FactionAIConfig.Get(player.faction).MilitaryBuildOrder;
 
             foreach (var priority in priorities)
             {
@@ -1097,17 +962,7 @@ namespace Sporefront.AI
 
                 if (existingCount < priority.minCount || existingCount >= priority.maxCount) continue;
 
-                var cost = priority.type.BuildCost();
-                bool canAfford = true;
-                foreach (var kvp in cost)
-                {
-                    if (!player.HasResource(kvp.Key, kvp.Value))
-                    {
-                        canAfford = false;
-                        break;
-                    }
-                }
-                if (!canAfford) continue;
+                if (!player.CanAfford(priority.type.BuildCost())) continue;
 
                 var location = gameState.FindBuildLocation(cityCenter.coordinate, 5, playerID);
                 if (!location.HasValue) continue;
@@ -1137,11 +992,7 @@ namespace Sporefront.AI
             var player = gameState.GetPlayer(playerID);
             if (player == null) return null;
 
-            var campCost = BuildingType.LumberCamp.BuildCost();
-            foreach (var kvp in campCost)
-            {
-                if (!player.HasResource(kvp.Key, kvp.Value)) return null;
-            }
+            if (!player.CanAfford(BuildingType.LumberCamp.BuildCost())) return null;
 
             var trees = gameState.GetExploredResourcePoints(playerID)
                 .Where(r => r.resourceType == ResourcePointType.Trees && r.remainingAmount > 0 &&
@@ -1269,9 +1120,7 @@ namespace Sporefront.AI
                 commands.Add(new AIMoveCommand(playerID, group.id, destination, false));
                 aiState.fleeingVillagers.Add(group.id);
 
-                DebugLog.Log(string.Format("AI {0}: Villager group fleeing from ({1},{2}) to ({3},{4}) — {5} enemy units nearby",
-                    playerID, group.coordinate.q, group.coordinate.r,
-                    destination.q, destination.r, totalEnemyUnits));
+                DebugLog.Log($"AI {playerID}: Villager group fleeing from ({group.coordinate.q},{group.coordinate.r}) to ({destination.q},{destination.r}) — {totalEnemyUnits} enemy units nearby");
             }
 
             return commands;
@@ -1389,17 +1238,7 @@ namespace Sporefront.AI
                         continue;
                 }
 
-                var campCost = campType.BuildCost();
-                bool canAfford = true;
-                foreach (var kvp in campCost)
-                {
-                    if (!player.HasResource(kvp.Key, kvp.Value))
-                    {
-                        canAfford = false;
-                        break;
-                    }
-                }
-                if (!canAfford) continue;
+                if (!player.CanAfford(campType.BuildCost())) continue;
 
                 double score = resourceUrgency * resource.remainingAmount / (100.0 * distance);
                 candidates.Add((resource, campType, score));
@@ -1423,11 +1262,7 @@ namespace Sporefront.AI
             var player = gameState.GetPlayer(playerID);
             if (player == null) return null;
 
-            var campCost = campType.BuildCost();
-            foreach (var kvp in campCost)
-            {
-                if (!player.HasResource(kvp.Key, kvp.Value)) return null;
-            }
+            if (!player.CanAfford(campType.BuildCost())) return null;
 
             if (gameState.CanBuildAt(resource.coordinate, playerID))
             {
@@ -1471,7 +1306,7 @@ namespace Sporefront.AI
             else
             {
                 // Shuffle and try random order
-                var shuffled = candidates.OrderBy(_ => rng.Next()).ToList();
+                var shuffled = candidates.OrderBy(_ => rng.Next());
                 foreach (var candidate in shuffled)
                 {
                     var cmd = candidate.tryBuild();
@@ -1536,9 +1371,8 @@ namespace Sporefront.AI
         /// </summary>
         public void CheckBuildOrderMilestones(AIPlayerState aiState, GameState gameState, double currentTime)
         {
-            if (currentTime - aiState.lastMilestoneCheckTime < GameConfig.AI.BuildOrderTiming.MilestoneCheckInterval)
+            if (!AIHelper.ShouldExecute(ref aiState.lastMilestoneCheckTime, currentTime, GameConfig.AI.BuildOrderTiming.MilestoneCheckInterval))
                 return;
-            aiState.lastMilestoneCheckTime = currentTime;
 
             // Initialize milestones if null
             if (aiState.milestones == null)
@@ -1558,8 +1392,7 @@ namespace Sporefront.AI
                         aiState.buildOrderEmergency = true;
                         aiState.emergencyBuildTarget = milestone.requiredBuilding;
                         anyBehind = true;
-                        DebugLog.Log(string.Format("AI {0}: Build order emergency — missing {1} past {2}s deadline",
-                            playerID, milestone.requiredBuilding, milestone.targetTime));
+                        DebugLog.Log($"AI {playerID}: Build order emergency — missing {milestone.requiredBuilding} past {milestone.targetTime}s deadline");
                         break; // Handle the most urgent milestone first
                     }
                 }

--- a/Sporefront/Assets/Scripts/AI/AIHelper.cs
+++ b/Sporefront/Assets/Scripts/AI/AIHelper.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Sporefront.Data;
+using Sporefront.Engine;
+
+namespace Sporefront.AI
+{
+    public static class AIHelper
+    {
+        /// <summary>
+        /// Returns true if enough time has elapsed since lastTime, and updates lastTime.
+        /// Use as a guard: if (!AIHelper.ShouldExecute(ref aiState.lastXTime, currentTime, interval)) return;
+        /// </summary>
+        public static bool ShouldExecute(ref double lastTime, double currentTime, double interval)
+        {
+            if (currentTime - lastTime < interval)
+                return false;
+            lastTime = currentTime;
+            return true;
+        }
+
+        /// <summary>
+        /// Checks all villager groups with hunting tasks — if they have arrived at the animal,
+        /// execute instant combat and convert to carcass gathering.
+        /// Shared between AIController and SimulationAIController.
+        /// </summary>
+        public static void ProcessHuntArrivals(GameState state, ResourceEngine resourceEngine)
+        {
+            // Defensive copy: RemoveVillagerGroup may modify the collection during iteration
+            var groups = state.villagerGroups.Values.ToList();
+
+            foreach (var group in groups)
+            {
+                var huntTask = group.currentTask as HuntingTask;
+                if (huntTask == null) continue;
+                if (group.currentPath != null) continue; // Still en route
+
+                var resourcePointID = huntTask.ResourcePointID;
+                var resource = state.GetResourcePoint(resourcePointID);
+                if (resource == null)
+                {
+                    group.ClearTask();
+                    continue;
+                }
+
+                if (!group.coordinate.Equals(resource.coordinate)) continue;
+
+                // At target — execute hunt combat
+                double villagerAttack = group.villagerCount * GameConfig.AI.Hunting.VillagerAttackPower;
+                double damageToAnimal = Math.Max(1.0, villagerAttack - resource.resourceType.DefensePower());
+                resource.TakeDamage(damageToAnimal);
+
+                double animalAttack = resource.resourceType.AttackPower();
+                double damageToVillagers = Math.Max(0.0, animalAttack - group.villagerCount * GameConfig.AI.Hunting.VillagerDefenseFactor);
+                int villagersLost = (int)(damageToVillagers / GameConfig.AI.Hunting.VillagerDeathThreshold);
+                if (villagersLost > 0) group.RemoveVillagers(villagersLost);
+
+                if (resource.currentHealth <= 0)
+                {
+                    // Animal killed — create carcass and start gathering
+                    var carcass = resource.CreateCarcassData();
+                    if (carcass != null)
+                    {
+                        state.RemoveResourcePoint(resource.id);
+                        state.AddResourcePoint(carcass);
+
+                        bool registered = resourceEngine.StartGathering(
+                            group.id, carcass.id);
+                        if (registered)
+                        {
+                            resourceEngine.UpdateCollectionRates(
+                                group.ownerID ?? Guid.Empty);
+                        }
+                        else
+                        {
+                            group.ClearTask();
+                        }
+                    }
+                    else
+                    {
+                        group.ClearTask();
+                    }
+                }
+                else
+                {
+                    // Animal survived — clear task, AI will retry next cycle
+                    group.ClearTask();
+                }
+
+                if (group.villagerCount <= 0)
+                {
+                    resourceEngine.StopGathering(group.id);
+                    state.RemoveVillagerGroup(group.id);
+                }
+            }
+        }
+    }
+}

--- a/Sporefront/Assets/Scripts/AI/AIHelper.cs.meta
+++ b/Sporefront/Assets/Scripts/AI/AIHelper.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2ce1c7c0c7e98466e82c3c009d013875

--- a/Sporefront/Assets/Scripts/AI/AIMilitaryPlanner.cs
+++ b/Sporefront/Assets/Scripts/AI/AIMilitaryPlanner.cs
@@ -42,8 +42,7 @@ namespace Sporefront.AI
                 };
 
                 var militaryBuildings = gameState.GetBuildingsForPlayer(playerID)
-                    .Where(b => militaryBuildingTypes.Contains(b.buildingType) && b.IsOperational && b.trainingQueue.Count == 0)
-                    .ToList();
+                    .Where(b => militaryBuildingTypes.Contains(b.buildingType) && b.IsOperational && b.trainingQueue.Count == 0);
 
                 bool trainedThisCycle = false;
                 foreach (var building in militaryBuildings)
@@ -120,13 +119,7 @@ namespace Sporefront.AI
 
             foreach (var unitType in trainableUnits)
             {
-                var trainingCost = unitType.TrainingCost();
-                bool canAfford = true;
-                foreach (var kvp in trainingCost)
-                {
-                    if (!player.HasResource(kvp.Key, kvp.Value)) { canAfford = false; break; }
-                }
-                if (!canAfford) continue;
+                if (!player.CanAfford(unitType.TrainingCost())) continue;
 
                 double score = ScoreUnitTraining(unitType, enemyAnalysis, ownComposition, player, gameState, playerID, gameTime, targetComp, aiState.gamePosition, aiState.siegeRequired && !aiState.siegeReady);
 
@@ -292,22 +285,19 @@ namespace Sporefront.AI
                     score -= 30.0;
             }
 
-            // Faction unit preferences
-            var faction = player.faction;
-            if (faction == FactionType.Morel)
+            // Faction unit preferences (data-driven via FactionAIConfig)
+            var factionConfig = FactionAIConfig.Get(player.faction);
+            double catBias;
+            if (factionConfig.UnitCategoryBias.TryGetValue(category, out catBias))
             {
-                if (category == UnitCategory.Infantry) score += 6.0;
-                if (unitType == MilitaryUnitType.Scout) score += 5.0; // +1 vision makes scouts more valuable
-                if (category == UnitCategory.Cavalry && unitType != MilitaryUnitType.Scout) score -= 5.0;
-                if (category == UnitCategory.Siege) score -= 5.0;
+                // Scouts are exempt from negative cavalry bias
+                if (unitType == MilitaryUnitType.Scout && catBias < 0)
+                    catBias = 0;
+                score += catBias;
             }
-            else if (faction == FactionType.Muscaria)
-            {
-                if (category == UnitCategory.Ranged) score += 6.0;
-                if (category == UnitCategory.Siege) score += 6.0;
-                if (category == UnitCategory.Infantry) score -= 4.0;
-                if (category == UnitCategory.Cavalry && unitType != MilitaryUnitType.Scout) score -= 4.0;
-            }
+            double typeBias;
+            if (factionConfig.UnitTypeBias.TryGetValue(unitType, out typeBias))
+                score += typeBias;
 
             // Feature 4: Comeback — favor cheap units when behind
             if (gamePosition == GamePosition.Behind || gamePosition == GamePosition.CriticallyBehind)
@@ -384,8 +374,7 @@ namespace Sporefront.AI
             var commands = new List<IEngineCommand>();
             var playerID = aiState.playerID;
 
-            if (currentTime - aiState.lastPatrolTime < 8.0) return commands;
-            aiState.lastPatrolTime = currentTime;
+            if (!AIHelper.ShouldExecute(ref aiState.lastPatrolTime, currentTime, 8.0)) return commands;
 
             var cityCenter = gameState.GetCityCenter(playerID);
             if (cityCenter == null) return commands;
@@ -464,8 +453,7 @@ namespace Sporefront.AI
             if (gameState.controlZones == null || gameState.controlZones.Count == 0)
                 return commands;
 
-            if (currentTime - aiState.lastZoneContestTime < 5.0) return commands;
-            aiState.lastZoneContestTime = currentTime;
+            if (!AIHelper.ShouldExecute(ref aiState.lastZoneContestTime, currentTime, 5.0)) return commands;
 
             var cityCenter = gameState.GetCityCenter(playerID);
             if (cityCenter == null) return commands;
@@ -811,16 +799,16 @@ namespace Sporefront.AI
                 scores.Add(new TargetScore(building.id, building.coordinate, score, true));
             }
 
-            // Muscaria aggression: poison DoT makes attacking armies more valuable
-            var attackerFaction = gameState.GetPlayer(playerID)?.faction ?? FactionType.None;
-            if (attackerFaction == FactionType.Muscaria)
+            // Faction aggression bonus for army targets (e.g. Muscaria poison DoT)
+            var attackerConfig = FactionAIConfig.Get(gameState.GetPlayer(playerID)?.faction ?? FactionType.None);
+            if (attackerConfig.ArmyTargetBonus > 0)
             {
                 for (int i = 0; i < scores.Count; i++)
                 {
                     if (!scores[i].isBuilding)
                     {
                         var s = scores[i];
-                        s.score += 8.0;
+                        s.score += attackerConfig.ArmyTargetBonus;
                         scores[i] = s;
                     }
                 }
@@ -904,8 +892,7 @@ namespace Sporefront.AI
                 if (!wasSiegeRequired)
                 {
                     aiState.siegeRequirementDetectedTime = gameState.currentTime;
-                    DebugLog.Log(string.Format("AI {0}: Siege required — {1} defensive buildings detected, need {2} siege units",
-                        playerID, totalDefensive, aiState.requiredSiegeCount));
+                    DebugLog.Log($"AI {playerID}: Siege required — {totalDefensive} defensive buildings detected, need {aiState.requiredSiegeCount} siege units");
                 }
             }
             else
@@ -934,8 +921,7 @@ namespace Sporefront.AI
             aiState.siegeReady = siegeCount >= aiState.requiredSiegeCount;
 
             if (aiState.siegeReady && !wasReady)
-                DebugLog.Log(string.Format("AI {0}: Siege ready — {1}/{2} siege units built",
-                    playerID, siegeCount, aiState.requiredSiegeCount));
+                DebugLog.Log($"AI {playerID}: Siege ready — {siegeCount}/{aiState.requiredSiegeCount} siege units built");
         }
 
         // ================================================================
@@ -1038,8 +1024,7 @@ namespace Sporefront.AI
                 new AIMoveCommand(playerID, flankArmy.id, bestFlankPos.Value, true)
             };
 
-            DebugLog.Log(string.Format("AI {0}: Flanking attack — main to ({1},{2}), flank to ({3},{4})",
-                playerID, target.q, target.r, bestFlankPos.Value.q, bestFlankPos.Value.r));
+            DebugLog.Log($"AI {playerID}: Flanking attack — main to ({target.q},{target.r}), flank to ({bestFlankPos.Value.q},{bestFlankPos.Value.r})");
 
             return commands;
         }
@@ -1093,8 +1078,7 @@ namespace Sporefront.AI
             aiState.feintInProgress = true;
             aiState.lastFeintAttemptTime = currentTime;
 
-            DebugLog.Log(string.Format("AI {0}: Feint initiated — sending {1}-unit army toward enemy CC at ({2},{3})",
-                playerID, feintArmy.GetTotalUnits(), enemyCC.q, enemyCC.r));
+            DebugLog.Log($"AI {playerID}: Feint initiated — sending {feintArmy.GetTotalUnits()}-unit army toward enemy CC at ({enemyCC.q},{enemyCC.r})");
 
             return commands;
         }
@@ -1139,19 +1123,19 @@ namespace Sporefront.AI
                             && a.id != feintArmy.id && !IsScoutArmy(a)
                             && !aiState.activeRaidArmies.Contains(a.id)
                             && a.GetTotalUnits() >= 5)
-                        .OrderByDescending(a => a.GetTotalUnits())
-                        .ToList();
+                        .OrderByDescending(a => a.GetTotalUnits());
 
+                    int mainArmyCount = 0;
                     foreach (var army in mainArmies)
                     {
                         // Send to opposite approach, then they'll path to enemy CC
                         commands.Add(new AIMoveCommand(playerID, army.id, oppositeApproach, true));
+                        mainArmyCount++;
                     }
 
-                    if (mainArmies.Count > 0)
+                    if (mainArmyCount > 0)
                     {
-                        DebugLog.Log(string.Format("AI {0}: Feint successful! Enemy responded — sending {1} armies from opposite direction ({2},{3})",
-                            playerID, mainArmies.Count, oppositeApproach.q, oppositeApproach.r));
+                        DebugLog.Log($"AI {playerID}: Feint successful! Enemy responded — sending {mainArmyCount} armies from opposite direction ({oppositeApproach.q},{oppositeApproach.r})");
                     }
                 }
 
@@ -1204,8 +1188,7 @@ namespace Sporefront.AI
             // Priority 1: Nearest friendly fort or tower within 8 tiles
             var defensiveBuildings = gameState.GetBuildingsForPlayer(playerID)
                 .Where(b => (b.buildingType == BuildingType.WoodenFort || b.buildingType == BuildingType.Tower ||
-                             b.buildingType == BuildingType.Castle) && b.IsOperational)
-                .ToList();
+                             b.buildingType == BuildingType.Castle) && b.IsOperational);
 
             BuildingData bestDefense = null;
             int bestDefenseDist = int.MaxValue;
@@ -1315,20 +1298,23 @@ namespace Sporefront.AI
                     {
                         aiState.knownEnemyBases.Add(building.coordinate);
                         aiState.enemyBaseFound = true;
-                        DebugLog.Log(string.Format("AI {0}: Found enemy base at ({1}, {2})", playerID, building.coordinate.q, building.coordinate.r));
+                        DebugLog.Log($"AI {playerID}: Found enemy base at ({building.coordinate.q}, {building.coordinate.r})");
                     }
                 }
             }
 
             // Feature 1: Early game deliberate scouting — send ANY fast army to explore
-            if (!aiState.earlyScoutDispatched && gameState.currentTime < 120.0 && gameState.currentTime >= GameConfig.AI.Scouting.EarlyScoutTime)
+            if (!aiState.earlyScoutDispatched && gameState.currentTime < GameConfig.AI.Scouting.EarlyScoutWindow && gameState.currentTime >= GameConfig.AI.Scouting.EarlyScoutTime)
             {
                 // Find the fastest idle army (prefer scouts, but use any army)
-                var earlyScoutCandidate = gameState.GetArmiesForPlayer(playerID)
-                    .Where(a => !a.isInCombat && a.currentPath == null && a.GetTotalUnits() <= 5)
-                    .OrderByDescending(a => IsScoutArmy(a) ? 1 : 0)
-                    .ThenByDescending(a => IsFastArmy(a) ? 1 : 0)
-                    .FirstOrDefault();
+                ArmyData earlyScoutCandidate = null;
+                int bestScore = -1;
+                foreach (var a in gameState.GetArmiesForPlayer(playerID))
+                {
+                    if (a.isInCombat || a.currentPath != null || a.GetTotalUnits() > GameConfig.AI.Hunting.MaxScoutCandidateUnits) continue;
+                    int score = (IsScoutArmy(a) ? 2 : 0) + (IsFastArmy(a) ? 1 : 0);
+                    if (score > bestScore) { bestScore = score; earlyScoutCandidate = a; }
+                }
 
                 if (earlyScoutCandidate != null)
                 {
@@ -1340,14 +1326,13 @@ namespace Sporefront.AI
 
                     commands.Add(new AIMoveCommand(playerID, earlyScoutCandidate.id, target.Value, true));
                     aiState.earlyScoutDispatched = true;
-                    DebugLog.Log(string.Format("AI {0}: Early scout dispatched to ({1},{2})", playerID, target.Value.q, target.Value.r));
+                    DebugLog.Log($"AI {playerID}: Early scout dispatched to ({target.Value.q},{target.Value.r})");
                 }
             }
 
             // Find scout armies
             var scoutArmies = gameState.GetArmiesForPlayer(playerID)
-                .Where(a => IsScoutArmy(a) && !a.isInCombat && a.currentPath == null)
-                .ToList();
+                .Where(a => IsScoutArmy(a) && !a.isInCombat && a.currentPath == null);
 
             foreach (var scout in scoutArmies)
             {
@@ -1520,8 +1505,7 @@ namespace Sporefront.AI
             aiState.activeRaidArmies.Add(raider.id);
             aiState.lastRaidTime = currentTime;
 
-            DebugLog.Log(string.Format("AI {0}: Sending raid party ({1} units) to ({2},{3})",
-                playerID, raider.GetTotalUnits(), raidTarget.q, raidTarget.r));
+            DebugLog.Log($"AI {playerID}: Sending raid party ({raider.GetTotalUnits()} units) to ({raidTarget.q},{raidTarget.r})");
 
             return commands;
         }
@@ -1563,8 +1547,7 @@ namespace Sporefront.AI
                     // Retreat toward our CC
                     commands.Add(new AIMoveCommand(playerID, army.id, cityCenter.coordinate, true));
                     toRemove.Add(raidArmyID);
-                    DebugLog.Log(string.Format("AI {0}: Raid party fleeing from ({1},{2})",
-                        playerID, army.coordinate.q, army.coordinate.r));
+                    DebugLog.Log($"AI {playerID}: Raid party fleeing from ({army.coordinate.q},{army.coordinate.r})");
                 }
             }
 
@@ -1804,7 +1787,7 @@ namespace Sporefront.AI
             }
 
             aiState.lastMultiObjectiveTime = currentTime;
-            DebugLog.Log(string.Format("AI {0}: Multi-objective attack with {1} armies", playerID, Math.Min(3, idleArmies.Count)));
+            DebugLog.Log($"AI {playerID}: Multi-objective attack with {Math.Min(3, idleArmies.Count)} armies");
 
             return commands;
         }
@@ -1902,9 +1885,9 @@ namespace Sporefront.AI
 
             if (aiState.rallyPoints.Count > 0)
             {
-                DebugLog.Log(string.Format("AI {0}: Computed {1} rally points", playerID, aiState.rallyPoints.Count));
+                DebugLog.Log($"AI {playerID}: Computed {aiState.rallyPoints.Count} rally points");
                 foreach (var rp in aiState.rallyPoints)
-                    DebugLog.Log(string.Format("   Rally point at ({0},{1})", rp.q, rp.r));
+                    DebugLog.Log($"   Rally point at ({rp.q},{rp.r})");
             }
         }
 
@@ -1922,8 +1905,7 @@ namespace Sporefront.AI
             var commands = new List<IEngineCommand>();
             var playerID = aiState.playerID;
 
-            if (currentTime - aiState.lastMergeCheckTime < 5.0) return commands;
-            aiState.lastMergeCheckTime = currentTime;
+            if (!AIHelper.ShouldExecute(ref aiState.lastMergeCheckTime, currentTime, 5.0)) return commands;
 
             var idleArmies = gameState.GetArmiesForPlayer(playerID)
                 .Where(a => !a.isInCombat && a.currentPath == null && !IsScoutArmy(a)
@@ -1970,9 +1952,7 @@ namespace Sporefront.AI
                         merged.Add(sourceID);
                         merged.Add(targetID);
 
-                        DebugLog.Log(string.Format("AI {0}: Merging armies ({1}+{2} units) at ({3},{4})",
-                            playerID, armyA.GetTotalUnits(), armyB.GetTotalUnits(),
-                            armyA.coordinate.q, armyA.coordinate.r));
+                        DebugLog.Log($"AI {playerID}: Merging armies ({armyA.GetTotalUnits()}+{armyB.GetTotalUnits()} units) at ({armyA.coordinate.q},{armyA.coordinate.r})");
                         break; // One merge per army per cycle
                     }
                     else if (distance <= 3)
@@ -2008,9 +1988,8 @@ namespace Sporefront.AI
             var commands = new List<IEngineCommand>();
             var playerID = aiState.playerID;
 
-            if (currentTime - aiState.lastCommanderCheckTime < GameConfig.AI.Commander.CheckInterval)
+            if (!AIHelper.ShouldExecute(ref aiState.lastCommanderCheckTime, currentTime, GameConfig.AI.Commander.CheckInterval))
                 return commands;
-            aiState.lastCommanderCheckTime = currentTime;
 
             var commanders = gameState.GetCommandersForPlayer(playerID);
             if (commanders.Count == 0) return commands;
@@ -2062,9 +2041,7 @@ namespace Sporefront.AI
             if (bestCommander != null && bestArmy != null)
             {
                 commands.Add(new AIAssignCommanderCommand(playerID, bestCommander.id, bestArmy.id));
-                DebugLog.Log(string.Format("AI {0}: Reassigning commander {1} ({2}) to army at ({3},{4}) — improvement: {5:F0}",
-                    playerID, bestCommander.name, bestCommander.specialty.DisplayName(),
-                    bestArmy.coordinate.q, bestArmy.coordinate.r, bestImprovement));
+                DebugLog.Log($"AI {playerID}: Reassigning commander {bestCommander.name} ({bestCommander.specialty.DisplayName()}) to army at ({bestArmy.coordinate.q},{bestArmy.coordinate.r}) — improvement: {bestImprovement:F0}");
             }
 
             return commands;

--- a/Sporefront/Assets/Scripts/AI/AIResearchPlanner.cs
+++ b/Sporefront/Assets/Scripts/AI/AIResearchPlanner.cs
@@ -23,6 +23,98 @@ namespace Sporefront.AI
         private readonly double researchCheckInterval = GameConfig.AI.Intervals.ResearchCheck;
 
         // ================================================================
+        // Data-Driven State × Category Bonuses
+        // ================================================================
+
+        private static readonly Dictionary<(AIState, ResearchCategory), double> StateCategoryBonuses =
+            new Dictionary<(AIState, ResearchCategory), double>
+            {
+                { (AIState.Peace, ResearchCategory.Economic), 30.0 },
+                { (AIState.Alert, ResearchCategory.Military), 25.0 },
+                { (AIState.Defense, ResearchCategory.Military), 30.0 },
+                { (AIState.Attack, ResearchCategory.Military), 30.0 },
+            };
+
+        // Alert non-military fallback handled separately (all non-Military categories get +15)
+
+        // ================================================================
+        // Data-Driven State × ResearchType Bonuses
+        // ================================================================
+
+        private static readonly Dictionary<(AIState, ResearchType), double> StateResearchBonuses =
+            new Dictionary<(AIState, ResearchType), double>
+            {
+                // Peace: prioritize economy
+                { (AIState.Peace, ResearchType.FarmGatheringI), 15.0 },
+                { (AIState.Peace, ResearchType.FarmGatheringII), 15.0 },
+                { (AIState.Peace, ResearchType.FarmGatheringIII), 15.0 },
+                { (AIState.Peace, ResearchType.LumberCampGatheringI), 12.0 },
+                { (AIState.Peace, ResearchType.LumberCampGatheringII), 12.0 },
+                { (AIState.Peace, ResearchType.LumberCampGatheringIII), 12.0 },
+                { (AIState.Peace, ResearchType.MiningCampGatheringI), 10.0 },
+                { (AIState.Peace, ResearchType.MiningCampGatheringII), 10.0 },
+                { (AIState.Peace, ResearchType.MiningCampGatheringIII), 10.0 },
+                { (AIState.Peace, ResearchType.PopulationCapacityI), 8.0 },
+                { (AIState.Peace, ResearchType.PopulationCapacityII), 8.0 },
+                { (AIState.Peace, ResearchType.PopulationCapacityIII), 8.0 },
+                { (AIState.Peace, ResearchType.BuildingSpeedI), 5.0 },
+                { (AIState.Peace, ResearchType.BuildingSpeedII), 5.0 },
+                { (AIState.Peace, ResearchType.BuildingSpeedIII), 5.0 },
+                // Alert: armor + training speed
+                { (AIState.Alert, ResearchType.InfantryMeleeArmorI), 10.0 },
+                { (AIState.Alert, ResearchType.InfantryMeleeArmorII), 10.0 },
+                { (AIState.Alert, ResearchType.InfantryMeleeArmorIII), 10.0 },
+                { (AIState.Alert, ResearchType.InfantryPierceArmorI), 10.0 },
+                { (AIState.Alert, ResearchType.InfantryPierceArmorII), 10.0 },
+                { (AIState.Alert, ResearchType.InfantryPierceArmorIII), 10.0 },
+                { (AIState.Alert, ResearchType.MilitaryTrainingSpeedI), 15.0 },
+                { (AIState.Alert, ResearchType.MilitaryTrainingSpeedII), 15.0 },
+                { (AIState.Alert, ResearchType.MilitaryTrainingSpeedIII), 15.0 },
+                // Defense: fortification + armor + retreat
+                { (AIState.Defense, ResearchType.FortifiedBuildingsI), 20.0 },
+                { (AIState.Defense, ResearchType.FortifiedBuildingsII), 20.0 },
+                { (AIState.Defense, ResearchType.FortifiedBuildingsIII), 20.0 },
+                { (AIState.Defense, ResearchType.BuildingBludgeonArmorI), 18.0 },
+                { (AIState.Defense, ResearchType.BuildingBludgeonArmorII), 18.0 },
+                { (AIState.Defense, ResearchType.BuildingBludgeonArmorIII), 18.0 },
+                { (AIState.Defense, ResearchType.InfantryMeleeArmorI), 12.0 },
+                { (AIState.Defense, ResearchType.InfantryMeleeArmorII), 12.0 },
+                { (AIState.Defense, ResearchType.InfantryMeleeArmorIII), 12.0 },
+                { (AIState.Defense, ResearchType.CavalryMeleeArmorI), 12.0 },
+                { (AIState.Defense, ResearchType.CavalryMeleeArmorII), 12.0 },
+                { (AIState.Defense, ResearchType.CavalryMeleeArmorIII), 12.0 },
+                { (AIState.Defense, ResearchType.RetreatSpeedI), 8.0 },
+                { (AIState.Defense, ResearchType.RetreatSpeedII), 8.0 },
+                { (AIState.Defense, ResearchType.RetreatSpeedIII), 8.0 },
+                // Attack: offense + siege + march speed
+                { (AIState.Attack, ResearchType.InfantryMeleeAttackI), 15.0 },
+                { (AIState.Attack, ResearchType.InfantryMeleeAttackII), 15.0 },
+                { (AIState.Attack, ResearchType.InfantryMeleeAttackIII), 15.0 },
+                { (AIState.Attack, ResearchType.CavalryMeleeAttackI), 15.0 },
+                { (AIState.Attack, ResearchType.CavalryMeleeAttackII), 15.0 },
+                { (AIState.Attack, ResearchType.CavalryMeleeAttackIII), 15.0 },
+                { (AIState.Attack, ResearchType.PiercingDamageI), 12.0 },
+                { (AIState.Attack, ResearchType.PiercingDamageII), 12.0 },
+                { (AIState.Attack, ResearchType.PiercingDamageIII), 12.0 },
+                { (AIState.Attack, ResearchType.MarchSpeedI), 10.0 },
+                { (AIState.Attack, ResearchType.MarchSpeedII), 10.0 },
+                { (AIState.Attack, ResearchType.MarchSpeedIII), 10.0 },
+                { (AIState.Attack, ResearchType.SiegeBludgeonDamageI), 15.0 },
+                { (AIState.Attack, ResearchType.SiegeBludgeonDamageII), 15.0 },
+                { (AIState.Attack, ResearchType.SiegeBludgeonDamageIII), 15.0 },
+                // Retreat: escape + survivability
+                { (AIState.Retreat, ResearchType.RetreatSpeedI), 25.0 },
+                { (AIState.Retreat, ResearchType.RetreatSpeedII), 25.0 },
+                { (AIState.Retreat, ResearchType.RetreatSpeedIII), 25.0 },
+                { (AIState.Retreat, ResearchType.InfantryMeleeArmorI), 15.0 },
+                { (AIState.Retreat, ResearchType.InfantryMeleeArmorII), 15.0 },
+                { (AIState.Retreat, ResearchType.InfantryMeleeArmorIII), 15.0 },
+                { (AIState.Retreat, ResearchType.CavalryMeleeArmorI), 15.0 },
+                { (AIState.Retreat, ResearchType.CavalryMeleeArmorII), 15.0 },
+                { (AIState.Retreat, ResearchType.CavalryMeleeArmorIII), 15.0 },
+            };
+
+        // ================================================================
         // Research Commands
         // ================================================================
 
@@ -31,8 +123,7 @@ namespace Sporefront.AI
             var commands = new List<IEngineCommand>();
             var playerID = aiState.playerID;
 
-            if (currentTime - aiState.lastResearchCheckTime < researchCheckInterval) return commands;
-            aiState.lastResearchCheckTime = currentTime;
+            if (!AIHelper.ShouldExecute(ref aiState.lastResearchCheckTime, currentTime, researchCheckInterval)) return commands;
 
             var player = gameState.GetPlayer(playerID);
             if (player == null) return commands;
@@ -45,7 +136,7 @@ namespace Sporefront.AI
                 if (CanAffordResearch(bestResearch.Value, playerID, gameState))
                 {
                     commands.Add(new AIStartResearchCommand(playerID, bestResearch.Value));
-                    DebugLog.Log(string.Format("AI starting research: {0}", bestResearch.Value.DisplayName()));
+                    DebugLog.Log($"AI starting research: {bestResearch.Value.DisplayName()}");
                 }
             }
 
@@ -90,142 +181,19 @@ namespace Sporefront.AI
             // Base score: prefer lower tier research (cheaper, faster)
             score += (4 - research.Tier()) * 10.0;
 
-            // State-based priorities
-            switch (aiState.currentState)
-            {
-                case AIState.Peace:
-                    if (research.Category() == ResearchCategory.Economic)
-                    {
-                        score += 30.0;
-                        switch (research)
-                        {
-                            case ResearchType.FarmGatheringI:
-                            case ResearchType.FarmGatheringII:
-                            case ResearchType.FarmGatheringIII:
-                                score += 15.0; break;
-                            case ResearchType.LumberCampGatheringI:
-                            case ResearchType.LumberCampGatheringII:
-                            case ResearchType.LumberCampGatheringIII:
-                                score += 12.0; break;
-                            case ResearchType.MiningCampGatheringI:
-                            case ResearchType.MiningCampGatheringII:
-                            case ResearchType.MiningCampGatheringIII:
-                                score += 10.0; break;
-                            case ResearchType.PopulationCapacityI:
-                            case ResearchType.PopulationCapacityII:
-                            case ResearchType.PopulationCapacityIII:
-                                score += 8.0; break;
-                            case ResearchType.BuildingSpeedI:
-                            case ResearchType.BuildingSpeedII:
-                            case ResearchType.BuildingSpeedIII:
-                                score += 5.0; break;
-                        }
-                    }
-                    break;
+            // State-based priorities (data-driven)
+            var state = aiState.currentState;
+            var category = research.Category();
 
-                case AIState.Alert:
-                    if (research.Category() == ResearchCategory.Military)
-                    {
-                        score += 25.0;
-                        switch (research)
-                        {
-                            case ResearchType.InfantryMeleeArmorI:
-                            case ResearchType.InfantryMeleeArmorII:
-                            case ResearchType.InfantryMeleeArmorIII:
-                            case ResearchType.InfantryPierceArmorI:
-                            case ResearchType.InfantryPierceArmorII:
-                            case ResearchType.InfantryPierceArmorIII:
-                                score += 10.0; break;
-                            case ResearchType.MilitaryTrainingSpeedI:
-                            case ResearchType.MilitaryTrainingSpeedII:
-                            case ResearchType.MilitaryTrainingSpeedIII:
-                                score += 15.0; break;
-                        }
-                    }
-                    else
-                    {
-                        score += 15.0;
-                    }
-                    break;
+            double categoryBonus;
+            if (StateCategoryBonuses.TryGetValue((state, category), out categoryBonus))
+                score += categoryBonus;
+            else if (state == AIState.Alert && category != ResearchCategory.Military)
+                score += 15.0; // Alert: non-military fallback
 
-                case AIState.Defense:
-                    if (research.Category() == ResearchCategory.Military)
-                    {
-                        score += 30.0;
-                        switch (research)
-                        {
-                            case ResearchType.FortifiedBuildingsI:
-                            case ResearchType.FortifiedBuildingsII:
-                            case ResearchType.FortifiedBuildingsIII:
-                                score += 20.0; break;
-                            case ResearchType.BuildingBludgeonArmorI:
-                            case ResearchType.BuildingBludgeonArmorII:
-                            case ResearchType.BuildingBludgeonArmorIII:
-                                score += 18.0; break;
-                            case ResearchType.InfantryMeleeArmorI:
-                            case ResearchType.InfantryMeleeArmorII:
-                            case ResearchType.InfantryMeleeArmorIII:
-                            case ResearchType.CavalryMeleeArmorI:
-                            case ResearchType.CavalryMeleeArmorII:
-                            case ResearchType.CavalryMeleeArmorIII:
-                                score += 12.0; break;
-                            case ResearchType.RetreatSpeedI:
-                            case ResearchType.RetreatSpeedII:
-                            case ResearchType.RetreatSpeedIII:
-                                score += 8.0; break;
-                        }
-                    }
-                    break;
-
-                case AIState.Attack:
-                    if (research.Category() == ResearchCategory.Military)
-                    {
-                        score += 30.0;
-                        switch (research)
-                        {
-                            case ResearchType.InfantryMeleeAttackI:
-                            case ResearchType.InfantryMeleeAttackII:
-                            case ResearchType.InfantryMeleeAttackIII:
-                            case ResearchType.CavalryMeleeAttackI:
-                            case ResearchType.CavalryMeleeAttackII:
-                            case ResearchType.CavalryMeleeAttackIII:
-                                score += 15.0; break;
-                            case ResearchType.PiercingDamageI:
-                            case ResearchType.PiercingDamageII:
-                            case ResearchType.PiercingDamageIII:
-                                score += 12.0; break;
-                            case ResearchType.MarchSpeedI:
-                            case ResearchType.MarchSpeedII:
-                            case ResearchType.MarchSpeedIII:
-                                score += 10.0; break;
-                            case ResearchType.SiegeBludgeonDamageI:
-                            case ResearchType.SiegeBludgeonDamageII:
-                            case ResearchType.SiegeBludgeonDamageIII:
-                                score += 15.0; break;
-                        }
-                    }
-                    break;
-
-                case AIState.Retreat:
-                    if (research.Category() == ResearchCategory.Military)
-                    {
-                        switch (research)
-                        {
-                            case ResearchType.RetreatSpeedI:
-                            case ResearchType.RetreatSpeedII:
-                            case ResearchType.RetreatSpeedIII:
-                                score += 25.0; break;
-                            case ResearchType.InfantryMeleeArmorI:
-                            case ResearchType.InfantryMeleeArmorII:
-                            case ResearchType.InfantryMeleeArmorIII:
-                            case ResearchType.CavalryMeleeArmorI:
-                            case ResearchType.CavalryMeleeArmorII:
-                            case ResearchType.CavalryMeleeArmorIII:
-                                score += 15.0; break;
-                        }
-                    }
-                    break;
-            }
+            double researchBonus;
+            if (StateResearchBonuses.TryGetValue((state, research), out researchBonus))
+                score += researchBonus;
 
             // Penalize Tier I research in gated branches when gate building isn't built yet
             if (research.Tier() == 1)
@@ -233,8 +201,7 @@ namespace Sporefront.AI
                 var gateBuildingType = research.Branch().GateBuildingType();
                 if (gateBuildingType.HasValue)
                 {
-                    bool hasGateBuilding = gameState.GetBuildingsForPlayer(aiState.playerID)
-                        .Any(b => b.buildingType == gateBuildingType.Value && b.IsOperational);
+                    bool hasGateBuilding = gameState.HasBuilding(aiState.playerID, gateBuildingType.Value, operationalOnly: true);
                     if (!hasGateBuilding)
                     {
                         score -= 5.0;
@@ -331,65 +298,21 @@ namespace Sporefront.AI
                     score -= 5.0; // Penalty for over-specializing
             }
 
-            // Faction synergy bonuses
-            var faction = player?.faction ?? FactionType.None;
+            // Faction synergy bonuses (data-driven via FactionAIConfig)
+            var factionConfig = FactionAIConfig.Get(player?.faction ?? FactionType.None);
 
-            if (faction == FactionType.Morel)
+            double factionBonus;
+            if (factionConfig.ResearchBonuses.TryGetValue(research, out factionBonus))
+                score += factionBonus;
+
+            if (factionConfig.ResearchNamePenalties.Count > 0)
             {
-                switch (research)
+                var researchName = research.ToString();
+                foreach (var penalty in factionConfig.ResearchNamePenalties)
                 {
-                    // Lumber gathering synergy (+5% wood bonus)
-                    case ResearchType.LumberCampGatheringI: score += 12.0; break;
-                    case ResearchType.LumberCampGatheringII: score += 10.0; break;
-                    // Faction-exclusive research
-                    case ResearchType.BurnAreas: score += 15.0; break;
-                    case ResearchType.ToxicSpores: score += 12.0; break;
-                    case ResearchType.LethalSpores: score += 10.0; break;
-                    // Infantry research (core army type)
-                    case ResearchType.InfantryMeleeAttackI:
-                    case ResearchType.InfantryMeleeAttackII:
-                    case ResearchType.InfantryMeleeAttackIII:
-                        score += 8.0; break;
-                    case ResearchType.InfantryMeleeArmorI:
-                    case ResearchType.InfantryMeleeArmorII:
-                    case ResearchType.InfantryMeleeArmorIII:
-                        score += 6.0; break;
-                    // March speed synergy with scouting focus
-                    case ResearchType.MarchSpeedI:
-                    case ResearchType.MarchSpeedII:
-                    case ResearchType.MarchSpeedIII:
-                        score += 5.0; break;
+                    if (researchName.Contains(penalty.pattern))
+                        score += penalty.penalty;
                 }
-                // Deprioritize T3-blocked categories (diminishing returns)
-                var name = research.ToString();
-                if (name.Contains("Cavalry")) score -= 5.0;
-                if (name.Contains("Siege")) score -= 5.0;
-            }
-            else if (faction == FactionType.Muscaria)
-            {
-                switch (research)
-                {
-                    // Poison research chain (faction-exclusive, high priority)
-                    case ResearchType.IncreasedPoisonDamage: score += 20.0; break;
-                    case ResearchType.ToxinAccumulation: score += 18.0; break;
-                    case ResearchType.SporeBurst: score += 15.0; break;
-                    // Mining gathering synergy (+5% stone/ore bonus)
-                    case ResearchType.MiningCampGatheringI: score += 12.0; break;
-                    case ResearchType.MiningCampGatheringII: score += 10.0; break;
-                    // Ranged/siege research (core army types)
-                    case ResearchType.PiercingDamageI:
-                    case ResearchType.PiercingDamageII:
-                    case ResearchType.PiercingDamageIII:
-                        score += 8.0; break;
-                    case ResearchType.SiegeBludgeonDamageI:
-                    case ResearchType.SiegeBludgeonDamageII:
-                    case ResearchType.SiegeBludgeonDamageIII:
-                        score += 8.0; break;
-                }
-                // Deprioritize T3-blocked categories
-                var name = research.ToString();
-                if (name.Contains("InfantryMelee")) score -= 5.0;
-                if (name.Contains("Cavalry")) score -= 5.0;
             }
 
             return score;
@@ -461,14 +384,7 @@ namespace Sporefront.AI
         {
             var player = gameState.GetPlayer(playerID);
             if (player == null) return false;
-
-            var cost = research.Cost();
-            foreach (var kvp in cost)
-            {
-                if (!player.HasResource(kvp.Key, kvp.Value))
-                    return false;
-            }
-            return true;
+            return player.CanAfford(research.Cost());
         }
     }
 }

--- a/Sporefront/Assets/Scripts/AI/Commands/AIAssignCommanderCommand.cs
+++ b/Sporefront/Assets/Scripts/AI/Commands/AIAssignCommanderCommand.cs
@@ -37,12 +37,8 @@ namespace Sporefront.AI.Commands
             if (!commander.ownerID.HasValue || commander.ownerID.Value != PlayerID)
                 return EngineCommandResult.Failure("Commander not owned by player");
 
-            var targetArmy = state.GetArmy(targetArmyID);
-            if (targetArmy == null)
-                return EngineCommandResult.Failure("Target army not found");
-
-            if (!targetArmy.ownerID.HasValue || targetArmy.ownerID.Value != PlayerID)
-                return EngineCommandResult.Failure("Target army not owned by player");
+            var fail = ValidateOwnedArmy(state, targetArmyID, out var targetArmy);
+            if (fail != null) return fail;
 
             if (commander.assignedArmyID.HasValue && commander.assignedArmyID.Value == targetArmyID)
                 return EngineCommandResult.Failure("Commander already assigned to target army");
@@ -59,9 +55,8 @@ namespace Sporefront.AI.Commands
             if (commander == null)
                 return EngineCommandResult.Failure("Commander not found");
 
-            var targetArmy = state.GetArmy(targetArmyID);
-            if (targetArmy == null)
-                return EngineCommandResult.Failure("Target army not found");
+            var fail = ValidateArmy(state, targetArmyID, out var targetArmy);
+            if (fail != null) return fail;
 
             // Unlink commander from their current army (if any)
             if (commander.assignedArmyID.HasValue)
@@ -83,8 +78,7 @@ namespace Sporefront.AI.Commands
             commander.assignedArmyID = targetArmyID;
             targetArmy.commanderID = commanderID;
 
-            DebugLog.Log(string.Format("AI reassigned commander {0} to army at ({1},{2})",
-                commander.name, targetArmy.coordinate.q, targetArmy.coordinate.r));
+            DebugLog.Log($"AI reassigned commander {commander.name} to army at ({targetArmy.coordinate.q},{targetArmy.coordinate.r})");
 
             return EngineCommandResult.Success(new List<StateChange>());
         }

--- a/Sporefront/Assets/Scripts/AI/Commands/AIBuildCommand.cs
+++ b/Sporefront/Assets/Scripts/AI/Commands/AIBuildCommand.cs
@@ -31,35 +31,13 @@ namespace Sporefront.AI.Commands
 
         private double GetTerrainCostMultiplier(GameState state)
         {
-            var occupiedCoords = buildingType.GetOccupiedCoordinates(coordinate, rotation);
-            bool hasMountain = occupiedCoords.Any(c => state.mapData.GetTerrain(c) == TerrainType.Mountain);
-            bool hasHighland = hasMountain || occupiedCoords.Any(c =>
-            {
-                var t = state.mapData.GetTerrain(c);
-                return t == TerrainType.Hill;
-            });
-            double multiplier = hasMountain ? GameConfig.Terrain.MountainBuildingCostMultiplier : 1.0;
-
-            // Apply faction mountain building cost reduction on highland terrain
-            if (hasHighland)
-            {
-                var player = state.GetPlayer(PlayerID);
-                if (player != null)
-                {
-                    double reduction = player.faction.MountainBuildCostReduction();
-                    if (reduction > 0)
-                        multiplier *= (1.0 - reduction);
-                }
-            }
-
-            return multiplier;
+            return BuildHelper.GetTerrainCostMultiplier(state, buildingType, coordinate, rotation, PlayerID);
         }
 
         public override EngineCommandResult Validate(GameState state)
         {
-            var player = state.GetPlayer(PlayerID);
-            if (player == null)
-                return EngineCommandResult.Failure("Player not found");
+            var fail = ValidatePlayer(state, out var player);
+            if (fail != null) return fail;
 
             // Check faction-exclusive building restrictions
             if (buildingType.IsFactionExclusive() && buildingType.ExclusiveFaction() != player.faction)
@@ -78,9 +56,7 @@ namespace Sporefront.AI.Commands
                 return EngineCommandResult.Failure("Cannot build at this location");
 
             // Require an idle villager — AI must assign a builder just like the player does
-            var hasIdleVillager = state.GetVillagerGroupsForPlayer(PlayerID)
-                .Any(g => g.currentTask.IsIdle && g.currentPath == null);
-            if (!hasIdleVillager)
+            if (BuildHelper.FindNearestIdleVillager(state, PlayerID, coordinate) == null)
                 return EngineCommandResult.Failure("No idle villager available to build");
 
             return EngineCommandResult.Success(new List<StateChange>());
@@ -88,9 +64,8 @@ namespace Sporefront.AI.Commands
 
         public override EngineCommandResult Execute(GameState state, StateChangeBuilder changeBuilder)
         {
-            var player = state.GetPlayer(PlayerID);
-            if (player == null)
-                return EngineCommandResult.Failure("Player not found");
+            var fail = ValidatePlayer(state, out var player);
+            if (fail != null) return fail;
 
             // Deduct resources with terrain multiplier
             double costMultiplier = GetTerrainCostMultiplier(state);
@@ -115,14 +90,10 @@ namespace Sporefront.AI.Commands
             });
 
             // Find nearest idle villager to dispatch as builder (validated to exist)
-            var idleVillagers = state.GetVillagerGroupsForPlayer(PlayerID)
-                .Where(g => g.currentTask.IsIdle && g.currentPath == null)
-                .OrderBy(g => g.coordinate.Distance(coordinate))
-                .ToList();
+            var builder = BuildHelper.FindNearestIdleVillager(state, PlayerID, coordinate);
 
-            if (idleVillagers.Count > 0)
+            if (builder != null)
             {
-                var builder = idleVillagers[0];
                 builder.AssignTask(new BuildingTask(building.id), coordinate, building.id);
 
                 if (builder.coordinate.Equals(coordinate))
@@ -169,7 +140,7 @@ namespace Sporefront.AI.Commands
                 return EngineCommandResult.Failure("No idle villager available to build");
             }
 
-            DebugLog.Log(string.Format("AI built {0} at ({1}, {2})", buildingType, coordinate.q, coordinate.r));
+            DebugLog.Log($"AI built {buildingType} at ({coordinate.q}, {coordinate.r})");
 
             return EngineCommandResult.Success(changeBuilder.Build().changes);
         }

--- a/Sporefront/Assets/Scripts/AI/Commands/AIDeployArmyCommand.cs
+++ b/Sporefront/Assets/Scripts/AI/Commands/AIDeployArmyCommand.cs
@@ -28,18 +28,14 @@ namespace Sporefront.AI.Commands
 
         public override EngineCommandResult Validate(GameState state)
         {
-            var building = state.GetBuilding(buildingID);
-            if (building == null)
-                return EngineCommandResult.Failure("Building not found");
-
-            if (!building.ownerID.HasValue || building.ownerID.Value != PlayerID)
-                return EngineCommandResult.Failure("Not your building");
+            var fail = ValidateOwnedBuilding(state, buildingID, out var building);
+            if (fail != null) return fail;
 
             foreach (var kvp in composition)
             {
                 int available = building.garrison.ContainsKey(kvp.Key) ? building.garrison[kvp.Key] : 0;
                 if (available < kvp.Value)
-                    return EngineCommandResult.Failure(string.Format("Not enough {0}", kvp.Key.DisplayName()));
+                    return EngineCommandResult.Failure($"Not enough {kvp.Key.DisplayName()}");
             }
 
             return EngineCommandResult.Success(new List<StateChange>());
@@ -47,9 +43,8 @@ namespace Sporefront.AI.Commands
 
         public override EngineCommandResult Execute(GameState state, StateChangeBuilder changeBuilder)
         {
-            var building = state.GetBuilding(buildingID);
-            if (building == null)
-                return EngineCommandResult.Failure("Building not found");
+            var fail = ValidateOwnedBuilding(state, buildingID, out var building);
+            if (fail != null) return fail;
 
             // Remove units from garrison
             foreach (var kvp in composition)
@@ -114,8 +109,7 @@ namespace Sporefront.AI.Commands
                 composition = compositionStrings
             });
 
-            DebugLog.Log(string.Format("AI deployed army with {0} units, commander: {1} ({2})",
-                army.GetTotalUnits(), commander.name, specialty));
+            DebugLog.Log($"AI deployed army with {army.GetTotalUnits()} units, commander: {commander.name} ({specialty})");
 
             return EngineCommandResult.Success(changeBuilder.Build().changes);
         }

--- a/Sporefront/Assets/Scripts/AI/Commands/AIDeployVillagersCommand.cs
+++ b/Sporefront/Assets/Scripts/AI/Commands/AIDeployVillagersCommand.cs
@@ -26,12 +26,8 @@ namespace Sporefront.AI.Commands
 
         public override EngineCommandResult Validate(GameState state)
         {
-            var building = state.GetBuilding(buildingID);
-            if (building == null)
-                return EngineCommandResult.Failure("Building not found");
-
-            if (!building.ownerID.HasValue || building.ownerID.Value != PlayerID)
-                return EngineCommandResult.Failure("Not your building");
+            var fail = ValidateOwnedBuilding(state, buildingID, out var building);
+            if (fail != null) return fail;
 
             if (building.villagerGarrison < quantity)
                 return EngineCommandResult.Failure("Not enough villagers in garrison");
@@ -41,9 +37,8 @@ namespace Sporefront.AI.Commands
 
         public override EngineCommandResult Execute(GameState state, StateChangeBuilder changeBuilder)
         {
-            var building = state.GetBuilding(buildingID);
-            if (building == null)
-                return EngineCommandResult.Failure("Building not found");
+            var fail = ValidateOwnedBuilding(state, buildingID, out var building);
+            if (fail != null) return fail;
 
             // Remove villagers from garrison
             building.villagerGarrison -= quantity;
@@ -71,8 +66,7 @@ namespace Sporefront.AI.Commands
                 quantity = quantity
             });
 
-            DebugLog.Log(string.Format("AI deployed {0} villagers at ({1}, {2})",
-                quantity, spawnCoord.q, spawnCoord.r));
+            DebugLog.Log($"AI deployed {quantity} villagers at ({spawnCoord.q}, {spawnCoord.r})");
 
             return EngineCommandResult.Success(changeBuilder.Build().changes);
         }

--- a/Sporefront/Assets/Scripts/AI/Commands/AIEntrenchCommand.cs
+++ b/Sporefront/Assets/Scripts/AI/Commands/AIEntrenchCommand.cs
@@ -24,12 +24,8 @@ namespace Sporefront.AI.Commands
 
         public override EngineCommandResult Validate(GameState state)
         {
-            var army = state.GetArmy(armyID);
-            if (army == null)
-                return EngineCommandResult.Failure("Army not found");
-
-            if (!army.ownerID.HasValue || army.ownerID.Value != PlayerID)
-                return EngineCommandResult.Failure("Not your army");
+            var fail = ValidateOwnedArmy(state, armyID, out var army);
+            if (fail != null) return fail;
 
             if (army.isEntrenched)
                 return EngineCommandResult.Failure("Already entrenched");
@@ -46,9 +42,8 @@ namespace Sporefront.AI.Commands
             if (army.isRetreating)
                 return EngineCommandResult.Failure("Cannot entrench while retreating");
 
-            var player = state.GetPlayer(PlayerID);
-            if (player == null)
-                return EngineCommandResult.Failure("Player not found");
+            fail = ValidatePlayer(state, out var player);
+            if (fail != null) return fail;
 
             if (!player.HasResource(ResourceType.Wood, GameConfig.Entrenchment.WoodCost))
                 return EngineCommandResult.Failure("Not enough wood");
@@ -69,13 +64,11 @@ namespace Sporefront.AI.Commands
 
         public override EngineCommandResult Execute(GameState state, StateChangeBuilder changeBuilder)
         {
-            var army = state.GetArmy(armyID);
-            if (army == null)
-                return EngineCommandResult.Failure("Army not found");
+            var fail = ValidateOwnedArmy(state, armyID, out var army);
+            if (fail != null) return fail;
 
-            var player = state.GetPlayer(PlayerID);
-            if (player == null)
-                return EngineCommandResult.Failure("Player not found");
+            fail = ValidatePlayer(state, out var player);
+            if (fail != null) return fail;
 
             // Deduct wood cost
             player.RemoveResource(ResourceType.Wood, GameConfig.Entrenchment.WoodCost);
@@ -101,8 +94,7 @@ namespace Sporefront.AI.Commands
                 coordinate = army.coordinate
             });
 
-            DebugLog.Log(string.Format("AIEntrenchCommand: AI army started entrenching at ({0}, {1})",
-                army.coordinate.q, army.coordinate.r));
+            DebugLog.Log($"AIEntrenchCommand: AI army started entrenching at ({army.coordinate.q}, {army.coordinate.r})");
 
             return EngineCommandResult.Success(changeBuilder.Build().changes);
         }

--- a/Sporefront/Assets/Scripts/AI/Commands/AIGatherCommand.cs
+++ b/Sporefront/Assets/Scripts/AI/Commands/AIGatherCommand.cs
@@ -28,12 +28,8 @@ namespace Sporefront.AI.Commands
 
         public override EngineCommandResult Validate(GameState state)
         {
-            var group = state.GetVillagerGroup(villagerGroupID);
-            if (group == null)
-                return EngineCommandResult.Failure("Villager group not found");
-
-            if (!group.ownerID.HasValue || group.ownerID.Value != PlayerID)
-                return EngineCommandResult.Failure("Not your villagers");
+            var fail = ValidateVillagerGroup(state, villagerGroupID, out var group);
+            if (fail != null) return fail;
 
             if (!group.currentTask.IsIdle)
                 return EngineCommandResult.Failure("Villager is busy");
@@ -87,7 +83,7 @@ namespace Sporefront.AI.Commands
                 targetCoordinate = resource.coordinate
             });
 
-            DebugLog.Log(string.Format("AI villagers assigned to gather {0}", resource.resourceType));
+            DebugLog.Log($"AI villagers assigned to gather {resource.resourceType}");
 
             return EngineCommandResult.Success(changeBuilder.Build().changes);
         }

--- a/Sporefront/Assets/Scripts/AI/Commands/AIHuntCommand.cs
+++ b/Sporefront/Assets/Scripts/AI/Commands/AIHuntCommand.cs
@@ -26,12 +26,8 @@ namespace Sporefront.AI.Commands
 
         public override EngineCommandResult Validate(GameState state)
         {
-            var group = state.GetVillagerGroup(villagerGroupID);
-            if (group == null)
-                return EngineCommandResult.Failure("Villager group not found");
-
-            if (!group.ownerID.HasValue || group.ownerID.Value != PlayerID)
-                return EngineCommandResult.Failure("Not your villagers");
+            var fail = ValidateVillagerGroup(state, villagerGroupID, out var group);
+            if (fail != null) return fail;
 
             if (!(group.currentTask is IdleTask))
                 return EngineCommandResult.Failure("Villager not available");
@@ -51,9 +47,8 @@ namespace Sporefront.AI.Commands
 
         public override EngineCommandResult Execute(GameState state, StateChangeBuilder changeBuilder)
         {
-            var group = state.GetVillagerGroup(villagerGroupID);
-            if (group == null)
-                return EngineCommandResult.Failure("Villager group not found");
+            var fail = ValidateVillagerGroup(state, villagerGroupID, out var group);
+            if (fail != null) return fail;
 
             var resource = state.GetResourcePoint(resourcePointID);
             if (resource == null)
@@ -80,8 +75,7 @@ namespace Sporefront.AI.Commands
                 targetCoordinate = resource.coordinate
             });
 
-            DebugLog.Log(string.Format("AIHuntCommand: Villagers assigned to hunt at ({0}, {1})",
-                resource.coordinate.q, resource.coordinate.r));
+            DebugLog.Log($"AIHuntCommand: Villagers assigned to hunt at ({resource.coordinate.q}, {resource.coordinate.r})");
 
             return EngineCommandResult.Success(changeBuilder.Build().changes);
         }

--- a/Sporefront/Assets/Scripts/AI/Commands/AIMergeArmyCommand.cs
+++ b/Sporefront/Assets/Scripts/AI/Commands/AIMergeArmyCommand.cs
@@ -31,17 +31,11 @@ namespace Sporefront.AI.Commands
 
         public override EngineCommandResult Validate(GameState state)
         {
-            var source = state.GetArmy(sourceArmyID);
-            var target = state.GetArmy(targetArmyID);
+            var fail = ValidateOwnedArmy(state, sourceArmyID, out var source);
+            if (fail != null) return fail;
 
-            if (source == null || target == null)
-                return EngineCommandResult.Failure("Army not found");
-
-            if (!source.ownerID.HasValue || source.ownerID.Value != PlayerID)
-                return EngineCommandResult.Failure("Source army not owned by player");
-
-            if (!target.ownerID.HasValue || target.ownerID.Value != PlayerID)
-                return EngineCommandResult.Failure("Target army not owned by player");
+            fail = ValidateOwnedArmy(state, targetArmyID, out var target);
+            if (fail != null) return fail;
 
             if (source.isInCombat || target.isInCombat)
                 return EngineCommandResult.Failure("Cannot merge armies in combat");
@@ -58,11 +52,11 @@ namespace Sporefront.AI.Commands
 
         public override EngineCommandResult Execute(GameState state, StateChangeBuilder changeBuilder)
         {
-            var source = state.GetArmy(sourceArmyID);
-            var target = state.GetArmy(targetArmyID);
+            var fail = ValidateArmy(state, sourceArmyID, out var source);
+            if (fail != null) return fail;
 
-            if (source == null || target == null)
-                return EngineCommandResult.Failure("Army not found");
+            fail = ValidateArmy(state, targetArmyID, out var target);
+            if (fail != null) return fail;
 
             // Merge source units into target
             target.Merge(source);
@@ -77,9 +71,7 @@ namespace Sporefront.AI.Commands
             // Remove the source army from state
             state.RemoveArmy(sourceArmyID);
 
-            DebugLog.Log(string.Format("AI merged army ({0} units) into army ({1} units) at ({2},{3})",
-                source.GetTotalUnits(), target.GetTotalUnits(),
-                target.coordinate.q, target.coordinate.r));
+            DebugLog.Log($"AI merged army ({source.GetTotalUnits()} units) into army ({target.GetTotalUnits()} units) at ({target.coordinate.q},{target.coordinate.r})");
 
             return EngineCommandResult.Success(changeBuilder.Build().changes);
         }

--- a/Sporefront/Assets/Scripts/AI/Commands/AIMoveCommand.cs
+++ b/Sporefront/Assets/Scripts/AI/Commands/AIMoveCommand.cs
@@ -30,24 +30,16 @@ namespace Sporefront.AI.Commands
         {
             if (isArmy)
             {
-                var army = state.GetArmy(entityID);
-                if (army == null)
-                    return EngineCommandResult.Failure("Army not found");
-
-                if (!army.ownerID.HasValue || army.ownerID.Value != PlayerID)
-                    return EngineCommandResult.Failure("Not your army");
+                var fail = ValidateOwnedArmy(state, entityID, out var army);
+                if (fail != null) return fail;
 
                 if (army.isInCombat)
                     return EngineCommandResult.Failure("Cannot move during combat");
             }
             else
             {
-                var group = state.GetVillagerGroup(entityID);
-                if (group == null)
-                    return EngineCommandResult.Failure("Villager group not found");
-
-                if (!group.ownerID.HasValue || group.ownerID.Value != PlayerID)
-                    return EngineCommandResult.Failure("Not your villagers");
+                var fail = ValidateVillagerGroup(state, entityID, out _);
+                if (fail != null) return fail;
             }
 
             if (!state.mapData.IsValidCoordinate(destination))
@@ -84,8 +76,7 @@ namespace Sporefront.AI.Commands
                     path = path
                 });
 
-                DebugLog.Log(string.Format("AIMoveCommand: Army moving to ({0}, {1})",
-                    destination.q, destination.r));
+                DebugLog.Log($"AIMoveCommand: Army moving to ({destination.q}, {destination.r})");
             }
             else
             {

--- a/Sporefront/Assets/Scripts/AI/Commands/AIStartResearchCommand.cs
+++ b/Sporefront/Assets/Scripts/AI/Commands/AIStartResearchCommand.cs
@@ -24,9 +24,8 @@ namespace Sporefront.AI.Commands
 
         public override EngineCommandResult Validate(GameState state)
         {
-            var player = state.GetPlayer(PlayerID);
-            if (player == null)
-                return EngineCommandResult.Failure("Player not found");
+            var fail = ValidatePlayer(state, out var player);
+            if (fail != null) return fail;
 
             if (player.IsResearchActive())
                 return EngineCommandResult.Failure("Research already in progress");
@@ -72,25 +71,20 @@ namespace Sporefront.AI.Commands
                     }
                 }
                 if (!hasBuilding)
-                    return EngineCommandResult.Failure(string.Format("Requires {0}", buildingReq.Value.buildingType));
+                    return EngineCommandResult.Failure($"Requires {buildingReq.Value.buildingType}");
             }
 
             // Check affordability
-            var cost = researchType.Cost();
-            foreach (var kvp in cost)
-            {
-                if (!player.HasResource(kvp.Key, kvp.Value))
-                    return EngineCommandResult.Failure("Insufficient resources");
-            }
+            var fail2 = ValidateCanAfford(player, researchType.Cost());
+            if (fail2 != null) return fail2;
 
             return EngineCommandResult.Success(null);
         }
 
         public override EngineCommandResult Execute(GameState state, StateChangeBuilder changeBuilder)
         {
-            var player = state.GetPlayer(PlayerID);
-            if (player == null)
-                return EngineCommandResult.Failure("Player not found");
+            var fail = ValidatePlayer(state, out var player);
+            if (fail != null) return fail;
 
             string rawValue = researchType.ToString();
 
@@ -112,8 +106,7 @@ namespace Sporefront.AI.Commands
                 startTime = state.currentTime
             });
 
-            DebugLog.Log(string.Format("AIStartResearchCommand: AI started research: {0}",
-                researchType.DisplayName()));
+            DebugLog.Log($"AIStartResearchCommand: AI started research: {researchType.DisplayName()}");
 
             return EngineCommandResult.Success(changeBuilder.Build().changes);
         }

--- a/Sporefront/Assets/Scripts/AI/Commands/AITrainMilitaryCommand.cs
+++ b/Sporefront/Assets/Scripts/AI/Commands/AITrainMilitaryCommand.cs
@@ -27,45 +27,26 @@ namespace Sporefront.AI.Commands
 
         public override EngineCommandResult Validate(GameState state)
         {
-            var building = state.GetBuilding(buildingID);
-            if (building == null)
-                return EngineCommandResult.Failure("Building not found");
+            var fail = ValidateOperationalBuilding(state, buildingID, out var building);
+            if (fail != null) return fail;
 
-            if (!building.ownerID.HasValue || building.ownerID.Value != PlayerID)
-                return EngineCommandResult.Failure("Not your building");
+            fail = ValidatePlayer(state, out var player);
+            if (fail != null) return fail;
 
-            if (!building.IsOperational)
-                return EngineCommandResult.Failure("Building not operational");
-
-            var player = state.GetPlayer(PlayerID);
-            if (player == null)
-                return EngineCommandResult.Failure("Player not found");
-
-            var unitCost = unitType.TrainingCost();
-            foreach (var kvp in unitCost)
-            {
-                int totalCost = kvp.Value * quantity;
-                if (!player.HasResource(kvp.Key, totalCost))
-                    return EngineCommandResult.Failure("Insufficient resources");
-            }
+            fail = ValidateCanAfford(player, unitType.TrainingCost(), quantity);
+            if (fail != null) return fail;
 
             return EngineCommandResult.Success(new List<StateChange>());
         }
 
         public override EngineCommandResult Execute(GameState state, StateChangeBuilder changeBuilder)
         {
-            var building = state.GetBuilding(buildingID);
-            var player = state.GetPlayer(PlayerID);
-            if (building == null || player == null)
-                return EngineCommandResult.Failure("Not found");
+            var fail = ValidateOwnedBuilding(state, buildingID, out var building);
+            if (fail != null) return fail;
+            fail = ValidatePlayer(state, out var player);
+            if (fail != null) return fail;
 
-            // Deduct resources
-            var unitCost = unitType.TrainingCost();
-            foreach (var kvp in unitCost)
-            {
-                int totalCost = kvp.Value * quantity;
-                player.RemoveResource(kvp.Key, totalCost);
-            }
+            player.DeductCost(unitType.TrainingCost(), quantity);
 
             // Start training
             building.StartTraining(unitType, quantity, state.currentTime);
@@ -78,7 +59,7 @@ namespace Sporefront.AI.Commands
                 startTime = state.currentTime
             });
 
-            DebugLog.Log(string.Format("AI training {0}x {1}", quantity, unitType.DisplayName()));
+            DebugLog.Log($"AI training {quantity}x {unitType.DisplayName()}");
 
             return EngineCommandResult.Success(changeBuilder.Build().changes);
         }

--- a/Sporefront/Assets/Scripts/AI/Commands/AITrainVillagerCommand.cs
+++ b/Sporefront/Assets/Scripts/AI/Commands/AITrainVillagerCommand.cs
@@ -25,19 +25,14 @@ namespace Sporefront.AI.Commands
 
         public override EngineCommandResult Validate(GameState state)
         {
-            var building = state.GetBuilding(buildingID);
-            if (building == null)
-                return EngineCommandResult.Failure("Building not found");
-
-            if (!building.ownerID.HasValue || building.ownerID.Value != PlayerID)
-                return EngineCommandResult.Failure("Not your building");
+            var fail = ValidateOwnedBuilding(state, buildingID, out var building);
+            if (fail != null) return fail;
 
             if (!building.CanTrainVillagers())
                 return EngineCommandResult.Failure("Cannot train villagers here");
 
-            var player = state.GetPlayer(PlayerID);
-            if (player == null)
-                return EngineCommandResult.Failure("Player not found");
+            fail = ValidatePlayer(state, out var player);
+            if (fail != null) return fail;
 
             if (!player.HasResource(ResourceType.Food, 50 * quantity))
                 return EngineCommandResult.Failure("Insufficient food");
@@ -47,10 +42,11 @@ namespace Sporefront.AI.Commands
 
         public override EngineCommandResult Execute(GameState state, StateChangeBuilder changeBuilder)
         {
-            var building = state.GetBuilding(buildingID);
-            var player = state.GetPlayer(PlayerID);
-            if (building == null || player == null)
-                return EngineCommandResult.Failure("Not found");
+            var fail = ValidateOwnedBuilding(state, buildingID, out var building);
+            if (fail != null) return fail;
+
+            fail = ValidatePlayer(state, out var player);
+            if (fail != null) return fail;
 
             // Deduct food
             player.RemoveResource(ResourceType.Food, 50 * quantity);
@@ -65,7 +61,7 @@ namespace Sporefront.AI.Commands
                 startTime = state.currentTime
             });
 
-            DebugLog.Log(string.Format("AI training {0} villagers", quantity));
+            DebugLog.Log($"AI training {quantity} villagers");
 
             return EngineCommandResult.Success(changeBuilder.Build().changes);
         }

--- a/Sporefront/Assets/Scripts/AI/Commands/AIUpgradeBuildingCommand.cs
+++ b/Sporefront/Assets/Scripts/AI/Commands/AIUpgradeBuildingCommand.cs
@@ -25,42 +25,32 @@ namespace Sporefront.AI.Commands
 
         public override EngineCommandResult Validate(GameState state)
         {
-            var building = state.GetBuilding(buildingID);
-            if (building == null)
-                return EngineCommandResult.Failure("Building not found");
-
-            if (!building.ownerID.HasValue || building.ownerID.Value != PlayerID)
-                return EngineCommandResult.Failure("Not your building");
+            var fail = ValidateOwnedBuilding(state, buildingID, out var building);
+            if (fail != null) return fail;
 
             if (!building.CanUpgrade)
                 return EngineCommandResult.Failure("Building cannot be upgraded");
 
-            var player = state.GetPlayer(PlayerID);
-            if (player == null)
-                return EngineCommandResult.Failure("Player not found");
+            fail = ValidatePlayer(state, out var player);
+            if (fail != null) return fail;
 
             var cost = building.GetUpgradeCost();
             if (cost == null)
                 return EngineCommandResult.Failure("No upgrade available");
 
-            foreach (var kvp in cost)
-            {
-                if (!player.HasResource(kvp.Key, kvp.Value))
-                    return EngineCommandResult.Failure("Insufficient resources");
-            }
+            var fail2 = ValidateCanAfford(player, cost);
+            if (fail2 != null) return fail2;
 
             return EngineCommandResult.Success(null);
         }
 
         public override EngineCommandResult Execute(GameState state, StateChangeBuilder changeBuilder)
         {
-            var building = state.GetBuilding(buildingID);
-            if (building == null)
-                return EngineCommandResult.Failure("Building not found");
+            var fail = ValidateOwnedBuilding(state, buildingID, out var building);
+            if (fail != null) return fail;
 
-            var player = state.GetPlayer(PlayerID);
-            if (player == null)
-                return EngineCommandResult.Failure("Player not found");
+            fail = ValidatePlayer(state, out var player);
+            if (fail != null) return fail;
 
             var cost = building.GetUpgradeCost();
             if (cost == null)
@@ -128,8 +118,7 @@ namespace Sporefront.AI.Commands
                 });
             }
 
-            DebugLog.Log(string.Format("AIUpgradeBuildingCommand: AI upgrading {0} to level {1}",
-                building.buildingType, newLevel));
+            DebugLog.Log($"AIUpgradeBuildingCommand: AI upgrading {building.buildingType} to level {newLevel}");
 
             return EngineCommandResult.Success(changeBuilder.Build().changes);
         }

--- a/Sporefront/Assets/Scripts/AI/Commands/AIUpgradeUnitCommand.cs
+++ b/Sporefront/Assets/Scripts/AI/Commands/AIUpgradeUnitCommand.cs
@@ -26,9 +26,8 @@ namespace Sporefront.AI.Commands
 
         public override EngineCommandResult Validate(GameState state)
         {
-            var player = state.GetPlayer(PlayerID);
-            if (player == null)
-                return EngineCommandResult.Failure("Player not found");
+            var fail = ValidatePlayer(state, out var player);
+            if (fail != null) return fail;
 
             if (player.IsUnitUpgradeActive())
                 return EngineCommandResult.Failure("Unit upgrade already in progress");
@@ -46,9 +45,8 @@ namespace Sporefront.AI.Commands
             }
 
             // Check building exists and matches requirements
-            var building = state.GetBuilding(buildingID);
-            if (building == null)
-                return EngineCommandResult.Failure("Building not found");
+            fail = ValidateBuilding(state, buildingID, out var building);
+            if (fail != null) return fail;
 
             if (building.buildingType != upgradeType.RequiredBuildingType())
                 return EngineCommandResult.Failure("Wrong building type");
@@ -57,21 +55,16 @@ namespace Sporefront.AI.Commands
                 return EngineCommandResult.Failure("Building level too low");
 
             // Check affordability
-            var cost = upgradeType.Cost();
-            foreach (var kvp in cost)
-            {
-                if (!player.HasResource(kvp.Key, kvp.Value))
-                    return EngineCommandResult.Failure("Insufficient resources");
-            }
+            var fail2 = ValidateCanAfford(player, upgradeType.Cost());
+            if (fail2 != null) return fail2;
 
             return EngineCommandResult.Success(null);
         }
 
         public override EngineCommandResult Execute(GameState state, StateChangeBuilder changeBuilder)
         {
-            var player = state.GetPlayer(PlayerID);
-            if (player == null)
-                return EngineCommandResult.Failure("Player not found");
+            var fail = ValidatePlayer(state, out var player);
+            if (fail != null) return fail;
 
             string rawValue = upgradeType.ToString();
 
@@ -95,8 +88,7 @@ namespace Sporefront.AI.Commands
                 startTime = state.currentTime
             });
 
-            DebugLog.Log(string.Format("AIUpgradeUnitCommand: AI started unit upgrade: {0}",
-                upgradeType.DisplayName()));
+            DebugLog.Log($"AIUpgradeUnitCommand: AI started unit upgrade: {upgradeType.DisplayName()}");
 
             return EngineCommandResult.Success(changeBuilder.Build().changes);
         }

--- a/Sporefront/Assets/Scripts/AI/FactionAIConfig.cs
+++ b/Sporefront/Assets/Scripts/AI/FactionAIConfig.cs
@@ -1,0 +1,237 @@
+// ============================================================================
+// FILE: AI/FactionAIConfig.cs
+// PURPOSE: Centralized per-faction AI tuning data. Adding a new faction
+//          requires one entry here instead of editing 4+ planner files.
+// ============================================================================
+
+using System;
+using System.Collections.Generic;
+using Sporefront.Data;
+using Sporefront.Models;
+
+namespace Sporefront.AI
+{
+    public class FactionAIConfig
+    {
+        // ================================================================
+        // Research Scoring
+        // ================================================================
+
+        /// <summary>Per-research score bonuses (faction synergy).</summary>
+        public Dictionary<ResearchType, double> ResearchBonuses = new Dictionary<ResearchType, double>();
+
+        /// <summary>
+        /// Substring penalties applied to research names (e.g. "Cavalry" → -5.0).
+        /// Used to deprioritize T3-blocked categories.
+        /// </summary>
+        public List<(string pattern, double penalty)> ResearchNamePenalties = new List<(string, double)>();
+
+        // ================================================================
+        // Unit Composition
+        // ================================================================
+
+        /// <summary>Score adjustments per unit category for army composition decisions.</summary>
+        public Dictionary<UnitCategory, double> UnitCategoryBias = new Dictionary<UnitCategory, double>();
+
+        /// <summary>Score adjustment for specific unit types (e.g. Scout bonus for Morel).</summary>
+        public Dictionary<MilitaryUnitType, double> UnitTypeBias = new Dictionary<MilitaryUnitType, double>();
+
+        /// <summary>Bonus score when selecting army targets (e.g. Muscaria poison aggression).</summary>
+        public double ArmyTargetBonus = 0.0;
+
+        // ================================================================
+        // Economy
+        // ================================================================
+
+        /// <summary>Multiplier applied to resource urgency (e.g. Morel 1.10 for Wood).</summary>
+        public Dictionary<ResourceType, double> ResourceUrgencyMultiplier = new Dictionary<ResourceType, double>();
+
+        /// <summary>Ordered military building priorities: (type, minExisting, maxAllowed).</summary>
+        public (BuildingType type, int minCount, int maxCount)[] MilitaryBuildOrder;
+
+        /// <summary>If true, prefer mountain/hill tiles when placing buildings (Muscaria).</summary>
+        public bool PreferHighlandBuilding = false;
+
+        // ================================================================
+        // Defense & Terrain
+        // ================================================================
+
+        /// <summary>Score bonus for tower placement on specific terrain types.</summary>
+        public Dictionary<TerrainType, double> TowerTerrainBonus = new Dictionary<TerrainType, double>();
+
+        /// <summary>If true, towers near forest resource points get a bonus (Morel camouflage synergy).</summary>
+        public bool TowerForestBonus = false;
+
+        /// <summary>Score bonus for entrenchment on specific terrain types.</summary>
+        public Dictionary<TerrainType, double> EntrenchTerrainBonus = new Dictionary<TerrainType, double>();
+
+        /// <summary>If true, entrenchment near forest resource points gets a bonus.</summary>
+        public double EntrenchForestBonus = 0.0;
+
+        // ================================================================
+        // Static Configs
+        // ================================================================
+
+        private static readonly Dictionary<FactionType, FactionAIConfig> Configs =
+            new Dictionary<FactionType, FactionAIConfig>
+            {
+                { FactionType.Morel, CreateMorel() },
+                { FactionType.Muscaria, CreateMuscaria() },
+            };
+
+        private static readonly FactionAIConfig DefaultConfig = new FactionAIConfig
+        {
+            MilitaryBuildOrder = new[]
+            {
+                (BuildingType.Barracks, 0, 1),
+                (BuildingType.ArcheryRange, 0, 1),
+                (BuildingType.Stable, 0, 1),
+                (BuildingType.SiegeWorkshop, 0, 1),
+                (BuildingType.Barracks, 1, 2),
+            }
+        };
+
+        public static FactionAIConfig Get(FactionType faction)
+        {
+            FactionAIConfig config;
+            return Configs.TryGetValue(faction, out config) ? config : DefaultConfig;
+        }
+
+        // ================================================================
+        // Morel Configuration
+        // ================================================================
+
+        private static FactionAIConfig CreateMorel()
+        {
+            return new FactionAIConfig
+            {
+                // Research synergies
+                ResearchBonuses = new Dictionary<ResearchType, double>
+                {
+                    { ResearchType.LumberCampGatheringI, 12.0 },
+                    { ResearchType.LumberCampGatheringII, 10.0 },
+                    { ResearchType.BurnAreas, 15.0 },
+                    { ResearchType.ToxicSpores, 12.0 },
+                    { ResearchType.LethalSpores, 10.0 },
+                    { ResearchType.InfantryMeleeAttackI, 8.0 },
+                    { ResearchType.InfantryMeleeAttackII, 8.0 },
+                    { ResearchType.InfantryMeleeAttackIII, 8.0 },
+                    { ResearchType.InfantryMeleeArmorI, 6.0 },
+                    { ResearchType.InfantryMeleeArmorII, 6.0 },
+                    { ResearchType.InfantryMeleeArmorIII, 6.0 },
+                    { ResearchType.MarchSpeedI, 5.0 },
+                    { ResearchType.MarchSpeedII, 5.0 },
+                    { ResearchType.MarchSpeedIII, 5.0 },
+                },
+                ResearchNamePenalties = new List<(string, double)>
+                {
+                    ("Cavalry", -5.0),
+                    ("Siege", -5.0),
+                },
+
+                // Infantry focus
+                UnitCategoryBias = new Dictionary<UnitCategory, double>
+                {
+                    { UnitCategory.Infantry, 6.0 },
+                    { UnitCategory.Cavalry, -5.0 },
+                    { UnitCategory.Siege, -5.0 },
+                },
+                UnitTypeBias = new Dictionary<MilitaryUnitType, double>
+                {
+                    { MilitaryUnitType.Scout, 5.0 },
+                },
+
+                // Economy
+                ResourceUrgencyMultiplier = new Dictionary<ResourceType, double>
+                {
+                    { ResourceType.Wood, 1.10 },
+                },
+                MilitaryBuildOrder = new[]
+                {
+                    (BuildingType.Barracks, 0, 1),
+                    (BuildingType.ArcheryRange, 0, 1),
+                    (BuildingType.Barracks, 1, 2),
+                    (BuildingType.Stable, 0, 1),
+                    (BuildingType.SiegeWorkshop, 0, 1),
+                },
+
+                // Defense: forest preference
+                TowerTerrainBonus = new Dictionary<TerrainType, double>
+                {
+                    { TerrainType.Mountain, 2.0 },
+                },
+                TowerForestBonus = true,
+                EntrenchForestBonus = 3.0,
+            };
+        }
+
+        // ================================================================
+        // Muscaria Configuration
+        // ================================================================
+
+        private static FactionAIConfig CreateMuscaria()
+        {
+            return new FactionAIConfig
+            {
+                // Research synergies
+                ResearchBonuses = new Dictionary<ResearchType, double>
+                {
+                    { ResearchType.IncreasedPoisonDamage, 20.0 },
+                    { ResearchType.ToxinAccumulation, 18.0 },
+                    { ResearchType.SporeBurst, 15.0 },
+                    { ResearchType.MiningCampGatheringI, 12.0 },
+                    { ResearchType.MiningCampGatheringII, 10.0 },
+                    { ResearchType.PiercingDamageI, 8.0 },
+                    { ResearchType.PiercingDamageII, 8.0 },
+                    { ResearchType.PiercingDamageIII, 8.0 },
+                    { ResearchType.SiegeBludgeonDamageI, 8.0 },
+                    { ResearchType.SiegeBludgeonDamageII, 8.0 },
+                    { ResearchType.SiegeBludgeonDamageIII, 8.0 },
+                },
+                ResearchNamePenalties = new List<(string, double)>
+                {
+                    ("InfantryMelee", -5.0),
+                    ("Cavalry", -5.0),
+                },
+
+                // Ranged/siege focus + poison aggression
+                UnitCategoryBias = new Dictionary<UnitCategory, double>
+                {
+                    { UnitCategory.Ranged, 6.0 },
+                    { UnitCategory.Siege, 6.0 },
+                    { UnitCategory.Infantry, -4.0 },
+                    { UnitCategory.Cavalry, -4.0 },
+                },
+                ArmyTargetBonus = 8.0,
+
+                // Economy
+                ResourceUrgencyMultiplier = new Dictionary<ResourceType, double>
+                {
+                    { ResourceType.Stone, 1.10 },
+                    { ResourceType.Ore, 1.10 },
+                },
+                PreferHighlandBuilding = true,
+                MilitaryBuildOrder = new[]
+                {
+                    (BuildingType.Barracks, 0, 1),
+                    (BuildingType.ArcheryRange, 0, 1),
+                    (BuildingType.SiegeWorkshop, 0, 1),
+                    (BuildingType.Stable, 0, 1),
+                    (BuildingType.Barracks, 1, 2),
+                },
+
+                // Defense: mountain/hill preference
+                TowerTerrainBonus = new Dictionary<TerrainType, double>
+                {
+                    { TerrainType.Mountain, 2.0 },
+                    { TerrainType.Hill, 1.5 },
+                },
+                EntrenchTerrainBonus = new Dictionary<TerrainType, double>
+                {
+                    { TerrainType.Mountain, 3.0 },
+                    { TerrainType.Hill, 2.0 },
+                },
+            };
+        }
+    }
+}

--- a/Sporefront/Assets/Scripts/AI/FactionAIConfig.cs.meta
+++ b/Sporefront/Assets/Scripts/AI/FactionAIConfig.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4d5f6fe3641624d8da9f985c9f3985d8

--- a/Sporefront/Assets/Scripts/AI/SimulationAIController.cs
+++ b/Sporefront/Assets/Scripts/AI/SimulationAIController.cs
@@ -104,78 +104,9 @@ namespace Sporefront.AI
         // Hunt Arrival Processing
         // ================================================================
 
-        /// <summary>
-        /// Checks all villager groups with hunting tasks -- if they have arrived at the animal,
-        /// execute instant combat and convert to carcass gathering.
-        /// </summary>
         private void ProcessHuntArrivals(GameState state)
         {
-            var groups = state.villagerGroups.Values.ToList();
-
-            foreach (var group in groups)
-            {
-                var huntTask = group.currentTask as HuntingTask;
-                if (huntTask == null) continue;
-                if (group.currentPath != null) continue; // Still en route
-
-                var resourcePointID = huntTask.ResourcePointID;
-                var resource = state.GetResourcePoint(resourcePointID);
-                if (resource == null)
-                {
-                    group.ClearTask();
-                    continue;
-                }
-
-                if (!group.coordinate.Equals(resource.coordinate)) continue;
-
-                // At target -- execute hunt combat
-                double villagerAttack = group.villagerCount * 25.0;
-                double damageToAnimal = Math.Max(1.0, villagerAttack - resource.resourceType.DefensePower());
-                resource.TakeDamage(damageToAnimal);
-
-                double animalAttack = resource.resourceType.AttackPower();
-                double damageToVillagers = Math.Max(0.0, animalAttack - group.villagerCount * 0.5);
-                int villagersLost = (int)(damageToVillagers / 5.0);
-                if (villagersLost > 0) group.RemoveVillagers(villagersLost);
-
-                if (resource.currentHealth <= 0)
-                {
-                    // Animal killed -- create carcass and start gathering
-                    var carcass = resource.CreateCarcassData();
-                    if (carcass != null)
-                    {
-                        state.RemoveResourcePoint(resource.id);
-                        state.AddResourcePoint(carcass);
-
-                        bool registered = context.resourceEngine.StartGathering(
-                            group.id, carcass.id);
-                        if (registered)
-                        {
-                            context.resourceEngine.UpdateCollectionRates(
-                                group.ownerID ?? Guid.Empty);
-                        }
-                        else
-                        {
-                            group.ClearTask();
-                        }
-                    }
-                    else
-                    {
-                        group.ClearTask();
-                    }
-                }
-                else
-                {
-                    // Animal survived -- clear task, AI will retry next cycle
-                    group.ClearTask();
-                }
-
-                if (group.villagerCount <= 0)
-                {
-                    context.resourceEngine.StopGathering(group.id);
-                    state.RemoveVillagerGroup(group.id);
-                }
-            }
+            AIHelper.ProcessHuntArrivals(state, context.resourceEngine);
         }
 
         // ================================================================
@@ -440,9 +371,8 @@ namespace Sporefront.AI
         {
             var playerID = aiState.playerID;
 
-            if (currentTime - aiState.lastUnitUpgradeCheckTime < genome.unitUpgradeCheckInterval)
+            if (!AIHelper.ShouldExecute(ref aiState.lastUnitUpgradeCheckTime, currentTime, genome.unitUpgradeCheckInterval))
                 return new List<IEngineCommand>();
-            aiState.lastUnitUpgradeCheckTime = currentTime;
 
             var player = gameState.GetPlayer(playerID);
             if (player == null) return new List<IEngineCommand>();
@@ -718,8 +648,7 @@ namespace Sporefront.AI
             var exploredCount = gameState.GetExploredResourcePoints(playerID).Count;
             var idleVillagerCount = gameState.GetVillagerGroupsForPlayer(playerID)
                 .Count(g => g.currentTask is IdleTask && g.currentPath == null);
-            DebugLog.Log(string.Format("Sim Economy: exploredResources={0}, idleVillagers={1}, wood={2}",
-                exploredCount, idleVillagerCount, player.GetResource(ResourceType.Wood)));
+            DebugLog.Log($"Sim Economy: exploredResources={exploredCount}, idleVillagers={idleVillagerCount}, wood={player.GetResource(ResourceType.Wood)}");
 
             var villagerCount = gameState.GetVillagerCount(playerID);
             int popCurrent, popCapacity;
@@ -853,9 +782,8 @@ namespace Sporefront.AI
         {
             var playerID = aiState.playerID;
 
-            if (currentTime - aiState.lastUpgradeCheckTime < genome.upgradeCheckInterval)
+            if (!AIHelper.ShouldExecute(ref aiState.lastUpgradeCheckTime, currentTime, genome.upgradeCheckInterval))
                 return new List<IEngineCommand>();
-            aiState.lastUpgradeCheckTime = currentTime;
 
             var player = gameState.GetPlayer(playerID);
             if (player == null) return new List<IEngineCommand>();
@@ -869,7 +797,7 @@ namespace Sporefront.AI
             if (player.GetResource(ResourceType.Wood) < 300) return new List<IEngineCommand>();
 
             // Don't upgrade CC until we have a lumber camp
-            bool hasLumber = buildings.Any(b => b.buildingType == BuildingType.LumberCamp && b.IsOperational);
+            bool hasLumber = gameState.HasBuilding(playerID, BuildingType.LumberCamp, operationalOnly: true);
             if (!hasLumber) return new List<IEngineCommand>();
 
             // Score and pick the best building to upgrade
@@ -881,16 +809,7 @@ namespace Sporefront.AI
                 var cost = building.GetUpgradeCost();
                 if (cost == null) continue;
 
-                bool canAfford = true;
-                foreach (var kvp in cost)
-                {
-                    if (!player.HasResource(kvp.Key, kvp.Value))
-                    {
-                        canAfford = false;
-                        break;
-                    }
-                }
-                if (!canAfford) continue;
+                if (!player.CanAfford(cost)) continue;
 
                 double score = 0.0;
                 switch (building.buildingType)
@@ -1019,8 +938,7 @@ namespace Sporefront.AI
                     urgency.TryGetValue(r.resourceType.ResourceYield(), out u);
                     return u;
                 })
-                .ThenBy(r => r.coordinate.Distance(cityCenter.coordinate))
-                .ToList();
+                .ThenBy(r => r.coordinate.Distance(cityCenter.coordinate));
 
             var assignedResources = new HashSet<Guid>();
             foreach (var villagerGroup in idleVillagers)
@@ -1130,13 +1048,11 @@ namespace Sporefront.AI
 
             if (huntableAnimals.Count == 0)
             {
-                DebugLog.Log(string.Format("Sim Hunt: no huntable animals found (explored={0})",
-                    gameState.GetExploredResourcePoints(playerID).Count));
+                DebugLog.Log($"Sim Hunt: no huntable animals found (explored={gameState.GetExploredResourcePoints(playerID).Count})");
             }
 
             var idleVillagers = gameState.GetVillagerGroupsForPlayer(playerID)
-                .Where(g => g.currentTask is IdleTask && g.currentPath == null)
-                .ToList();
+                .Where(g => g.currentTask is IdleTask && g.currentPath == null);
 
             var usedVillagers = new HashSet<Guid>();
             foreach (var animal in huntableAnimals)
@@ -1166,11 +1082,7 @@ namespace Sporefront.AI
             var player = gameState.GetPlayer(playerID);
             if (player == null) return null;
 
-            var campCost = BuildingType.LumberCamp.BuildCost();
-            foreach (var kvp in campCost)
-            {
-                if (!player.HasResource(kvp.Key, kvp.Value)) return null;
-            }
+            if (!player.CanAfford(BuildingType.LumberCamp.BuildCost())) return null;
 
             var trees = gameState.GetExploredResourcePoints(playerID)
                 .Where(r => r.resourceType == ResourcePointType.Trees && r.remainingAmount > 0 &&
@@ -1241,92 +1153,45 @@ namespace Sporefront.AI
             }
         }
 
-        private IEngineCommand TryBuildFarm(Guid playerID, GameState gameState)
+        /// <summary>
+        /// Generic building construction helper for simulation AI. Validates player/CC,
+        /// checks optional preconditions, affordability, and finds a build location.
+        /// </summary>
+        private IEngineCommand TryBuildStructure(Guid playerID, GameState gameState, BuildingType type, int searchRadius,
+            bool requiresCCLevel = false, bool singleton = false, int? maxAllowed = null)
         {
             var cityCenter = gameState.GetCityCenter(playerID);
             if (cityCenter == null) return null;
             var player = gameState.GetPlayer(playerID);
             if (player == null) return null;
 
-            var farmCost = BuildingType.Farm.BuildCost();
-            foreach (var kvp in farmCost)
-            {
-                if (!player.HasResource(kvp.Key, kvp.Value)) return null;
-            }
+            if (requiresCCLevel && cityCenter.level < type.RequiredCityCenterLevel()) return null;
+            if (singleton && gameState.HasBuilding(playerID, type)) return null;
+            if (maxAllowed.HasValue && gameState.GetBuildingCount(type, playerID) >= maxAllowed.Value) return null;
 
-            var location = gameState.FindBuildLocation(cityCenter.coordinate, 4, playerID);
+            if (!player.CanAfford(type.BuildCost())) return null;
+
+            var location = gameState.FindBuildLocation(cityCenter.coordinate, searchRadius, playerID);
             if (!location.HasValue) return null;
 
-            return new AIBuildCommand(playerID, BuildingType.Farm, location.Value, 0);
+            return new AIBuildCommand(playerID, type, location.Value, 0);
         }
+
+        private IEngineCommand TryBuildFarm(Guid playerID, GameState gameState)
+            => TryBuildStructure(playerID, gameState, BuildingType.Farm, 4);
 
         private IEngineCommand TryBuildHouse(Guid playerID, GameState gameState, double currentTime, AIPlayerState aiState)
-        {
-            var cityCenter = gameState.GetCityCenter(playerID);
-            if (cityCenter == null) return null;
-            var player = gameState.GetPlayer(playerID);
-            if (player == null) return null;
-
-            var houseCost = BuildingType.Neighborhood.BuildCost();
-            foreach (var kvp in houseCost)
-            {
-                if (!player.HasResource(kvp.Key, kvp.Value)) return null;
-            }
-
-            var location = gameState.FindBuildLocation(cityCenter.coordinate, 5, playerID);
-            if (!location.HasValue) return null;
-
-            return new AIBuildCommand(playerID, BuildingType.Neighborhood, location.Value, 0);
-        }
+            => TryBuildStructure(playerID, gameState, BuildingType.Neighborhood, 5);
 
         private IEngineCommand TryBuildStorage(Guid playerID, GameState gameState)
         {
-            var cityCenter = gameState.GetCityCenter(playerID);
-            if (cityCenter == null) return null;
-            var player = gameState.GetPlayer(playerID);
-            if (player == null) return null;
-
-            int ccLevel = cityCenter.level;
-            int currentWarehouses = gameState.GetBuildingCount(BuildingType.Warehouse, playerID);
-            int maxWarehouses = BuildingTypeExtensions.MaxWarehousesAllowed(ccLevel);
-
-            if (currentWarehouses >= maxWarehouses) return null;
-
-            var warehouseCost = BuildingType.Warehouse.BuildCost();
-            foreach (var kvp in warehouseCost)
-            {
-                if (!player.HasResource(kvp.Key, kvp.Value)) return null;
-            }
-
-            var location = gameState.FindBuildLocation(cityCenter.coordinate, 5, playerID);
-            if (!location.HasValue) return null;
-
-            return new AIBuildCommand(playerID, BuildingType.Warehouse, location.Value, 0);
+            int ccLevel = gameState.GetCityCenter(playerID)?.level ?? 0;
+            return TryBuildStructure(playerID, gameState, BuildingType.Warehouse, 5,
+                maxAllowed: BuildingTypeExtensions.MaxWarehousesAllowed(ccLevel));
         }
 
         private IEngineCommand TryBuildLibrary(Guid playerID, GameState gameState)
-        {
-            var cityCenter = gameState.GetCityCenter(playerID);
-            if (cityCenter == null) return null;
-            var player = gameState.GetPlayer(playerID);
-            if (player == null) return null;
-
-            if (cityCenter.level < BuildingType.Library.RequiredCityCenterLevel()) return null;
-
-            bool existingLibrary = gameState.GetBuildingsForPlayer(playerID).Any(b => b.buildingType == BuildingType.Library);
-            if (existingLibrary) return null;
-
-            var libraryCost = BuildingType.Library.BuildCost();
-            foreach (var kvp in libraryCost)
-            {
-                if (!player.HasResource(kvp.Key, kvp.Value)) return null;
-            }
-
-            var location = gameState.FindBuildLocation(cityCenter.coordinate, 4, playerID);
-            if (!location.HasValue) return null;
-
-            return new AIBuildCommand(playerID, BuildingType.Library, location.Value, 0);
-        }
+            => TryBuildStructure(playerID, gameState, BuildingType.Library, 4, requiresCCLevel: true, singleton: true);
 
         private IEngineCommand TryBuildMilitaryBuilding(Guid playerID, GameState gameState)
         {
@@ -1357,17 +1222,7 @@ namespace Sporefront.AI
 
                 if (existingCount < priority.minCount || existingCount >= priority.maxCount) continue;
 
-                var cost = priority.type.BuildCost();
-                bool canAfford = true;
-                foreach (var kvp in cost)
-                {
-                    if (!player.HasResource(kvp.Key, kvp.Value))
-                    {
-                        canAfford = false;
-                        break;
-                    }
-                }
-                if (!canAfford) continue;
+                if (!player.CanAfford(priority.type.BuildCost())) continue;
 
                 var location = gameState.FindBuildLocation(cityCenter.coordinate, 5, playerID);
                 if (!location.HasValue) continue;
@@ -1435,17 +1290,7 @@ namespace Sporefront.AI
                 }
                 if (hasCoverage) continue;
 
-                var campCost = campType.BuildCost();
-                bool canAfford = true;
-                foreach (var kvp in campCost)
-                {
-                    if (!player.HasResource(kvp.Key, kvp.Value))
-                    {
-                        canAfford = false;
-                        break;
-                    }
-                }
-                if (!canAfford) continue;
+                if (!player.CanAfford(campType.BuildCost())) continue;
 
                 double resourceUrgency;
                 urgency.TryGetValue(resource.resourceType.ResourceYield(), out resourceUrgency);
@@ -1543,7 +1388,7 @@ namespace Sporefront.AI
             else
             {
                 // Shuffle and try random order
-                var shuffled = candidates.OrderBy(_ => rng.Next()).ToList();
+                var shuffled = candidates.OrderBy(_ => rng.Next());
                 foreach (var candidate in shuffled)
                 {
                     var cmd = candidate.tryBuild();
@@ -1590,8 +1435,7 @@ namespace Sporefront.AI
                 };
 
                 var militaryBuildings = gameState.GetBuildingsForPlayer(playerID)
-                    .Where(b => militaryBuildingTypes.Contains(b.buildingType) && b.IsOperational && b.trainingQueue.Count == 0)
-                    .ToList();
+                    .Where(b => militaryBuildingTypes.Contains(b.buildingType) && b.IsOperational && b.trainingQueue.Count == 0);
 
                 bool trainedThisCycle = false;
                 foreach (var building in militaryBuildings)
@@ -1656,13 +1500,7 @@ namespace Sporefront.AI
 
             foreach (var unitType in trainableUnits)
             {
-                var trainingCost = unitType.TrainingCost();
-                bool canAfford = true;
-                foreach (var kvp in trainingCost)
-                {
-                    if (!player.HasResource(kvp.Key, kvp.Value)) { canAfford = false; break; }
-                }
-                if (!canAfford) continue;
+                if (!player.CanAfford(unitType.TrainingCost())) continue;
 
                 double score = ScoreUnitTraining(unitType, enemyAnalysis, ownComposition, player, gameState, playerID, gameTime);
 
@@ -2075,8 +1913,7 @@ namespace Sporefront.AI
 
             // Find scout armies
             var scoutArmies = gameState.GetArmiesForPlayer(playerID)
-                .Where(a => IsScoutArmy(a) && !a.isInCombat && a.currentPath == null)
-                .ToList();
+                .Where(a => IsScoutArmy(a) && !a.isInCombat && a.currentPath == null);
 
             foreach (var scout in scoutArmies)
             {
@@ -2166,8 +2003,7 @@ namespace Sporefront.AI
             aiState.previousThreatLevel = threatLevel;
 
             int towerCount = gameState.GetBuildingCount(BuildingType.Tower, playerID);
-            bool hasBarracks = gameState.GetBuildingsForPlayer(playerID)
-                .Any(b => b.buildingType == BuildingType.Barracks && b.IsOperational);
+            bool hasBarracks = gameState.HasBuilding(playerID, BuildingType.Barracks, operationalOnly: true);
 
             bool shouldBuildDefense;
             if (aiState.currentState == AIState.Peace)
@@ -2235,18 +2071,14 @@ namespace Sporefront.AI
             int ccLevel = cityCenter.level;
             if (ccLevel < buildingType.RequiredCityCenterLevel()) return null;
 
-            var cost = buildingType.BuildCost();
-            foreach (var kvp in cost)
-            {
-                if (!player.HasResource(kvp.Key, kvp.Value)) return null;
-            }
+            if (!player.CanAfford(buildingType.BuildCost())) return null;
 
             int maxDistance = buildingType == BuildingType.Tower ? 4 : 5;
             var rng = new System.Random();
             for (int distance = 2; distance <= maxDistance; distance++)
             {
                 var ring = cityCenter.coordinate.CoordinatesInRing(distance);
-                var shuffled = ring.OrderBy(_ => rng.Next()).ToList();
+                var shuffled = ring.OrderBy(_ => rng.Next());
 
                 foreach (var coord in shuffled)
                 {
@@ -2269,8 +2101,7 @@ namespace Sporefront.AI
             var commands = new List<IEngineCommand>();
             var playerID = aiState.playerID;
 
-            if (currentTime - aiState.lastGarrisonCheckTime < genome.garrisonCheckInterval) return commands;
-            aiState.lastGarrisonCheckTime = currentTime;
+            if (!AIHelper.ShouldExecute(ref aiState.lastGarrisonCheckTime, currentTime, genome.garrisonCheckInterval)) return commands;
 
             var defensiveTypes = new HashSet<BuildingType>
             {
@@ -2293,8 +2124,7 @@ namespace Sporefront.AI
 
             var idleArmies = gameState.GetArmiesForPlayer(playerID)
                 .Where(a => !a.isInCombat && a.currentPath == null &&
-                            a.militaryComposition.Any(kvp => garrisonableTypes.Contains(kvp.Key) && kvp.Value > 0))
-                .ToList();
+                            a.militaryComposition.Any(kvp => garrisonableTypes.Contains(kvp.Key) && kvp.Value > 0));
 
             var assignedBuildings = new HashSet<Guid>();
             foreach (var army in idleArmies)
@@ -2321,9 +2151,8 @@ namespace Sporefront.AI
         {
             var playerID = aiState.playerID;
 
-            if (currentTime - aiState.lastEntrenchCheckTime < genome.entrenchCheckInterval)
+            if (!AIHelper.ShouldExecute(ref aiState.lastEntrenchCheckTime, currentTime, genome.entrenchCheckInterval))
                 return new List<IEngineCommand>();
-            aiState.lastEntrenchCheckTime = currentTime;
 
             var player = gameState.GetPlayer(playerID);
             if (player == null) return new List<IEngineCommand>();
@@ -2348,8 +2177,7 @@ namespace Sporefront.AI
             var candidates = armies
                 .Where(a => !a.isInCombat && a.currentPath == null && !a.isRetreating &&
                             !a.isEntrenched && !a.isEntrenching)
-                .OrderBy(a => a.coordinate.Distance(cityCenter.coordinate))
-                .ToList();
+                .OrderBy(a => a.coordinate.Distance(cityCenter.coordinate));
 
             foreach (var army in candidates)
             {
@@ -2393,8 +2221,7 @@ namespace Sporefront.AI
             var commands = new List<IEngineCommand>();
             var playerID = aiState.playerID;
 
-            if (currentTime - aiState.lastResearchCheckTime < genome.researchCheckInterval) return commands;
-            aiState.lastResearchCheckTime = currentTime;
+            if (!AIHelper.ShouldExecute(ref aiState.lastResearchCheckTime, currentTime, genome.researchCheckInterval)) return commands;
 
             var player = gameState.GetPlayer(playerID);
             if (player == null) return commands;
@@ -2404,19 +2231,7 @@ namespace Sporefront.AI
             var bestResearch = SelectBestResearch(aiState, gameState);
             if (bestResearch.HasValue)
             {
-                // Check affordability
-                var cost = bestResearch.Value.Cost();
-                bool canAfford = true;
-                foreach (var kvp in cost)
-                {
-                    if (!player.HasResource(kvp.Key, kvp.Value))
-                    {
-                        canAfford = false;
-                        break;
-                    }
-                }
-
-                if (canAfford)
+                if (player.CanAfford(bestResearch.Value.Cost()))
                 {
                     commands.Add(new AIStartResearchCommand(playerID, bestResearch.Value));
                 }

--- a/Sporefront/Assets/Scripts/Commands/AttackCommand.cs
+++ b/Sporefront/Assets/Scripts/Commands/AttackCommand.cs
@@ -175,7 +175,31 @@ namespace Sporefront.Commands
             if (army == null)
                 return EngineCommandResult.Failure("Attacker not found");
 
-            // Consume commander stamina
+            PrepareAttacker(army, state, changeBuilder);
+
+            double currentTime = state.currentTime;
+            HexCoordinate attackerOrigin = army.coordinate;
+            DefensiveStack stack = DefensiveStack.Build(targetCoordinate, state, PlayerID);
+
+            // Branch by target type
+            BuildingData targetBuilding = state.GetBuilding(targetCoordinate);
+            if (targetBuilding != null)
+                return ExecuteBuildingAttack(army, stack, attackerOrigin, currentTime, state, changeBuilder);
+
+            if (stack.ArmyEntries.Count > 0)
+                return ExecuteArmyAttack(army, stack, attackerOrigin, currentTime, state, changeBuilder);
+
+            if (stack.OnlyVillagers)
+                return ExecuteVillagerAttack(army, stack, currentTime, state, changeBuilder);
+
+            return ExecuteCrossTileAttack(army, attackerOrigin, currentTime, state, changeBuilder);
+        }
+
+        /// <summary>
+        /// Consumes commander stamina and cancels entrenchment before attacking.
+        /// </summary>
+        private void PrepareAttacker(ArmyData army, GameState state, StateChangeBuilder changeBuilder)
+        {
             if (army.commanderID.HasValue)
             {
                 CommanderData cmdr = state.GetCommander(army.commanderID.Value);
@@ -183,7 +207,6 @@ namespace Sporefront.Commands
                     cmdr.ConsumeStamina();
             }
 
-            // Cancel entrenchment if army is entrenching or entrenched
             if (army.isEntrenching || army.isEntrenched)
             {
                 HexCoordinate armyCoord = army.coordinate;
@@ -197,184 +220,126 @@ namespace Sporefront.Commands
                     coordinate = armyCoord
                 });
             }
+        }
 
-            double currentTime = state.currentTime;
-
-            // Capture origin BEFORE moving — friendly armies at origin should join the attack
-            HexCoordinate attackerOrigin = army.coordinate;
-
-            // Build defensive stack at the target
-            DefensiveStack stack = DefensiveStack.Build(targetCoordinate, state, PlayerID);
-
-            // Check for building target first
-            BuildingData targetBuilding = state.GetBuilding(targetCoordinate);
-
-            if (targetBuilding != null)
+        /// <summary>
+        /// Gathers friendly armies at the attacker's origin that can join the attack.
+        /// </summary>
+        private List<Guid> GatherAttackerGroup(HexCoordinate origin, GameState state)
+        {
+            var attackerArmyIDs = new List<Guid> { armyID };
+            List<ArmyData> friendlyArmies = state.GetArmies(origin);
+            foreach (ArmyData ally in friendlyArmies)
             {
-                // Move attacker to target tile first
-                var moveResult = MoveAttackerToTarget(army, targetCoordinate, state, changeBuilder, "No path to target building");
-                if (moveResult != null)
-                    return moveResult;
-
-                // Building combat scenario
-                if (stack.ArmyEntries.Count > 0)
+                if (ally.ownerID.HasValue && ally.ownerID.Value == PlayerID &&
+                    !ally.isInCombat && ally.id != armyID)
                 {
-                    // Defenders present - use stack combat
-                    List<Guid> attackerArmyIDs = new List<Guid> { armyID };
-
-                    // Gather friendly armies at the attacker's ORIGIN position that can join
-                    List<ArmyData> friendlyArmies = state.GetArmies(attackerOrigin);
-                    foreach (ArmyData ally in friendlyArmies)
-                    {
-                        if (ally.ownerID.HasValue && ally.ownerID.Value == PlayerID &&
-                            !ally.isInCombat && ally.id != armyID)
-                        {
-                            attackerArmyIDs.Add(ally.id);
-                        }
-                    }
-
-                    List<StateChange> stackChanges = GameEngine.Instance.combatEngine.StartStackCombat(
-                        attackerArmyIDs, targetCoordinate, currentTime);
-
-                    if (stackChanges != null)
-                        changeBuilder.AddAll(stackChanges);
+                    attackerArmyIDs.Add(ally.id);
                 }
-                else if (stack.villagerGroupIDs.Count > 0)
-                {
-                    // Only villagers defending - start villager combat
-                    Guid firstVillagerID = stack.villagerGroupIDs[0];
-                    StateChange villagerChange = GameEngine.Instance.combatEngine.StartVillagerCombat(
-                        armyID, firstVillagerID, currentTime);
-
-                    if (villagerChange != null)
-                        changeBuilder.Add(villagerChange);
-                }
-                else
-                {
-                    // No defenders - pure building combat
-                    StateChange buildingChange = GameEngine.Instance.combatEngine.StartBuildingCombat(
-                        armyID, targetBuilding.id, currentTime);
-
-                    if (buildingChange != null)
-                        changeBuilder.Add(buildingChange);
-
-                    // Collect any extra changes from False Morel instant-kill
-                    var falseMorelChanges = GameEngine.Instance.combatEngine.CollectPendingFalseMorelChanges();
-                    foreach (var fmc in falseMorelChanges)
-                        changeBuilder.Add(fmc);
-                }
-
-                return EngineCommandResult.Success(changeBuilder.Build().changes);
             }
+            return attackerArmyIDs;
+        }
 
-            // Army or villager target (not on a building)
+        private EngineCommandResult ExecuteBuildingAttack(ArmyData army, DefensiveStack stack,
+            HexCoordinate attackerOrigin, double currentTime, GameState state, StateChangeBuilder changeBuilder)
+        {
+            var moveResult = MoveAttackerToTarget(army, targetCoordinate, state, changeBuilder, "No path to target building");
+            if (moveResult != null) return moveResult;
+
             if (stack.ArmyEntries.Count > 0)
             {
-                // Move attacker to target tile first
-                var moveResult = MoveAttackerToTarget(army, targetCoordinate, state, changeBuilder, "No path to target");
-                if (moveResult != null)
-                    return moveResult;
-
-                // Has army defenders
-                if (stack.ArmyEntries.Count > 1 || stack.HasEntrenchedDefenders)
-                {
-                    // Multiple defenders or entrenched defenders - use stack combat
-                    List<Guid> attackerArmyIDs = new List<Guid> { armyID };
-
-                    // Gather friendly armies at the attacker's ORIGIN position
-                    List<ArmyData> friendlyArmies = state.GetArmies(attackerOrigin);
-                    foreach (ArmyData ally in friendlyArmies)
-                    {
-                        if (ally.ownerID.HasValue && ally.ownerID.Value == PlayerID &&
-                            !ally.isInCombat && ally.id != armyID)
-                        {
-                            attackerArmyIDs.Add(ally.id);
-                        }
-                    }
-
-                    List<StateChange> stackChanges = GameEngine.Instance.combatEngine.StartStackCombat(
-                        attackerArmyIDs, targetCoordinate, currentTime);
-
-                    if (stackChanges != null)
-                        changeBuilder.AddAll(stackChanges);
-                }
-                else
-                {
-                    // Simple 1v1 combat against the single defender
-                    Guid defenderArmyID = stack.ArmyEntries[0].armyID;
-                    StateChange combatChange = GameEngine.Instance.combatEngine.StartCombat(
-                        armyID, defenderArmyID, currentTime);
-
-                    if (combatChange != null)
-                        changeBuilder.Add(combatChange);
-                }
-
-                return EngineCommandResult.Success(changeBuilder.Build().changes);
+                var attackerArmyIDs = GatherAttackerGroup(attackerOrigin, state);
+                var stackChanges = GameEngine.Instance.combatEngine.StartStackCombat(
+                    attackerArmyIDs, targetCoordinate, currentTime);
+                if (stackChanges != null) changeBuilder.AddAll(stackChanges);
             }
-
-            if (stack.OnlyVillagers)
+            else if (stack.villagerGroupIDs.Count > 0)
             {
-                // Move attacker to target tile first
-                var moveResult = MoveAttackerToTarget(army, targetCoordinate, state, changeBuilder, "No path to target villagers");
-                if (moveResult != null)
-                    return moveResult;
+                var villagerChange = GameEngine.Instance.combatEngine.StartVillagerCombat(
+                    armyID, stack.villagerGroupIDs[0], currentTime);
+                if (villagerChange != null) changeBuilder.Add(villagerChange);
+            }
+            else
+            {
+                BuildingData targetBuilding = state.GetBuilding(targetCoordinate);
+                var buildingChange = GameEngine.Instance.combatEngine.StartBuildingCombat(
+                    armyID, targetBuilding.id, currentTime);
+                if (buildingChange != null) changeBuilder.Add(buildingChange);
 
-                // Only villagers at target - start villager combat
-                Guid firstVillagerID = stack.villagerGroupIDs[0];
-                StateChange villagerChange = GameEngine.Instance.combatEngine.StartVillagerCombat(
-                    armyID, firstVillagerID, currentTime);
-
-                if (villagerChange != null)
-                    changeBuilder.Add(villagerChange);
-
-                return EngineCommandResult.Success(changeBuilder.Build().changes);
+                var falseMorelChanges = GameEngine.Instance.combatEngine.CollectPendingFalseMorelChanges();
+                foreach (var fmc in falseMorelChanges) changeBuilder.Add(fmc);
             }
 
-            // Check for cross-tile entrenched enemies covering this coordinate
+            return EngineCommandResult.Success(changeBuilder.Build().changes);
+        }
+
+        private EngineCommandResult ExecuteArmyAttack(ArmyData army, DefensiveStack stack,
+            HexCoordinate attackerOrigin, double currentTime, GameState state, StateChangeBuilder changeBuilder)
+        {
+            var moveResult = MoveAttackerToTarget(army, targetCoordinate, state, changeBuilder, "No path to target");
+            if (moveResult != null) return moveResult;
+
+            if (stack.ArmyEntries.Count > 1 || stack.HasEntrenchedDefenders)
+            {
+                var attackerArmyIDs = GatherAttackerGroup(attackerOrigin, state);
+                var stackChanges = GameEngine.Instance.combatEngine.StartStackCombat(
+                    attackerArmyIDs, targetCoordinate, currentTime);
+                if (stackChanges != null) changeBuilder.AddAll(stackChanges);
+            }
+            else
+            {
+                Guid defenderArmyID = stack.ArmyEntries[0].armyID;
+                var combatChange = GameEngine.Instance.combatEngine.StartCombat(
+                    armyID, defenderArmyID, currentTime);
+                if (combatChange != null) changeBuilder.Add(combatChange);
+            }
+
+            return EngineCommandResult.Success(changeBuilder.Build().changes);
+        }
+
+        private EngineCommandResult ExecuteVillagerAttack(ArmyData army, DefensiveStack stack,
+            double currentTime, GameState state, StateChangeBuilder changeBuilder)
+        {
+            var moveResult = MoveAttackerToTarget(army, targetCoordinate, state, changeBuilder, "No path to target villagers");
+            if (moveResult != null) return moveResult;
+
+            var villagerChange = GameEngine.Instance.combatEngine.StartVillagerCombat(
+                armyID, stack.villagerGroupIDs[0], currentTime);
+            if (villagerChange != null) changeBuilder.Add(villagerChange);
+
+            return EngineCommandResult.Success(changeBuilder.Build().changes);
+        }
+
+        private EngineCommandResult ExecuteCrossTileAttack(ArmyData army, HexCoordinate attackerOrigin,
+            double currentTime, GameState state, StateChangeBuilder changeBuilder)
+        {
             List<ArmyData> crossTileEntrenched = state.GetEntrenchedArmiesCovering(targetCoordinate);
-            List<ArmyData> enemyCrossTile = new List<ArmyData>();
+            bool hasCrossTileEnemy = false;
             foreach (ArmyData entrenched in crossTileEntrenched)
             {
                 if (entrenched.ownerID.HasValue && entrenched.ownerID.Value != PlayerID)
-                    enemyCrossTile.Add(entrenched);
-            }
-
-            if (enemyCrossTile.Count > 0)
-            {
-                // Move attacker to target tile first
-                var moveResult = MoveAttackerToTarget(army, targetCoordinate, state, changeBuilder, "No path to entrenchment zone");
-                if (moveResult != null)
-                    return moveResult;
-
-                // Build defensive stack which gathers cross-tile entrenched into Tier 1
-                DefensiveStack crossStack = DefensiveStack.Build(targetCoordinate, state, PlayerID);
-
-                if (crossStack.ArmyEntries.Count > 0)
                 {
-                    List<Guid> attackerArmyIDs = new List<Guid> { armyID };
-
-                    // Gather friendly armies at the attacker's ORIGIN position
-                    List<ArmyData> friendlyArmies = state.GetArmies(attackerOrigin);
-                    foreach (ArmyData ally in friendlyArmies)
-                    {
-                        if (ally.ownerID.HasValue && ally.ownerID.Value == PlayerID &&
-                            !ally.isInCombat && ally.id != armyID)
-                        {
-                            attackerArmyIDs.Add(ally.id);
-                        }
-                    }
-
-                    List<StateChange> stackChanges = GameEngine.Instance.combatEngine.StartStackCombat(
-                        attackerArmyIDs, targetCoordinate, currentTime);
-
-                    if (stackChanges != null)
-                        changeBuilder.AddAll(stackChanges);
+                    hasCrossTileEnemy = true;
+                    break;
                 }
-
-                return EngineCommandResult.Success(changeBuilder.Build().changes);
             }
 
-            return EngineCommandResult.Failure("No valid target found");
+            if (!hasCrossTileEnemy)
+                return EngineCommandResult.Failure("No valid target found");
+
+            var moveResult = MoveAttackerToTarget(army, targetCoordinate, state, changeBuilder, "No path to entrenchment zone");
+            if (moveResult != null) return moveResult;
+
+            DefensiveStack crossStack = DefensiveStack.Build(targetCoordinate, state, PlayerID);
+            if (crossStack.ArmyEntries.Count > 0)
+            {
+                var attackerArmyIDs = GatherAttackerGroup(attackerOrigin, state);
+                var stackChanges = GameEngine.Instance.combatEngine.StartStackCombat(
+                    attackerArmyIDs, targetCoordinate, currentTime);
+                if (stackChanges != null) changeBuilder.AddAll(stackChanges);
+            }
+
+            return EngineCommandResult.Success(changeBuilder.Build().changes);
         }
 
         /// <summary>

--- a/Sporefront/Assets/Scripts/Commands/BuildCommand.cs
+++ b/Sporefront/Assets/Scripts/Commands/BuildCommand.cs
@@ -142,13 +142,7 @@ namespace Sporefront.Commands
             }
             else
             {
-                var idleVillagers = state.GetVillagerGroupsForPlayer(PlayerID)
-                    .Where(g => g.currentTask.IsIdle && g.currentPath == null)
-                    .OrderBy(g => g.coordinate.Distance(coordinate))
-                    .ToList();
-
-                if (idleVillagers.Count > 0)
-                    builder = idleVillagers[0];
+                builder = BuildHelper.FindNearestIdleVillager(state, PlayerID, coordinate);
             }
 
             if (builder != null)
@@ -204,24 +198,7 @@ namespace Sporefront.Commands
 
         private Dictionary<ResourceType, int> GetEffectiveBuildCost(GameState state, PlayerState player)
         {
-            var baseCost = buildingType.BuildCost();
-
-            // Apply faction mountain building cost reduction
-            var tileTerrain = state.mapData.GetTerrain(coordinate);
-            if (tileTerrain.HasValue &&
-                (tileTerrain.Value == TerrainType.Mountain || tileTerrain.Value == TerrainType.Hill))
-            {
-                double reduction = player.faction.MountainBuildCostReduction();
-                if (reduction > 0)
-                {
-                    var reducedCost = new Dictionary<ResourceType, int>();
-                    foreach (var kvp in baseCost)
-                        reducedCost[kvp.Key] = Math.Max(1, (int)(kvp.Value * (1.0 - reduction)));
-                    return reducedCost;
-                }
-            }
-
-            return baseCost;
+            return BuildHelper.GetEffectiveBuildCost(state, buildingType, coordinate, rotation, PlayerID);
         }
     }
 }

--- a/Sporefront/Assets/Scripts/Commands/CancelReinforcementCommand.cs
+++ b/Sporefront/Assets/Scripts/Commands/CancelReinforcementCommand.cs
@@ -108,8 +108,7 @@ namespace Sporefront.Commands
                     });
                 }
 
-                DebugLog.Log(string.Format("CancelReinforcementCommand: Returned {0} units to building at {1}",
-                    reinforcement.GetTotalUnits(), sourceBuilding.coordinate));
+                DebugLog.Log($"CancelReinforcementCommand: Returned {reinforcement.GetTotalUnits()} units to building at {sourceBuilding.coordinate}");
             }
             else
             {
@@ -131,15 +130,13 @@ namespace Sporefront.Commands
                         });
                     }
 
-                    DebugLog.Log(string.Format(
-                        "CancelReinforcementCommand: Source building unavailable, returned {0} units to fallback building at {1}",
-                        reinforcement.GetTotalUnits(), fallbackBuilding.coordinate));
+                    DebugLog.Log(
+                        $"CancelReinforcementCommand: Source building unavailable, returned {reinforcement.GetTotalUnits()} units to fallback building at {fallbackBuilding.coordinate}");
                 }
                 else
                 {
-                    DebugLog.Log(string.Format(
-                        "CancelReinforcementCommand: No building available to return {0} units, units lost",
-                        reinforcement.GetTotalUnits()));
+                    DebugLog.Log(
+                        $"CancelReinforcementCommand: No building available to return {reinforcement.GetTotalUnits()} units, units lost");
                 }
             }
 

--- a/Sporefront/Assets/Scripts/Commands/DeployCommand.cs
+++ b/Sporefront/Assets/Scripts/Commands/DeployCommand.cs
@@ -28,12 +28,8 @@ namespace Sporefront.Commands
 
         public override EngineCommandResult Validate(GameState state)
         {
-            var building = state.GetBuilding(buildingID);
-            if (building == null)
-                return EngineCommandResult.Failure("Building not found");
-
-            if (!building.ownerID.HasValue || building.ownerID.Value != PlayerID)
-                return EngineCommandResult.Failure("Building is not owned by this player");
+            var fail = ValidateOwnedBuilding(state, buildingID, out var building);
+            if (fail != null) return fail;
 
             if (composition == null || composition.Count == 0)
                 return EngineCommandResult.Failure("Composition cannot be empty");
@@ -42,13 +38,12 @@ namespace Sporefront.Commands
             foreach (var kvp in composition)
             {
                 if (kvp.Value <= 0)
-                    return EngineCommandResult.Failure(string.Format("Invalid quantity for {0}", kvp.Key.DisplayName()));
+                    return EngineCommandResult.Failure($"Invalid quantity for {kvp.Key.DisplayName()}");
 
                 int garrisoned = building.garrison.ContainsKey(kvp.Key) ? building.garrison[kvp.Key] : 0;
                 if (garrisoned < kvp.Value)
-                    return EngineCommandResult.Failure(string.Format(
-                        "Not enough {0} in garrison (have {1}, need {2})",
-                        kvp.Key.DisplayName(), garrisoned, kvp.Value));
+                    return EngineCommandResult.Failure(
+                        $"Not enough {kvp.Key.DisplayName()} in garrison (have {garrisoned}, need {kvp.Value})");
             }
 
             // Army count limit: current armies < max allowed (1 + ccLevel / 2)
@@ -56,18 +51,16 @@ namespace Sporefront.Commands
             int maxArmies = 1 + ccLevel / 2;
             var currentArmies = state.GetArmiesForPlayer(PlayerID);
             if (currentArmies.Count >= maxArmies)
-                return EngineCommandResult.Failure(string.Format(
-                    "Army limit reached ({0}/{1}). Upgrade your City Center to deploy more armies.",
-                    currentArmies.Count, maxArmies));
+                return EngineCommandResult.Failure(
+                    $"Army limit reached ({currentArmies.Count}/{maxArmies}). Upgrade your City Center to deploy more armies.");
 
             return EngineCommandResult.Success(null);
         }
 
         public override EngineCommandResult Execute(GameState state, StateChangeBuilder changeBuilder)
         {
-            var building = state.GetBuilding(buildingID);
-            if (building == null)
-                return EngineCommandResult.Failure("Building not found");
+            var fail = ValidateOwnedBuilding(state, buildingID, out var building);
+            if (fail != null) return fail;
 
             // Remove units from garrison and emit ungarrisoned changes
             foreach (var kvp in composition)
@@ -83,30 +76,10 @@ namespace Sporefront.Commands
             }
 
             // Find spawn position near building
-            HexCoordinate spawnCoord = building.coordinate;
-
-            // Try to find a walkable tile near the building if the building tile is occupied
-            var armiesAtBuilding = state.GetArmies(spawnCoord);
-            if (armiesAtBuilding.Count >= GameConfig.Stacking.MaxEntitiesPerTile)
-            {
-                bool found = false;
-                foreach (var neighbor in spawnCoord.Neighbors())
-                {
-                    if (state.mapData.IsValidCoordinate(neighbor) && state.mapData.IsWalkable(neighbor))
-                    {
-                        var armiesAtNeighbor = state.GetArmies(neighbor);
-                        if (armiesAtNeighbor.Count < GameConfig.Stacking.MaxEntitiesPerTile)
-                        {
-                            spawnCoord = neighbor;
-                            found = true;
-                            break;
-                        }
-                    }
-                }
-
-                if (!found)
-                    return EngineCommandResult.Failure("No available spawn position near building");
-            }
+            var spawnResult = FindSpawnPosition(state, building.coordinate, c => state.GetArmies(c).Count);
+            if (!spawnResult.HasValue)
+                return EngineCommandResult.Failure("No available spawn position near building");
+            HexCoordinate spawnCoord = spawnResult.Value;
 
             // Create army
             var army = new ArmyData("Army", spawnCoord, PlayerID);
@@ -133,8 +106,7 @@ namespace Sporefront.Commands
                 composition = compositionStrings
             });
 
-            DebugLog.Log(string.Format("DeployArmyCommand: Deployed army {0} at {1} with {2} unit type(s)",
-                army.id, spawnCoord, composition.Count));
+            DebugLog.Log($"DeployArmyCommand: Deployed army {army.id} at {spawnCoord} with {composition.Count} unit type(s)");
 
             return EngineCommandResult.Success(changeBuilder.Build().changes);
         }
@@ -165,26 +137,20 @@ namespace Sporefront.Commands
             if (count <= 0)
                 return EngineCommandResult.Failure("Count must be greater than zero");
 
-            var building = state.GetBuilding(buildingID);
-            if (building == null)
-                return EngineCommandResult.Failure("Building not found");
-
-            if (!building.ownerID.HasValue || building.ownerID.Value != PlayerID)
-                return EngineCommandResult.Failure("Building is not owned by this player");
+            var fail = ValidateOwnedBuilding(state, buildingID, out var building);
+            if (fail != null) return fail;
 
             if (building.villagerGarrison < count)
-                return EngineCommandResult.Failure(string.Format(
-                    "Not enough villagers in garrison (have {0}, need {1})",
-                    building.villagerGarrison, count));
+                return EngineCommandResult.Failure(
+                    $"Not enough villagers in garrison (have {building.villagerGarrison}, need {count})");
 
             return EngineCommandResult.Success(null);
         }
 
         public override EngineCommandResult Execute(GameState state, StateChangeBuilder changeBuilder)
         {
-            var building = state.GetBuilding(buildingID);
-            if (building == null)
-                return EngineCommandResult.Failure("Building not found");
+            var fail = ValidateOwnedBuilding(state, buildingID, out var building);
+            if (fail != null) return fail;
 
             // Remove villagers from garrison
             building.RemoveVillagersFromGarrison(count);
@@ -197,30 +163,10 @@ namespace Sporefront.Commands
             });
 
             // Find spawn position near building
-            HexCoordinate spawnCoord = building.coordinate;
-
-            // Try to find a walkable tile near the building if needed
-            var groupsAtBuilding = state.GetVillagerGroups(spawnCoord);
-            if (groupsAtBuilding.Count >= GameConfig.Stacking.MaxEntitiesPerTile)
-            {
-                bool found = false;
-                foreach (var neighbor in spawnCoord.Neighbors())
-                {
-                    if (state.mapData.IsValidCoordinate(neighbor) && state.mapData.IsWalkable(neighbor))
-                    {
-                        var groupsAtNeighbor = state.GetVillagerGroups(neighbor);
-                        if (groupsAtNeighbor.Count < GameConfig.Stacking.MaxEntitiesPerTile)
-                        {
-                            spawnCoord = neighbor;
-                            found = true;
-                            break;
-                        }
-                    }
-                }
-
-                if (!found)
-                    return EngineCommandResult.Failure("No available spawn position near building");
-            }
+            var spawnResult = FindSpawnPosition(state, building.coordinate, c => state.GetVillagerGroups(c).Count);
+            if (!spawnResult.HasValue)
+                return EngineCommandResult.Failure("No available spawn position near building");
+            HexCoordinate spawnCoord = spawnResult.Value;
 
             // Create villager group
             var group = new VillagerGroupData("Villagers", spawnCoord, count, PlayerID);
@@ -237,8 +183,7 @@ namespace Sporefront.Commands
                 count = count
             });
 
-            DebugLog.Log(string.Format("DeployVillagersCommand: Deployed {0} villager(s) at {1}",
-                count, spawnCoord));
+            DebugLog.Log($"DeployVillagersCommand: Deployed {count} villager(s) at {spawnCoord}");
 
             return EngineCommandResult.Success(changeBuilder.Build().changes);
         }

--- a/Sporefront/Assets/Scripts/Commands/EntrenchCommand.cs
+++ b/Sporefront/Assets/Scripts/Commands/EntrenchCommand.cs
@@ -92,9 +92,8 @@ namespace Sporefront.Commands
             }
 
             // Deduct wood cost
-            int oldWood = player.GetResource(ResourceType.Wood);
-            player.RemoveResource(ResourceType.Wood, GameConfig.Entrenchment.WoodCost);
-            int newWood = player.GetResource(ResourceType.Wood);
+            var entrenchCost = new Dictionary<ResourceType, int> { { ResourceType.Wood, GameConfig.Entrenchment.WoodCost } };
+            DeductResourcesWithChanges(player, entrenchCost, changeBuilder);
 
             // Mark army as entrenching
             army.isEntrenching = true;
@@ -105,15 +104,6 @@ namespace Sporefront.Commands
             {
                 armyID = armyID,
                 coordinate = army.coordinate
-            });
-
-            // Emit resource change for wood deduction
-            changeBuilder.Add(new ResourcesChangedChange
-            {
-                playerID = PlayerID,
-                resourceType = ResourceType.Wood.ToString(),
-                oldAmount = oldWood,
-                newAmount = newWood
             });
 
             return EngineCommandResult.Success(changeBuilder.Build().changes);

--- a/Sporefront/Assets/Scripts/Commands/GarrisonArmyCommand.cs
+++ b/Sporefront/Assets/Scripts/Commands/GarrisonArmyCommand.cs
@@ -28,25 +28,14 @@ namespace Sporefront.Commands
 
         public override EngineCommandResult Validate(GameState state)
         {
-            var army = state.GetArmy(armyID);
-            if (army == null)
-                return EngineCommandResult.Failure("Army not found");
-
-            if (!army.ownerID.HasValue || army.ownerID.Value != PlayerID)
-                return EngineCommandResult.Failure("Army is not owned by this player");
+            var fail = ValidateOwnedArmy(state, armyID, out var army);
+            if (fail != null) return fail;
 
             if (army.isInCombat)
                 return EngineCommandResult.Failure("Cannot garrison while in combat");
 
-            var building = state.GetBuilding(buildingID);
-            if (building == null)
-                return EngineCommandResult.Failure("Building not found");
-
-            if (!building.ownerID.HasValue || building.ownerID.Value != PlayerID)
-                return EngineCommandResult.Failure("Building is not owned by this player");
-
-            if (!building.IsOperational)
-                return EngineCommandResult.Failure("Building is not operational");
+            fail = ValidateOperationalBuilding(state, buildingID, out var building);
+            if (fail != null) return fail;
 
             // Army must be at the building's tile (or an occupied coordinate)
             bool atBuilding = building.Occupies(army.coordinate);

--- a/Sporefront/Assets/Scripts/Commands/GatherCommand.cs
+++ b/Sporefront/Assets/Scripts/Commands/GatherCommand.cs
@@ -28,14 +28,8 @@ namespace Sporefront.Commands
 
         public override EngineCommandResult Validate(GameState state)
         {
-            // Villager group must exist
-            var group = state.GetVillagerGroup(villagerGroupID);
-            if (group == null)
-                return EngineCommandResult.Failure("Villager group not found");
-
-            // Must be owned by this player
-            if (!group.ownerID.HasValue || group.ownerID.Value != PlayerID)
-                return EngineCommandResult.Failure("Villager group is not owned by this player");
+            var fail = ValidateVillagerGroup(state, villagerGroupID, out var group);
+            if (fail != null) return fail;
 
             // Resource point must exist
             var resourcePoint = state.GetResourcePoint(resourcePointID);
@@ -55,9 +49,8 @@ namespace Sporefront.Commands
 
         public override EngineCommandResult Execute(GameState state, StateChangeBuilder changeBuilder)
         {
-            var group = state.GetVillagerGroup(villagerGroupID);
-            if (group == null)
-                return EngineCommandResult.Failure("Villager group not found");
+            var fail = ValidateVillagerGroup(state, villagerGroupID, out var group);
+            if (fail != null) return fail;
 
             var resourcePoint = state.GetResourcePoint(resourcePointID);
             if (resourcePoint == null)
@@ -69,8 +62,7 @@ namespace Sporefront.Commands
                 bool success = GameEngine.Instance.resourceEngine.StartGathering(villagerGroupID, resourcePointID);
                 if (!success)
                 {
-                    DebugLog.Log(string.Format("GatherCommand: StartGathering failed for group {0} at resource {1}",
-                        villagerGroupID, resourcePointID));
+                    DebugLog.Log($"GatherCommand: StartGathering failed for group {villagerGroupID} at resource {resourcePointID}");
                     return EngineCommandResult.Failure("Failed to start gathering");
                 }
 
@@ -81,8 +73,7 @@ namespace Sporefront.Commands
                     targetCoordinate = resourcePoint.coordinate
                 });
 
-                DebugLog.Log(string.Format("GatherCommand: Villager group {0} now gathering at {1}",
-                    group.name, resourcePoint.coordinate));
+                DebugLog.Log($"GatherCommand: Villager group {group.name} now gathering at {resourcePoint.coordinate}");
             }
             else
             {
@@ -102,8 +93,7 @@ namespace Sporefront.Commands
                     targetCoordinate = resourcePoint.coordinate
                 });
 
-                DebugLog.Log(string.Format("GatherCommand: Villager group {0} moving to gather at {1}",
-                    group.name, resourcePoint.coordinate));
+                DebugLog.Log($"GatherCommand: Villager group {group.name} moving to gather at {resourcePoint.coordinate}");
             }
 
             return EngineCommandResult.Success(changeBuilder.Build().changes);
@@ -129,14 +119,8 @@ namespace Sporefront.Commands
 
         public override EngineCommandResult Validate(GameState state)
         {
-            // Villager group must exist
-            var group = state.GetVillagerGroup(villagerGroupID);
-            if (group == null)
-                return EngineCommandResult.Failure("Villager group not found");
-
-            // Must be owned by this player
-            if (!group.ownerID.HasValue || group.ownerID.Value != PlayerID)
-                return EngineCommandResult.Failure("Villager group is not owned by this player");
+            var fail = ValidateVillagerGroup(state, villagerGroupID, out var group);
+            if (fail != null) return fail;
 
             // Must be currently gathering
             if (!group.IsGathering())
@@ -147,9 +131,8 @@ namespace Sporefront.Commands
 
         public override EngineCommandResult Execute(GameState state, StateChangeBuilder changeBuilder)
         {
-            var group = state.GetVillagerGroup(villagerGroupID);
-            if (group == null)
-                return EngineCommandResult.Failure("Villager group not found");
+            var fail = ValidateVillagerGroup(state, villagerGroupID, out var group);
+            if (fail != null) return fail;
 
             // Stop gathering via ResourceEngine
             GameEngine.Instance.resourceEngine.StopGathering(villagerGroupID);
@@ -162,8 +145,7 @@ namespace Sporefront.Commands
                 targetCoordinate = null
             });
 
-            DebugLog.Log(string.Format("StopGatheringCommand: Villager group {0} stopped gathering, now idle",
-                group.name));
+            DebugLog.Log($"StopGatheringCommand: Villager group {group.name} stopped gathering, now idle");
 
             return EngineCommandResult.Success(changeBuilder.Build().changes);
         }

--- a/Sporefront/Assets/Scripts/Commands/HuntCommand.cs
+++ b/Sporefront/Assets/Scripts/Commands/HuntCommand.cs
@@ -28,12 +28,8 @@ namespace Sporefront.Commands
 
         public override EngineCommandResult Validate(GameState state)
         {
-            var group = state.GetVillagerGroup(villagerGroupID);
-            if (group == null)
-                return EngineCommandResult.Failure("Villager group not found");
-
-            if (!group.ownerID.HasValue || group.ownerID.Value != PlayerID)
-                return EngineCommandResult.Failure("Not your villagers");
+            var fail = ValidateVillagerGroup(state, villagerGroupID, out var group);
+            if (fail != null) return fail;
 
             var resource = state.GetResourcePoint(resourcePointID);
             if (resource == null)
@@ -50,9 +46,8 @@ namespace Sporefront.Commands
 
         public override EngineCommandResult Execute(GameState state, StateChangeBuilder changeBuilder)
         {
-            var group = state.GetVillagerGroup(villagerGroupID);
-            if (group == null)
-                return EngineCommandResult.Failure("Villager group not found");
+            var fail = ValidateVillagerGroup(state, villagerGroupID, out var group);
+            if (fail != null) return fail;
 
             var resource = state.GetResourcePoint(resourcePointID);
             if (resource == null)
@@ -78,8 +73,7 @@ namespace Sporefront.Commands
                 targetCoordinate = resource.coordinate
             });
 
-            DebugLog.Log(string.Format("HuntCommand: Villagers assigned to hunt at ({0}, {1})",
-                resource.coordinate.q, resource.coordinate.r));
+            DebugLog.Log($"HuntCommand: Villagers assigned to hunt at ({resource.coordinate.q}, {resource.coordinate.r})");
 
             return EngineCommandResult.Success(changeBuilder.Build().changes);
         }

--- a/Sporefront/Assets/Scripts/Commands/JoinVillagerGroupCommand.cs
+++ b/Sporefront/Assets/Scripts/Commands/JoinVillagerGroupCommand.cs
@@ -31,16 +31,9 @@ namespace Sporefront.Commands
 
         public override EngineCommandResult Validate(GameState state)
         {
-            // Building exists and is owned by player
-            var building = state.GetBuilding(buildingID);
-            if (building == null)
-                return EngineCommandResult.Failure("Building not found");
-
-            if (!building.ownerID.HasValue || building.ownerID.Value != PlayerID)
-                return EngineCommandResult.Failure("Building is not owned by this player");
-
-            if (!building.IsOperational)
-                return EngineCommandResult.Failure("Building is not operational");
+            // Building exists, is owned by player, and is operational
+            var fail = ValidateOperationalBuilding(state, buildingID, out var building);
+            if (fail != null) return fail;
 
             // Count must be > 0
             if (count <= 0)
@@ -49,16 +42,11 @@ namespace Sporefront.Commands
             // Building has enough villagers
             if (building.villagerGarrison < count)
                 return EngineCommandResult.Failure(
-                    string.Format("Building does not have enough villagers in garrison (have {0}, need {1})",
-                        building.villagerGarrison, count));
+                    $"Building does not have enough villagers in garrison (have {building.villagerGarrison}, need {count})");
 
             // Target villager group exists and is owned by player
-            var targetGroup = state.GetVillagerGroup(targetVillagerGroupID);
-            if (targetGroup == null)
-                return EngineCommandResult.Failure("Target villager group not found");
-
-            if (!targetGroup.ownerID.HasValue || targetGroup.ownerID.Value != PlayerID)
-                return EngineCommandResult.Failure("Target villager group is not owned by this player");
+            fail = ValidateVillagerGroup(state, targetVillagerGroupID, out var targetGroup);
+            if (fail != null) return fail;
 
             // Path exists from building to group
             var path = state.mapData.FindPath(building.coordinate, targetGroup.coordinate, PlayerID, state);
@@ -70,13 +58,11 @@ namespace Sporefront.Commands
 
         public override EngineCommandResult Execute(GameState state, StateChangeBuilder changeBuilder)
         {
-            var building = state.GetBuilding(buildingID);
-            if (building == null)
-                return EngineCommandResult.Failure("Building not found");
+            var fail = ValidateOwnedBuilding(state, buildingID, out var building);
+            if (fail != null) return fail;
 
-            var targetGroup = state.GetVillagerGroup(targetVillagerGroupID);
-            if (targetGroup == null)
-                return EngineCommandResult.Failure("Target villager group not found");
+            fail = ValidateVillagerGroup(state, targetVillagerGroupID, out var targetGroup);
+            if (fail != null) return fail;
 
             // Find path from building to target villager group
             var path = state.mapData.FindPath(building.coordinate, targetGroup.coordinate, PlayerID, state);
@@ -95,7 +81,7 @@ namespace Sporefront.Commands
 
             // Create a new villager group to march from building to target
             var marchingGroup = new VillagerGroupData(
-                string.Format("Marching Villagers ({0})", removed),
+                $"Marching Villagers ({removed})",
                 building.coordinate,
                 removed,
                 PlayerID
@@ -127,8 +113,7 @@ namespace Sporefront.Commands
                 path = path
             });
 
-            DebugLog.Log(string.Format("JoinVillagerGroupCommand: Dispatched {0} villagers from {1} to group {2} ({3} steps)",
-                removed, building.coordinate, targetGroup.name, path.Count));
+            DebugLog.Log($"JoinVillagerGroupCommand: Dispatched {removed} villagers from {building.coordinate} to group {targetGroup.name} ({path.Count} steps)");
 
             return EngineCommandResult.Success(changeBuilder.Build().changes);
         }

--- a/Sporefront/Assets/Scripts/Commands/MarketTradeCommand.cs
+++ b/Sporefront/Assets/Scripts/Commands/MarketTradeCommand.cs
@@ -35,22 +35,11 @@ namespace Sporefront.Commands
 
         public override EngineCommandResult Validate(GameState state)
         {
-            var player = state.GetPlayer(PlayerID);
-            if (player == null)
-                return EngineCommandResult.Failure("Player not found");
+            var fail = ValidatePlayer(state, out var player);
+            if (fail != null) return fail;
 
-            var building = state.GetBuilding(buildingID);
-            if (building == null)
-                return EngineCommandResult.Failure("Building not found");
-
-            if (building.buildingType != BuildingType.Market)
-                return EngineCommandResult.Failure("Building is not a market");
-
-            if (!building.IsOperational)
-                return EngineCommandResult.Failure("Market is not operational");
-
-            if (!building.ownerID.HasValue || building.ownerID.Value != PlayerID)
-                return EngineCommandResult.Failure("Market is not owned by this player");
+            fail = ValidateOperationalBuilding(state, buildingID, out var building, BuildingType.Market);
+            if (fail != null) return fail;
 
             // Must have at least some input
             int totalInput = 0;
@@ -64,7 +53,7 @@ namespace Sporefront.Commands
 
                 if (kvp.Value > 0 && !player.HasResource(kvp.Key, kvp.Value))
                     return EngineCommandResult.Failure(
-                        string.Format("Insufficient {0}: need {1}", kvp.Key, kvp.Value));
+                        $"Insufficient {kvp.Key}: need {kvp.Value}");
 
                 totalInput += kvp.Value;
             }
@@ -77,9 +66,8 @@ namespace Sporefront.Commands
 
         public override EngineCommandResult Execute(GameState state, StateChangeBuilder changeBuilder)
         {
-            var player = state.GetPlayer(PlayerID);
-            if (player == null)
-                return EngineCommandResult.Failure("Player not found");
+            var fail = ValidatePlayer(state, out var player);
+            if (fail != null) return fail;
 
             // Deduct input resources
             int totalInput = 0;
@@ -106,8 +94,7 @@ namespace Sporefront.Commands
 
             changeBuilder.Add(new ResourcesChangedChange { playerID = PlayerID });
 
-            DebugLog.Log(string.Format("MarketTradeCommand: Player {0} traded {1} resources for {2} {3}",
-                PlayerID, totalInput, outputAmount, outputType));
+            DebugLog.Log($"MarketTradeCommand: Player {PlayerID} traded {totalInput} resources for {outputAmount} {outputType}");
 
             return EngineCommandResult.Success(changeBuilder.Build().changes);
         }

--- a/Sporefront/Assets/Scripts/Commands/MoveCommand.cs
+++ b/Sporefront/Assets/Scripts/Commands/MoveCommand.cs
@@ -37,12 +37,8 @@ namespace Sporefront.Commands
 
             if (isArmy)
             {
-                var army = state.GetArmy(entityID);
-                if (army == null)
-                    return EngineCommandResult.Failure("Army not found");
-
-                if (!army.ownerID.HasValue || army.ownerID.Value != PlayerID)
-                    return EngineCommandResult.Failure("Army is not owned by this player");
+                var fail = ValidateOwnedArmy(state, entityID, out var army);
+                if (fail != null) return fail;
 
                 if (army.isInCombat)
                     return EngineCommandResult.Failure("Army is currently in combat");
@@ -72,12 +68,8 @@ namespace Sporefront.Commands
             }
             else
             {
-                var group = state.GetVillagerGroup(entityID);
-                if (group == null)
-                    return EngineCommandResult.Failure("Villager group not found");
-
-                if (!group.ownerID.HasValue || group.ownerID.Value != PlayerID)
-                    return EngineCommandResult.Failure("Villager group is not owned by this player");
+                var fail = ValidateVillagerGroup(state, entityID, out var group);
+                if (fail != null) return fail;
             }
 
             return EngineCommandResult.Success(null);
@@ -87,9 +79,8 @@ namespace Sporefront.Commands
         {
             if (isArmy)
             {
-                var army = state.GetArmy(entityID);
-                if (army == null)
-                    return EngineCommandResult.Failure("Army not found");
+                var fail = ValidateArmy(state, entityID, out var army);
+                if (fail != null) return fail;
 
                 // Consume commander stamina
                 if (army.commanderID.HasValue)
@@ -138,7 +129,7 @@ namespace Sporefront.Commands
                         armyID = army.id,
                         coordinate = fromCoordinate
                     });
-                    DebugLog.Log(string.Format("MoveCommand: Cancelled entrenchment for army {0}", army.name));
+                    DebugLog.Log($"MoveCommand: Cancelled entrenchment for army {army.name}");
                 }
 
                 // Find path from army's current position to destination
@@ -161,14 +152,12 @@ namespace Sporefront.Commands
                     path = path
                 });
 
-                DebugLog.Log(string.Format("MoveCommand: Army {0} moving from {1} to {2} ({3} steps)",
-                    army.name, fromCoordinate, destination, path.Count));
+                DebugLog.Log($"MoveCommand: Army {army.name} moving from {fromCoordinate} to {destination} ({path.Count} steps)");
             }
             else
             {
-                var group = state.GetVillagerGroup(entityID);
-                if (group == null)
-                    return EngineCommandResult.Failure("Villager group not found");
+                var fail = ValidateVillagerGroup(state, entityID, out var group);
+                if (fail != null) return fail;
 
                 HexCoordinate fromCoordinate = group.coordinate;
 
@@ -190,8 +179,7 @@ namespace Sporefront.Commands
                     path = path
                 });
 
-                DebugLog.Log(string.Format("MoveCommand: Villager group {0} moving from {1} to {2} ({3} steps)",
-                    group.name, fromCoordinate, destination, path.Count));
+                DebugLog.Log($"MoveCommand: Villager group {group.name} moving from {fromCoordinate} to {destination} ({path.Count} steps)");
             }
 
             return EngineCommandResult.Success(changeBuilder.Build().changes);

--- a/Sporefront/Assets/Scripts/Commands/RecruitCommanderCommand.cs
+++ b/Sporefront/Assets/Scripts/Commands/RecruitCommanderCommand.cs
@@ -80,20 +80,7 @@ namespace Sporefront.Commands
             }
 
             // Deduct resources and emit state changes
-            foreach (var kvp in RecruitCost)
-            {
-                int oldAmount = player.GetResource(kvp.Key);
-                player.RemoveResource(kvp.Key, kvp.Value);
-                int newAmount = player.GetResource(kvp.Key);
-
-                changeBuilder.Add(new ResourcesChangedChange
-                {
-                    playerID = PlayerID,
-                    resourceType = kvp.Key.ToString(),
-                    oldAmount = oldAmount,
-                    newAmount = newAmount
-                });
-            }
+            DeductResourcesWithChanges(player, RecruitCost, changeBuilder);
 
             // Create commander
             var commander = new CommanderData(
@@ -112,27 +99,12 @@ namespace Sporefront.Commands
             });
 
             // Deploy commander as a standalone army at the recruiting building
-            HexCoordinate spawnCoord = recruitBuilding != null
+            HexCoordinate baseCoord = recruitBuilding != null
                 ? recruitBuilding.coordinate
                 : state.GetCityCenter(PlayerID)?.coordinate ?? new HexCoordinate(0, 0);
 
-            // Find a walkable spawn tile if the building tile is full
-            var armiesAtSpawn = state.GetArmies(spawnCoord);
-            if (armiesAtSpawn.Count >= GameConfig.Stacking.MaxEntitiesPerTile)
-            {
-                foreach (var neighbor in spawnCoord.Neighbors())
-                {
-                    if (state.mapData.IsValidCoordinate(neighbor) && state.mapData.IsWalkable(neighbor))
-                    {
-                        var armiesAtNeighbor = state.GetArmies(neighbor);
-                        if (armiesAtNeighbor.Count < GameConfig.Stacking.MaxEntitiesPerTile)
-                        {
-                            spawnCoord = neighbor;
-                            break;
-                        }
-                    }
-                }
-            }
+            var spawnResult = FindSpawnPosition(state, baseCoord, c => state.GetArmies(c).Count);
+            HexCoordinate spawnCoord = spawnResult ?? baseCoord;
 
             // Create army with commander assigned
             var army = new ArmyData(commander.name + "'s Company", spawnCoord, PlayerID);

--- a/Sporefront/Assets/Scripts/Commands/ReinforceArmyCommand.cs
+++ b/Sporefront/Assets/Scripts/Commands/ReinforceArmyCommand.cs
@@ -31,24 +31,13 @@ namespace Sporefront.Commands
 
         public override EngineCommandResult Validate(GameState state)
         {
-            // Building exists and is owned by player
-            var building = state.GetBuilding(buildingID);
-            if (building == null)
-                return EngineCommandResult.Failure("Building not found");
-
-            if (!building.ownerID.HasValue || building.ownerID.Value != PlayerID)
-                return EngineCommandResult.Failure("Building is not owned by this player");
-
-            if (!building.IsOperational)
-                return EngineCommandResult.Failure("Building is not operational");
+            // Building exists, is owned by player, and is operational
+            var fail = ValidateOperationalBuilding(state, buildingID, out var building);
+            if (fail != null) return fail;
 
             // Army exists and is owned by player
-            var army = state.GetArmy(armyID);
-            if (army == null)
-                return EngineCommandResult.Failure("Army not found");
-
-            if (!army.ownerID.HasValue || army.ownerID.Value != PlayerID)
-                return EngineCommandResult.Failure("Army is not owned by this player");
+            fail = ValidateOwnedArmy(state, armyID, out var army);
+            if (fail != null) return fail;
 
             // Total units must be > 0
             int totalUnits = 0;
@@ -66,8 +55,7 @@ namespace Sporefront.Commands
                 int garrisonCount = building.garrison.ContainsKey(kvp.Key) ? building.garrison[kvp.Key] : 0;
                 if (garrisonCount < kvp.Value)
                     return EngineCommandResult.Failure(
-                        string.Format("Building does not have enough {0} in garrison (have {1}, need {2})",
-                            kvp.Key, garrisonCount, kvp.Value));
+                        $"Building does not have enough {kvp.Key} in garrison (have {garrisonCount}, need {kvp.Value})");
             }
 
             // Path exists from building to army
@@ -80,13 +68,11 @@ namespace Sporefront.Commands
 
         public override EngineCommandResult Execute(GameState state, StateChangeBuilder changeBuilder)
         {
-            var building = state.GetBuilding(buildingID);
-            if (building == null)
-                return EngineCommandResult.Failure("Building not found");
+            var fail = ValidateOwnedBuilding(state, buildingID, out var building);
+            if (fail != null) return fail;
 
-            var army = state.GetArmy(armyID);
-            if (army == null)
-                return EngineCommandResult.Failure("Army not found");
+            fail = ValidateArmy(state, armyID, out var army);
+            if (fail != null) return fail;
 
             // Find path from building to army
             var path = state.mapData.FindPath(building.coordinate, army.coordinate, PlayerID, state);
@@ -134,8 +120,7 @@ namespace Sporefront.Commands
                 newComposition = compositionDict
             });
 
-            DebugLog.Log(string.Format("ReinforceArmyCommand: Dispatched reinforcement from {0} to army {1} ({2} units, {3} steps)",
-                building.coordinate, army.name, GetTotalUnits(), path.Count));
+            DebugLog.Log($"ReinforceArmyCommand: Dispatched reinforcement from {building.coordinate} to army {army.name} ({GetTotalUnits()} units, {path.Count} steps)");
 
             return EngineCommandResult.Success(changeBuilder.Build().changes);
         }

--- a/Sporefront/Assets/Scripts/Commands/ResearchCommand.cs
+++ b/Sporefront/Assets/Scripts/Commands/ResearchCommand.cs
@@ -95,20 +95,7 @@ namespace Sporefront.Commands
 
             // Deduct resources
             var cost = researchType.Cost();
-            foreach (var kvp in cost)
-            {
-                int oldAmount = player.GetResource(kvp.Key);
-                player.RemoveResource(kvp.Key, kvp.Value);
-                int newAmount = player.GetResource(kvp.Key);
-
-                changeBuilder.Add(new ResourcesChangedChange
-                {
-                    playerID = PlayerID,
-                    resourceType = kvp.Key.ToString(),
-                    oldAmount = oldAmount,
-                    newAmount = newAmount
-                });
-            }
+            DeductResourcesWithChanges(player, cost, changeBuilder);
 
             // Start research on player
             player.StartResearch(researchTypeRawValue, state.currentTime);

--- a/Sporefront/Assets/Scripts/Commands/RetreatCommand.cs
+++ b/Sporefront/Assets/Scripts/Commands/RetreatCommand.cs
@@ -25,12 +25,8 @@ namespace Sporefront.Commands
 
         public override EngineCommandResult Validate(GameState state)
         {
-            var army = state.GetArmy(armyID);
-            if (army == null)
-                return EngineCommandResult.Failure("Army not found");
-
-            if (!army.ownerID.HasValue || army.ownerID.Value != PlayerID)
-                return EngineCommandResult.Failure("Army is not owned by this player");
+            var fail = ValidateOwnedArmy(state, armyID, out var army);
+            if (fail != null) return fail;
 
             if (army.isRetreating)
                 return EngineCommandResult.Failure("Army is already retreating");
@@ -40,9 +36,8 @@ namespace Sporefront.Commands
 
         public override EngineCommandResult Execute(GameState state, StateChangeBuilder changeBuilder)
         {
-            var army = state.GetArmy(armyID);
-            if (army == null)
-                return EngineCommandResult.Failure("Army not found");
+            var fail = ValidateArmy(state, armyID, out var army);
+            if (fail != null) return fail;
 
             // Find nearest home base
             BuildingData homeBase = null;
@@ -65,7 +60,7 @@ namespace Sporefront.Commands
 
             if (homeBase == null)
             {
-                DebugLog.Log(string.Format("RetreatCommand: No home base available for army {0} to retreat to", army.name));
+                DebugLog.Log($"RetreatCommand: No home base available for army {army.name} to retreat to");
                 return EngineCommandResult.Failure("No home base available for retreat");
             }
 
@@ -73,8 +68,7 @@ namespace Sporefront.Commands
             var path = state.mapData.FindPath(army.coordinate, homeBase.coordinate, PlayerID, state);
             if (path == null || path.Count == 0)
             {
-                DebugLog.Log(string.Format("RetreatCommand: No valid path found for army {0} to retreat to {1}",
-                    army.name, homeBase.coordinate));
+                DebugLog.Log($"RetreatCommand: No valid path found for army {army.name} to retreat to {homeBase.coordinate}");
                 return EngineCommandResult.Failure("No valid path found to home base");
             }
 
@@ -87,14 +81,14 @@ namespace Sporefront.Commands
                     armyID = army.id,
                     coordinate = army.coordinate
                 });
-                DebugLog.Log(string.Format("RetreatCommand: Cancelled entrenchment for army {0}", army.name));
+                DebugLog.Log($"RetreatCommand: Cancelled entrenchment for army {army.name}");
             }
 
             // Disengage from combat if in combat
             if (army.isInCombat)
             {
                 GameEngine.Instance.combatEngine.RetreatFromCombat(armyID);
-                DebugLog.Log(string.Format("RetreatCommand: Disengaged army {0} from combat", army.name));
+                DebugLog.Log($"RetreatCommand: Disengaged army {army.name} from combat");
             }
 
             // Clear any pending attack and set army path as retreating
@@ -111,8 +105,7 @@ namespace Sporefront.Commands
                 to = homeBase.coordinate
             });
 
-            DebugLog.Log(string.Format("RetreatCommand: Army {0} retreating from {1} to {2} ({3})",
-                army.name, army.coordinate, homeBase.coordinate, homeBase.buildingType));
+            DebugLog.Log($"RetreatCommand: Army {army.name} retreating from {army.coordinate} to {homeBase.coordinate} ({homeBase.buildingType})");
 
             return EngineCommandResult.Success(changeBuilder.Build().changes);
         }

--- a/Sporefront/Assets/Scripts/Commands/StopMovementCommand.cs
+++ b/Sporefront/Assets/Scripts/Commands/StopMovementCommand.cs
@@ -25,12 +25,8 @@ namespace Sporefront.Commands
 
         public override EngineCommandResult Validate(GameState state)
         {
-            var army = state.GetArmy(armyID);
-            if (army == null)
-                return EngineCommandResult.Failure("Army not found");
-
-            if (!army.ownerID.HasValue || army.ownerID.Value != PlayerID)
-                return EngineCommandResult.Failure("Army is not owned by this player");
+            var fail = ValidateOwnedArmy(state, armyID, out var army);
+            if (fail != null) return fail;
 
             if (army.isInCombat)
                 return EngineCommandResult.Failure("Army is currently in combat");
@@ -43,9 +39,8 @@ namespace Sporefront.Commands
 
         public override EngineCommandResult Execute(GameState state, StateChangeBuilder changeBuilder)
         {
-            var army = state.GetArmy(armyID);
-            if (army == null)
-                return EngineCommandResult.Failure("Army not found");
+            var fail = ValidateArmy(state, armyID, out var army);
+            if (fail != null) return fail;
 
             HexCoordinate originalCoord = army.coordinate;
 
@@ -73,7 +68,7 @@ namespace Sporefront.Commands
             army.isRetreating = false;
             army.pendingAttackTarget = null;
 
-            DebugLog.Log(string.Format("StopMovementCommand: Army {0} stopped at {1}", army.name, army.coordinate));
+            DebugLog.Log($"StopMovementCommand: Army {army.name} stopped at {army.coordinate}");
 
             return EngineCommandResult.Success(changeBuilder.Build().changes);
         }

--- a/Sporefront/Assets/Scripts/Commands/TrainCommand.cs
+++ b/Sporefront/Assets/Scripts/Commands/TrainCommand.cs
@@ -34,23 +34,15 @@ namespace Sporefront.Commands
             if (quantity <= 0)
                 return EngineCommandResult.Failure("Quantity must be greater than zero");
 
-            var building = state.GetBuilding(buildingID);
-            if (building == null)
-                return EngineCommandResult.Failure("Building not found");
-
-            if (!building.ownerID.HasValue || building.ownerID.Value != PlayerID)
-                return EngineCommandResult.Failure("Building is not owned by this player");
-
-            if (!building.IsOperational)
-                return EngineCommandResult.Failure("Building is not operational");
+            var fail = ValidateOperationalBuilding(state, buildingID, out var building);
+            if (fail != null) return fail;
 
             if (!building.CanTrain(unitType))
-                return EngineCommandResult.Failure(string.Format("Building cannot train {0}", unitType.DisplayName()));
+                return EngineCommandResult.Failure($"Building cannot train {unitType.DisplayName()}");
 
             // Check player can afford the training cost
-            var player = state.GetPlayer(PlayerID);
-            if (player == null)
-                return EngineCommandResult.Failure("Player not found");
+            fail = ValidatePlayer(state, out var player);
+            if (fail != null) return fail;
 
             var unitCost = unitType.TrainingCost();
             var totalCost = new Dictionary<ResourceType, int>();
@@ -73,13 +65,11 @@ namespace Sporefront.Commands
 
         public override EngineCommandResult Execute(GameState state, StateChangeBuilder changeBuilder)
         {
-            var building = state.GetBuilding(buildingID);
-            if (building == null)
-                return EngineCommandResult.Failure("Building not found");
+            var fail = ValidateOwnedBuilding(state, buildingID, out var building);
+            if (fail != null) return fail;
 
-            var player = state.GetPlayer(PlayerID);
-            if (player == null)
-                return EngineCommandResult.Failure("Player not found");
+            fail = ValidatePlayer(state, out var player);
+            if (fail != null) return fail;
 
             // Deduct resources
             var unitCost = unitType.TrainingCost();
@@ -98,8 +88,7 @@ namespace Sporefront.Commands
                 startTime = state.currentTime
             });
 
-            DebugLog.Log(string.Format("TrainMilitaryCommand: Started training {0}x {1} at building {2}",
-                quantity, unitType.DisplayName(), buildingID));
+            DebugLog.Log($"TrainMilitaryCommand: Started training {quantity}x {unitType.DisplayName()} at building {buildingID}");
 
             return EngineCommandResult.Success(changeBuilder.Build().changes);
         }
@@ -133,23 +122,15 @@ namespace Sporefront.Commands
             if (quantity <= 0)
                 return EngineCommandResult.Failure("Quantity must be greater than zero");
 
-            var building = state.GetBuilding(buildingID);
-            if (building == null)
-                return EngineCommandResult.Failure("Building not found");
-
-            if (!building.ownerID.HasValue || building.ownerID.Value != PlayerID)
-                return EngineCommandResult.Failure("Building is not owned by this player");
-
-            if (!building.IsOperational)
-                return EngineCommandResult.Failure("Building is not operational");
+            var fail = ValidateOperationalBuilding(state, buildingID, out var building);
+            if (fail != null) return fail;
 
             if (!building.CanTrainVillagers())
                 return EngineCommandResult.Failure("Building cannot train villagers (must be City Center or Neighborhood)");
 
             // Check player can afford
-            var player = state.GetPlayer(PlayerID);
-            if (player == null)
-                return EngineCommandResult.Failure("Player not found");
+            fail = ValidatePlayer(state, out var player);
+            if (fail != null) return fail;
 
             var totalCost = new Dictionary<ResourceType, int>();
             foreach (var kvp in VillagerCost)
@@ -170,13 +151,11 @@ namespace Sporefront.Commands
 
         public override EngineCommandResult Execute(GameState state, StateChangeBuilder changeBuilder)
         {
-            var building = state.GetBuilding(buildingID);
-            if (building == null)
-                return EngineCommandResult.Failure("Building not found");
+            var fail = ValidateOwnedBuilding(state, buildingID, out var building);
+            if (fail != null) return fail;
 
-            var player = state.GetPlayer(PlayerID);
-            if (player == null)
-                return EngineCommandResult.Failure("Player not found");
+            fail = ValidatePlayer(state, out var player);
+            if (fail != null) return fail;
 
             // Deduct resources
             foreach (var kvp in VillagerCost)
@@ -193,8 +172,7 @@ namespace Sporefront.Commands
                 startTime = state.currentTime
             });
 
-            DebugLog.Log(string.Format("TrainVillagerCommand: Started training {0} villager(s) at building {1}",
-                quantity, buildingID));
+            DebugLog.Log($"TrainVillagerCommand: Started training {quantity} villager(s) at building {buildingID}");
 
             return EngineCommandResult.Success(changeBuilder.Build().changes);
         }

--- a/Sporefront/Assets/Scripts/Commands/TrainScoutCommand.cs
+++ b/Sporefront/Assets/Scripts/Commands/TrainScoutCommand.cs
@@ -31,23 +31,12 @@ namespace Sporefront.Commands
 
         public override EngineCommandResult Validate(GameState state)
         {
-            var building = state.GetBuilding(buildingID);
-            if (building == null)
-                return EngineCommandResult.Failure("Building not found");
-
-            if (!building.ownerID.HasValue || building.ownerID.Value != PlayerID)
-                return EngineCommandResult.Failure("Building is not owned by this player");
-
-            if (!building.IsOperational)
-                return EngineCommandResult.Failure("Building is not operational");
-
-            if (building.buildingType != BuildingType.CityCenter)
-                return EngineCommandResult.Failure("Scouts can only be trained at the City Center");
+            var fail = ValidateOperationalBuilding(state, buildingID, out var building, BuildingType.CityCenter);
+            if (fail != null) return fail;
 
             // Check player can afford
-            var player = state.GetPlayer(PlayerID);
-            if (player == null)
-                return EngineCommandResult.Failure("Player not found");
+            fail = ValidatePlayer(state, out var player);
+            if (fail != null) return fail;
 
             var cost = new Dictionary<ResourceType, int> { { ResourceType.Food, GameConfig.Scout.FoodCost } };
             if (!player.CanAfford(cost))
@@ -58,13 +47,11 @@ namespace Sporefront.Commands
 
         public override EngineCommandResult Execute(GameState state, StateChangeBuilder changeBuilder)
         {
-            var building = state.GetBuilding(buildingID);
-            if (building == null)
-                return EngineCommandResult.Failure("Building not found");
+            var fail = ValidateOwnedBuilding(state, buildingID, out var building);
+            if (fail != null) return fail;
 
-            var player = state.GetPlayer(PlayerID);
-            if (player == null)
-                return EngineCommandResult.Failure("Player not found");
+            fail = ValidatePlayer(state, out var player);
+            if (fail != null) return fail;
 
             // Deduct resources
             player.RemoveResource(ResourceType.Food, GameConfig.Scout.FoodCost);
@@ -79,7 +66,7 @@ namespace Sporefront.Commands
                 startTime = state.currentTime
             });
 
-            DebugLog.Log(string.Format("TrainScoutCommand: Started training scout at building {0}", buildingID));
+            DebugLog.Log($"TrainScoutCommand: Started training scout at building {buildingID}");
 
             return EngineCommandResult.Success(changeBuilder.Build().changes);
         }

--- a/Sporefront/Assets/Scripts/Commands/UpgradeCommand.cs
+++ b/Sporefront/Assets/Scripts/Commands/UpgradeCommand.cs
@@ -29,12 +29,8 @@ namespace Sporefront.Commands
 
         public override EngineCommandResult Validate(GameState state)
         {
-            var building = state.GetBuilding(buildingID);
-            if (building == null)
-                return EngineCommandResult.Failure("Building not found");
-
-            if (!building.ownerID.HasValue || building.ownerID.Value != PlayerID)
-                return EngineCommandResult.Failure("Building is not owned by this player");
+            var fail = ValidateOwnedBuilding(state, buildingID, out var building);
+            if (fail != null) return fail;
 
             if (building.state != BuildingState.Completed)
                 return EngineCommandResult.Failure("Building is not completed");
@@ -45,9 +41,8 @@ namespace Sporefront.Commands
             if (building.level >= building.MaxLevel)
                 return EngineCommandResult.Failure("Building is already at max level");
 
-            var player = state.GetPlayer(PlayerID);
-            if (player == null)
-                return EngineCommandResult.Failure("Player not found");
+            fail = ValidatePlayer(state, out var player);
+            if (fail != null) return fail;
 
             var cost = building.GetUpgradeCost();
             if (!player.CanAfford(cost))
@@ -56,11 +51,8 @@ namespace Sporefront.Commands
             // Validate assigned villager if specified
             if (assignedVillagerGroupID.HasValue)
             {
-                var group = state.GetVillagerGroup(assignedVillagerGroupID.Value);
-                if (group == null)
-                    return EngineCommandResult.Failure("Assigned villager group not found.");
-                if (!group.ownerID.HasValue || group.ownerID.Value != PlayerID)
-                    return EngineCommandResult.Failure("Assigned villager group not owned by player.");
+                fail = ValidateVillagerGroup(state, assignedVillagerGroupID.Value, out _);
+                if (fail != null) return fail;
             }
 
             return EngineCommandResult.Success(null);
@@ -68,13 +60,11 @@ namespace Sporefront.Commands
 
         public override EngineCommandResult Execute(GameState state, StateChangeBuilder changeBuilder)
         {
-            var building = state.GetBuilding(buildingID);
-            if (building == null)
-                return EngineCommandResult.Failure("Building not found");
+            var fail = ValidateOwnedBuilding(state, buildingID, out var building);
+            if (fail != null) return fail;
 
-            var player = state.GetPlayer(PlayerID);
-            if (player == null)
-                return EngineCommandResult.Failure("Player not found");
+            fail = ValidatePlayer(state, out var player);
+            if (fail != null) return fail;
 
             // Deduct resources
             var cost = building.GetUpgradeCost();
@@ -169,8 +159,7 @@ namespace Sporefront.Commands
                 });
             }
 
-            DebugLog.Log(string.Format("UpgradeCommand: Building {0} ({1}) upgrading to level {2}",
-                buildingID, building.buildingType, toLevel));
+            DebugLog.Log($"UpgradeCommand: Building {buildingID} ({building.buildingType}) upgrading to level {toLevel}");
 
             return EngineCommandResult.Success(changeBuilder.Build().changes);
         }
@@ -195,12 +184,8 @@ namespace Sporefront.Commands
 
         public override EngineCommandResult Validate(GameState state)
         {
-            var building = state.GetBuilding(buildingID);
-            if (building == null)
-                return EngineCommandResult.Failure("Building not found");
-
-            if (!building.ownerID.HasValue || building.ownerID.Value != PlayerID)
-                return EngineCommandResult.Failure("Building is not owned by this player");
+            var fail = ValidateOwnedBuilding(state, buildingID, out var building);
+            if (fail != null) return fail;
 
             if (building.state != BuildingState.Upgrading)
                 return EngineCommandResult.Failure("Building is not upgrading");
@@ -210,13 +195,11 @@ namespace Sporefront.Commands
 
         public override EngineCommandResult Execute(GameState state, StateChangeBuilder changeBuilder)
         {
-            var building = state.GetBuilding(buildingID);
-            if (building == null)
-                return EngineCommandResult.Failure("Building not found");
+            var fail = ValidateOwnedBuilding(state, buildingID, out var building);
+            if (fail != null) return fail;
 
-            var player = state.GetPlayer(PlayerID);
-            if (player == null)
-                return EngineCommandResult.Failure("Player not found");
+            fail = ValidatePlayer(state, out var player);
+            if (fail != null) return fail;
 
             // Cancel upgrade and get full cost for refund calculation
             var fullCost = building.CancelUpgrade();
@@ -236,8 +219,7 @@ namespace Sporefront.Commands
                 }
             }
 
-            DebugLog.Log(string.Format("CancelUpgradeCommand: Cancelled upgrade for building {0} ({1})",
-                buildingID, building.buildingType));
+            DebugLog.Log($"CancelUpgradeCommand: Cancelled upgrade for building {buildingID} ({building.buildingType})");
 
             return EngineCommandResult.Success(changeBuilder.Build().changes);
         }

--- a/Sporefront/Assets/Scripts/Commands/UpgradeUnitCommand.cs
+++ b/Sporefront/Assets/Scripts/Commands/UpgradeUnitCommand.cs
@@ -34,17 +34,12 @@ namespace Sporefront.Commands
                 return EngineCommandResult.Failure("Invalid upgrade type");
 
             // Player exists
-            var player = state.GetPlayer(PlayerID);
-            if (player == null)
-                return EngineCommandResult.Failure("Player not found");
+            var fail = ValidatePlayer(state, out var player);
+            if (fail != null) return fail;
 
             // Building exists and owned by player
-            var building = state.GetBuilding(buildingID);
-            if (building == null)
-                return EngineCommandResult.Failure("Building not found");
-
-            if (!building.ownerID.HasValue || building.ownerID.Value != PlayerID)
-                return EngineCommandResult.Failure("Building is not owned by this player");
+            fail = ValidateOwnedBuilding(state, buildingID, out var building);
+            if (fail != null) return fail;
 
             // Building is completed
             if (building.state != BuildingState.Completed)
@@ -53,22 +48,19 @@ namespace Sporefront.Commands
             // Building type matches required building type
             BuildingType requiredBuildingType = upgradeType.RequiredBuildingType();
             if (building.buildingType != requiredBuildingType)
-                return EngineCommandResult.Failure(string.Format("Building type {0} does not match required type {1}",
-                    building.buildingType, requiredBuildingType));
+                return EngineCommandResult.Failure($"Building type {building.buildingType} does not match required type {requiredBuildingType}");
 
             // Building level sufficient
             int requiredLevel = upgradeType.RequiredBuildingLevel();
             if (building.level < requiredLevel)
-                return EngineCommandResult.Failure(string.Format("Building level {0} is below required level {1}",
-                    building.level, requiredLevel));
+                return EngineCommandResult.Failure($"Building level {building.level} is below required level {requiredLevel}");
 
             // Prerequisite completed
             UnitUpgradeType? prerequisite = upgradeType.Prerequisite();
             if (prerequisite.HasValue)
             {
                 if (!player.HasCompletedUnitUpgrade(prerequisite.Value.ToString()))
-                    return EngineCommandResult.Failure(string.Format("Prerequisite upgrade {0} not completed",
-                        prerequisite.Value));
+                    return EngineCommandResult.Failure($"Prerequisite upgrade {prerequisite.Value} not completed");
             }
 
             // Not already completed
@@ -94,9 +86,8 @@ namespace Sporefront.Commands
             if (!Enum.TryParse<UnitUpgradeType>(upgradeTypeRawValue, out upgradeType))
                 return EngineCommandResult.Failure("Invalid upgrade type");
 
-            var player = state.GetPlayer(PlayerID);
-            if (player == null)
-                return EngineCommandResult.Failure("Player not found");
+            var fail = ValidatePlayer(state, out var player);
+            if (fail != null) return fail;
 
             // Deduct resources
             var cost = upgradeType.Cost();
@@ -118,8 +109,7 @@ namespace Sporefront.Commands
                 startTime = state.currentTime
             });
 
-            DebugLog.Log(string.Format("UpgradeUnitCommand: Player {0} started {1} (tier {2}) at building {3}",
-                PlayerID, upgradeTypeRawValue, upgradeType.Tier(), buildingID));
+            DebugLog.Log($"UpgradeUnitCommand: Player {PlayerID} started {upgradeTypeRawValue} (tier {upgradeType.Tier()}) at building {buildingID}");
 
             return EngineCommandResult.Success(changeBuilder.Build().changes);
         }

--- a/Sporefront/Assets/Scripts/Data/AICommandData.cs
+++ b/Sporefront/Assets/Scripts/Data/AICommandData.cs
@@ -181,18 +181,12 @@ namespace Sporefront.Data
             else if (command is AIDeployArmyCommand deployArmyCmd)
             {
                 aiType = AICommandType.AIDeployArmy;
-                var keys = new List<string>();
-                var values = new List<int>();
-                foreach (var kvp in deployArmyCmd.composition)
-                {
-                    keys.Add(kvp.Key.ToString());
-                    values.Add(kvp.Value);
-                }
+                DictSerializationHelper.SerializeEnumDict(deployArmyCmd.composition, out var keys, out var values);
                 paramJson = JsonUtility.ToJson(new AIDeployArmyParams
                 {
                     buildingID = deployArmyCmd.buildingID.ToString(),
-                    compositionKeys = keys.ToArray(),
-                    compositionValues = values.ToArray()
+                    compositionKeys = keys,
+                    compositionValues = values
                 });
             }
             else if (command is AIDeployVillagersCommand deployVilCmd)
@@ -268,7 +262,7 @@ namespace Sporefront.Data
             }
             else
             {
-                DebugLog.Log(string.Format("Unknown AI command type: {0}", command.GetType().Name));
+                DebugLog.Log($"Unknown AI command type: {command.GetType().Name}");
                 return null;
             }
 
@@ -331,19 +325,7 @@ namespace Sporefront.Data
                     if (p == null) return null;
                     Guid bID;
                     if (!Guid.TryParse(p.buildingID, out bID)) return null;
-                    var composition = new Dictionary<MilitaryUnitType, int>();
-                    if (p.compositionKeys != null && p.compositionValues != null
-                        && p.compositionKeys.Length == p.compositionValues.Length)
-                    {
-                        for (int i = 0; i < p.compositionKeys.Length; i++)
-                        {
-                            MilitaryUnitType ut;
-                            if (Enum.TryParse<MilitaryUnitType>(p.compositionKeys[i], out ut))
-                            {
-                                composition[ut] = p.compositionValues[i];
-                            }
-                        }
-                    }
+                    var composition = DictSerializationHelper.DeserializeEnumDict<MilitaryUnitType>(p.compositionKeys, p.compositionValues);
                     return new AIDeployArmyCommand(pid, bID, composition);
                 }
 
@@ -425,7 +407,7 @@ namespace Sporefront.Data
                 }
 
                 default:
-                    DebugLog.Log(string.Format("Unknown AI command type: {0}", cmdType));
+                    DebugLog.Log($"Unknown AI command type: {cmdType}");
                     return null;
             }
         }

--- a/Sporefront/Assets/Scripts/Data/EnumMappings.cs
+++ b/Sporefront/Assets/Scripts/Data/EnumMappings.cs
@@ -1,0 +1,31 @@
+// ============================================================================
+// FILE: Data/EnumMappings.cs
+// PURPOSE: Pre-cached enum ToString() lookups and cross-enum mappings to avoid
+//          repeated allocations in hot paths (engine update loops)
+// ============================================================================
+
+using System.Collections.Generic;
+using Sporefront.Models;
+
+namespace Sporefront.Data
+{
+    /// <summary>
+    /// Static lookup tables for enum string conversions and cross-enum mappings.
+    /// Eliminates per-frame ToString() allocations in engine update loops.
+    /// </summary>
+    public static class EnumMappings
+    {
+        /// <summary>
+        /// Maps ResourcePointType to the corresponding ResearchBonusType for gathering rate bonuses.
+        /// Only resource types that have a research bonus are included.
+        /// </summary>
+        public static readonly Dictionary<ResourcePointType, ResearchBonusType> ResourceToResearchBonus =
+            new Dictionary<ResourcePointType, ResearchBonusType>
+            {
+                { ResourcePointType.Farmland, ResearchBonusType.FarmGatheringRate },
+                { ResourcePointType.Trees, ResearchBonusType.LumberCampGatheringRate },
+                { ResourcePointType.OreMine, ResearchBonusType.MiningCampGatheringRate },
+                { ResourcePointType.StoneQuarry, ResearchBonusType.MiningCampGatheringRate }
+            };
+    }
+}

--- a/Sporefront/Assets/Scripts/Data/EnumMappings.cs.meta
+++ b/Sporefront/Assets/Scripts/Data/EnumMappings.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f768406910fa94584bf1a127cfb74cf4

--- a/Sporefront/Assets/Scripts/Data/GameSession.cs
+++ b/Sporefront/Assets/Scripts/Data/GameSession.cs
@@ -395,7 +395,7 @@ namespace Sporefront.Data
             for (int i = 0; i < aiPlayers.Count; i++)
             {
                 var ai = aiPlayers[i];
-                string aiKey = string.Format("ai_{0}", i);
+                string aiKey = $"ai_{i}";
                 players[aiKey] = new GameSessionPlayer(
                     uid: aiKey,
                     displayName: ai.displayName,

--- a/Sporefront/Assets/Scripts/Data/GameSnapshot.cs
+++ b/Sporefront/Assets/Scripts/Data/GameSnapshot.cs
@@ -30,28 +30,7 @@ namespace Sporefront.Data
         public int sizeBytes;
         public string gameVersion; // Game version that created this snapshot
 
-        // Shared serializer settings (matches SaveManager)
-        private static JsonSerializerSettings _settings;
-        private static JsonSerializerSettings Settings
-        {
-            get
-            {
-                if (_settings == null)
-                {
-                    _settings = new JsonSerializerSettings
-                    {
-                        Formatting = Formatting.None,
-                        NullValueHandling = NullValueHandling.Ignore,
-                        TypeNameHandling = TypeNameHandling.None,
-                        Converters = new List<JsonConverter>
-                        {
-                            new HexCoordinateConverter()
-                        }
-                    };
-                }
-                return _settings;
-            }
-        }
+        private static JsonSerializerSettings Settings => SporefrontJsonSettings.Compact;
 
         // ================================================================
         // Factory: Create from GameState
@@ -80,7 +59,7 @@ namespace Sporefront.Data
             }
             catch (Exception e)
             {
-                DebugLog.Log(string.Format("Failed to create game snapshot: {0}", e.Message));
+                DebugLog.Log($"Failed to create game snapshot: {e.Message}");
                 return null;
             }
         }
@@ -276,7 +255,7 @@ namespace Sporefront.Data
 
         public static string DecodingFailed(string detail)
         {
-            return string.Format("Failed to decode snapshot: {0}", detail);
+            return $"Failed to decode snapshot: {detail}";
         }
     }
 }

--- a/Sporefront/Assets/Scripts/Data/GameState.cs
+++ b/Sporefront/Assets/Scripts/Data/GameState.cs
@@ -71,6 +71,10 @@ namespace Sporefront.Data
         private Dictionary<Guid, List<VillagerGroupData>> villagerGroupsByPlayer = new Dictionary<Guid, List<VillagerGroupData>>();
         [System.NonSerialized]
         private Dictionary<Guid, List<ScoutData>> scoutsByPlayer = new Dictionary<Guid, List<ScoutData>>();
+        [System.NonSerialized]
+        private Dictionary<Guid, BuildingData> cityCenterCache = new Dictionary<Guid, BuildingData>();
+        [System.NonSerialized]
+        private Dictionary<Guid, List<CommanderData>> commandersByPlayer = new Dictionary<Guid, List<CommanderData>>();
 
         // Enemy composition analysis cache (transient)
         [System.NonSerialized]
@@ -78,6 +82,13 @@ namespace Sporefront.Data
             new Dictionary<Guid, (EnemyCompositionAnalysis?, double)>();
         [System.NonSerialized]
         private readonly double enemyAnalysisCacheTTL = 0.5; // seconds
+
+        // Visible enemy buildings cache (transient)
+        [System.NonSerialized]
+        private Dictionary<Guid, (List<BuildingData> result, double timestamp)> visibleEnemyBuildingsCache =
+            new Dictionary<Guid, (List<BuildingData>, double)>();
+        [System.NonSerialized]
+        private readonly double visibleEnemyBuildingsCacheTTL = 0.5; // seconds
 
         public GameState(int mapWidth, int mapHeight)
         {
@@ -167,6 +178,7 @@ namespace Sporefront.Data
         public void AddBuilding(BuildingData building)
         {
             buildings[building.id] = building;
+            visibleEnemyBuildingsCache.Clear();
 
             // Register with map data
             mapData.RegisterBuilding(building.id, building.coordinate, building.OccupiedCoordinates);
@@ -185,12 +197,16 @@ namespace Sporefront.Data
                 }
                 playerBuildings.Add(building);
             }
+
+            if (building.buildingType == BuildingType.CityCenter && building.ownerID.HasValue)
+                cityCenterCache[building.ownerID.Value] = building;
         }
 
         public void RemoveBuilding(Guid id)
         {
             BuildingData building;
             if (!buildings.TryGetValue(id, out building)) return;
+            visibleEnemyBuildingsCache.Clear();
 
             // Reassign home bases for armies that had this building as home
             ReassignHomeBasesForDestroyedBuilding(id, building.ownerID);
@@ -205,6 +221,9 @@ namespace Sporefront.Data
                 if (buildingsByPlayer.TryGetValue(building.ownerID.Value, out playerBuildings))
                     playerBuildings.Remove(building);
             }
+
+            if (building.buildingType == BuildingType.CityCenter && building.ownerID.HasValue)
+                cityCenterCache.Remove(building.ownerID.Value);
 
             // Unregister from map data
             mapData.UnregisterBuilding(id);
@@ -304,15 +323,16 @@ namespace Sporefront.Data
             return GetArmyCountForHomeBase(buildingID) < capacity.Value;
         }
 
+        private static readonly HashSet<BuildingType> HomeBaseTypes = new HashSet<BuildingType>
+            { BuildingType.CityCenter, BuildingType.WoodenFort, BuildingType.Castle };
+
         public BuildingData FindHomeBaseWithCapacity(Guid playerID, HexCoordinate fromCoordinate, Guid? excludingBuildingID = null)
         {
-            var validTypes = new HashSet<BuildingType> { BuildingType.CityCenter, BuildingType.WoodenFort, BuildingType.Castle };
             var candidates = new List<BuildingData>();
 
-            foreach (var b in buildings.Values)
+            foreach (var b in GetBuildingsForPlayer(playerID))
             {
-                if (b.ownerID.HasValue && b.ownerID.Value == playerID &&
-                    validTypes.Contains(b.buildingType) &&
+                if (HomeBaseTypes.Contains(b.buildingType) &&
                     b.IsOperational &&
                     (!excludingBuildingID.HasValue || b.id != excludingBuildingID.Value))
                 {
@@ -331,13 +351,11 @@ namespace Sporefront.Data
 
         public BuildingData FindNearestHomeBase(Guid playerID, HexCoordinate fromCoordinate, HexCoordinate? excludingCoordinate = null)
         {
-            var validTypes = new HashSet<BuildingType> { BuildingType.CityCenter, BuildingType.WoodenFort, BuildingType.Castle };
             var candidates = new List<BuildingData>();
 
-            foreach (var b in buildings.Values)
+            foreach (var b in GetBuildingsForPlayer(playerID))
             {
-                if (b.ownerID.HasValue && b.ownerID.Value == playerID &&
-                    validTypes.Contains(b.buildingType) &&
+                if (HomeBaseTypes.Contains(b.buildingType) &&
                     b.IsOperational)
                 {
                     if (excludingCoordinate.HasValue && b.OccupiedCoordinates.Contains(excludingCoordinate.Value))
@@ -386,12 +404,36 @@ namespace Sporefront.Data
             return GetBuilding(buildingID.Value);
         }
 
-        public List<BuildingData> GetBuildingsForPlayer(Guid playerID)
+        private static readonly List<BuildingData> EmptyBuildingList = new List<BuildingData>();
+
+        public IReadOnlyList<BuildingData> GetBuildingsForPlayer(Guid playerID)
         {
             List<BuildingData> cached;
             if (buildingsByPlayer.TryGetValue(playerID, out cached))
-                return new List<BuildingData>(cached);
-            return new List<BuildingData>();
+                return cached;
+            return EmptyBuildingList;
+        }
+
+        public bool HasBuilding(Guid playerID, BuildingType type, bool operationalOnly = false)
+        {
+            var buildings = GetBuildingsForPlayer(playerID);
+            for (int i = 0; i < buildings.Count; i++)
+            {
+                if (buildings[i].buildingType == type && (!operationalOnly || buildings[i].IsOperational))
+                    return true;
+            }
+            return false;
+        }
+
+        public BuildingData GetFirstBuilding(Guid playerID, BuildingType type, bool operationalOnly = false)
+        {
+            var buildings = GetBuildingsForPlayer(playerID);
+            for (int i = 0; i < buildings.Count; i++)
+            {
+                if (buildings[i].buildingType == type && (!operationalOnly || buildings[i].IsOperational))
+                    return buildings[i];
+            }
+            return null;
         }
 
         // ================================================================
@@ -506,12 +548,14 @@ namespace Sporefront.Data
             return covered;
         }
 
-        public List<ArmyData> GetArmiesForPlayer(Guid playerID)
+        private static readonly List<ArmyData> EmptyArmyList = new List<ArmyData>();
+
+        public IReadOnlyList<ArmyData> GetArmiesForPlayer(Guid playerID)
         {
             List<ArmyData> cached;
             if (armiesByPlayer.TryGetValue(playerID, out cached))
-                return new List<ArmyData>(cached);
-            return new List<ArmyData>();
+                return cached;
+            return EmptyArmyList;
         }
 
         public void UpdateArmyPosition(Guid armyID, HexCoordinate to)
@@ -589,12 +633,14 @@ namespace Sporefront.Data
             return result;
         }
 
-        public List<VillagerGroupData> GetVillagerGroupsForPlayer(Guid playerID)
+        private static readonly List<VillagerGroupData> EmptyVillagerGroupList = new List<VillagerGroupData>();
+
+        public IReadOnlyList<VillagerGroupData> GetVillagerGroupsForPlayer(Guid playerID)
         {
             List<VillagerGroupData> cached;
             if (villagerGroupsByPlayer.TryGetValue(playerID, out cached))
-                return new List<VillagerGroupData>(cached);
-            return new List<VillagerGroupData>();
+                return cached;
+            return EmptyVillagerGroupList;
         }
 
         public void UpdateVillagerGroupPosition(Guid groupID, HexCoordinate to)
@@ -648,12 +694,14 @@ namespace Sporefront.Data
             return scouts.TryGetValue(id, out scout) ? scout : null;
         }
 
-        public List<ScoutData> GetScoutsForPlayer(Guid playerID)
+        private static readonly List<ScoutData> EmptyScoutList = new List<ScoutData>();
+
+        public IReadOnlyList<ScoutData> GetScoutsForPlayer(Guid playerID)
         {
             List<ScoutData> cached;
             if (scoutsByPlayer.TryGetValue(playerID, out cached))
-                return new List<ScoutData>(cached);
-            return new List<ScoutData>();
+                return cached;
+            return EmptyScoutList;
         }
 
         public void UpdateScoutPosition(Guid scoutID, HexCoordinate to)
@@ -710,6 +758,14 @@ namespace Sporefront.Data
             {
                 var player = GetPlayer(commander.ownerID.Value);
                 if (player != null) player.AddOwnedCommander(commander.id);
+
+                List<CommanderData> playerCommanders;
+                if (!commandersByPlayer.TryGetValue(commander.ownerID.Value, out playerCommanders))
+                {
+                    playerCommanders = new List<CommanderData>();
+                    commandersByPlayer[commander.ownerID.Value] = playerCommanders;
+                }
+                playerCommanders.Add(commander);
             }
         }
 
@@ -722,6 +778,10 @@ namespace Sporefront.Data
             {
                 var player = GetPlayer(commander.ownerID.Value);
                 if (player != null) player.RemoveOwnedCommander(id);
+
+                List<CommanderData> playerCommanders;
+                if (commandersByPlayer.TryGetValue(commander.ownerID.Value, out playerCommanders))
+                    playerCommanders.Remove(commander);
             }
 
             commanders.Remove(id);
@@ -733,15 +793,14 @@ namespace Sporefront.Data
             return commanders.TryGetValue(id, out commander) ? commander : null;
         }
 
-        public List<CommanderData> GetCommandersForPlayer(Guid playerID)
+        private static readonly List<CommanderData> EmptyCommanderList = new List<CommanderData>();
+
+        public IReadOnlyList<CommanderData> GetCommandersForPlayer(Guid playerID)
         {
-            var result = new List<CommanderData>();
-            foreach (var commander in commanders.Values)
-            {
-                if (commander.ownerID.HasValue && commander.ownerID.Value == playerID)
-                    result.Add(commander);
-            }
-            return result;
+            List<CommanderData> cached;
+            if (commandersByPlayer.TryGetValue(playerID, out cached))
+                return cached;
+            return EmptyCommanderList;
         }
 
         // ================================================================
@@ -763,10 +822,27 @@ namespace Sporefront.Data
         public List<ArmyData> GetEnemyArmiesInRange(HexCoordinate coordinate, int range, Guid playerID)
         {
             var result = new List<ArmyData>();
-            foreach (var army in armies.Values)
+            // For small ranges, use spatial lookup instead of scanning all armies
+            if (range <= 6)
             {
-                if (!army.ownerID.HasValue || army.ownerID.Value == playerID) continue;
-                if (army.coordinate.Distance(coordinate) <= range) result.Add(army);
+                foreach (var coord in coordinate.CoordinatesWithinRange(range))
+                {
+                    foreach (var armyId in mapData.GetArmyIDs(coord))
+                    {
+                        ArmyData army;
+                        if (!armies.TryGetValue(armyId, out army)) continue;
+                        if (!army.ownerID.HasValue || army.ownerID.Value == playerID) continue;
+                        result.Add(army);
+                    }
+                }
+            }
+            else
+            {
+                foreach (var army in armies.Values)
+                {
+                    if (!army.ownerID.HasValue || army.ownerID.Value == playerID) continue;
+                    if (army.coordinate.Distance(coordinate) <= range) result.Add(army);
+                }
             }
             return result;
         }
@@ -828,16 +904,11 @@ namespace Sporefront.Data
 
         public int GetCityCenterLevel(Guid playerID)
         {
-            int maxLevel = 0;
-            foreach (var building in GetBuildingsForPlayer(playerID))
-            {
-                if (building.buildingType == BuildingType.CityCenter &&
-                    (building.state == BuildingState.Completed || building.state == BuildingState.Upgrading))
-                {
-                    if (building.level > maxLevel) maxLevel = building.level;
-                }
-            }
-            return maxLevel;
+            BuildingData cc;
+            if (cityCenterCache.TryGetValue(playerID, out cc) &&
+                (cc.state == BuildingState.Completed || cc.state == BuildingState.Upgrading))
+                return cc.level;
+            return 0;
         }
 
         // ================================================================
@@ -987,25 +1058,61 @@ namespace Sporefront.Data
         public List<ArmyData> GetEnemyArmies(HexCoordinate near, int range, Guid playerID)
         {
             var result = new List<ArmyData>();
-            foreach (var army in armies.Values)
+            // For small ranges, use spatial lookup instead of scanning all armies
+            if (range <= 6)
             {
-                if (!army.ownerID.HasValue || army.ownerID.Value == playerID) continue;
-
-                var status = GetDiplomacyStatus(playerID, army.ownerID.Value);
-                if (status != DiplomacyStatus.Enemy) continue;
-
-                if (army.coordinate.Distance(near) <= range) result.Add(army);
+                foreach (var coord in near.CoordinatesWithinRange(range))
+                {
+                    foreach (var armyId in mapData.GetArmyIDs(coord))
+                    {
+                        ArmyData army;
+                        if (!armies.TryGetValue(armyId, out army)) continue;
+                        if (!army.ownerID.HasValue || army.ownerID.Value == playerID) continue;
+                        var status = GetDiplomacyStatus(playerID, army.ownerID.Value);
+                        if (status != DiplomacyStatus.Enemy) continue;
+                        result.Add(army);
+                    }
+                }
+            }
+            else
+            {
+                foreach (var army in armies.Values)
+                {
+                    if (!army.ownerID.HasValue || army.ownerID.Value == playerID) continue;
+                    var status = GetDiplomacyStatus(playerID, army.ownerID.Value);
+                    if (status != DiplomacyStatus.Enemy) continue;
+                    if (army.coordinate.Distance(near) <= range) result.Add(army);
+                }
             }
             return result;
         }
 
         public List<BuildingData> GetUndefendedBuildings(Guid playerID)
         {
+            // Pre-compute all coordinates defended by garrison buildings (O(n * r) where r = defense range)
+            var defendedCoords = new HashSet<HexCoordinate>();
+            foreach (var building in GetBuildingsForPlayer(playerID))
+            {
+                if (!building.CanProvideGarrisonDefense || !building.IsOperational) continue;
+                int defenseRange = building.GarrisonDefenseRange;
+                foreach (var coord in building.OccupiedCoordinates)
+                {
+                    foreach (var covered in coord.CoordinatesWithinRange(defenseRange))
+                        defendedCoords.Add(covered);
+                }
+            }
+
+            // Check each building: if ANY of its tiles are in the defended set, it's protected
             var result = new List<BuildingData>();
             foreach (var building in GetBuildingsForPlayer(playerID))
             {
-                if (!IsBuildingProtected(building.id) && building.IsOperational)
-                    result.Add(building);
+                if (!building.IsOperational) continue;
+                bool isProtected = false;
+                foreach (var coord in building.OccupiedCoordinates)
+                {
+                    if (defendedCoords.Contains(coord)) { isProtected = true; break; }
+                }
+                if (!isProtected) result.Add(building);
             }
             return result;
         }
@@ -1049,6 +1156,14 @@ namespace Sporefront.Data
             var player = GetPlayer(playerID);
             if (player == null) return new List<BuildingData>();
 
+            // Check cache
+            (List<BuildingData> result, double timestamp) cached;
+            if (visibleEnemyBuildingsCache.TryGetValue(playerID, out cached) &&
+                currentTime - cached.timestamp < visibleEnemyBuildingsCacheTTL)
+            {
+                return cached.result;
+            }
+
             var result = new List<BuildingData>();
             foreach (var building in buildings.Values)
             {
@@ -1064,16 +1179,16 @@ namespace Sporefront.Data
                 }
                 if (isVisible) result.Add(building);
             }
+
+            visibleEnemyBuildingsCache[playerID] = (result, currentTime);
             return result;
         }
 
         public BuildingData GetCityCenter(Guid playerID)
         {
-            foreach (var building in GetBuildingsForPlayer(playerID))
-            {
-                if (building.buildingType == BuildingType.CityCenter && building.IsOperational)
-                    return building;
-            }
+            BuildingData cached;
+            if (cityCenterCache.TryGetValue(playerID, out cached) && cached.IsOperational)
+                return cached;
             return null;
         }
 
@@ -1312,10 +1427,8 @@ namespace Sporefront.Data
             {
                 double civilianRate = civilianCount * baseRate;
                 double militaryRate = militaryCount * baseRate;
-                double civMultiplier = player.GetResearchBonusMultiplier(
-                    ResearchBonusType.FoodConsumption.ToString());
-                double milMultiplier = player.GetResearchBonusMultiplier(
-                    ResearchBonusType.MilitaryFoodConsumption.ToString());
+                double civMultiplier = player.GetResearchBonusMultiplier(ResearchBonusType.FoodConsumption);
+                double milMultiplier = player.GetResearchBonusMultiplier(ResearchBonusType.MilitaryFoodConsumption);
 
                 var commanders = GetCommandersForPlayer(playerID);
                 int bestRationing = 0;

--- a/Sporefront/Assets/Scripts/Data/MapData.cs
+++ b/Sporefront/Assets/Scripts/Data/MapData.cs
@@ -113,40 +113,51 @@ namespace Sporefront.Data
 
         // Army Management
 
+        // Reverse lookup: coordinate → army IDs (O(1) instead of O(N) scan)
+        private Dictionary<HexCoordinate, HashSet<Guid>> coordinateToArmies = new Dictionary<HexCoordinate, HashSet<Guid>>();
+        private static readonly HashSet<Guid> EmptyGuidSet = new HashSet<Guid>();
+
         public void RegisterArmy(Guid id, HexCoordinate coordinate)
         {
             armyIDs.Add(id);
             armyCoordinates[id] = coordinate;
+            AddToCoordinateSet(coordinateToArmies, coordinate, id);
         }
 
         public void UnregisterArmy(Guid id)
         {
+            HexCoordinate coord;
+            if (armyCoordinates.TryGetValue(id, out coord))
+                RemoveFromCoordinateSet(coordinateToArmies, coord, id);
             armyIDs.Remove(id);
             armyCoordinates.Remove(id);
         }
 
         public void UpdateArmyPosition(Guid id, HexCoordinate coordinate)
         {
+            HexCoordinate oldCoord;
+            if (armyCoordinates.TryGetValue(id, out oldCoord))
+                RemoveFromCoordinateSet(coordinateToArmies, oldCoord, id);
             armyCoordinates[id] = coordinate;
+            AddToCoordinateSet(coordinateToArmies, coordinate, id);
         }
 
         public Guid? GetArmyID(HexCoordinate coordinate)
         {
-            foreach (var kvp in armyCoordinates)
+            HashSet<Guid> set;
+            if (coordinateToArmies.TryGetValue(coordinate, out set))
             {
-                if (kvp.Value == coordinate) return kvp.Key;
+                foreach (var id in set) return id;
             }
             return null;
         }
 
-        public List<Guid> GetArmyIDs(HexCoordinate coordinate)
+        public IReadOnlyCollection<Guid> GetArmyIDs(HexCoordinate coordinate)
         {
-            var result = new List<Guid>();
-            foreach (var kvp in armyCoordinates)
-            {
-                if (kvp.Value == coordinate) result.Add(kvp.Key);
-            }
-            return result;
+            HashSet<Guid> set;
+            if (coordinateToArmies.TryGetValue(coordinate, out set))
+                return set;
+            return EmptyGuidSet;
         }
 
         public HexCoordinate? GetArmyCoordinate(Guid id)
@@ -157,40 +168,50 @@ namespace Sporefront.Data
 
         // Villager Group Management
 
+        // Reverse lookup: coordinate → villager group IDs (O(1) instead of O(N) scan)
+        private Dictionary<HexCoordinate, HashSet<Guid>> coordinateToVillagerGroups = new Dictionary<HexCoordinate, HashSet<Guid>>();
+
         public void RegisterVillagerGroup(Guid id, HexCoordinate coordinate)
         {
             villagerGroupIDs.Add(id);
             villagerGroupCoordinates[id] = coordinate;
+            AddToCoordinateSet(coordinateToVillagerGroups, coordinate, id);
         }
 
         public void UnregisterVillagerGroup(Guid id)
         {
+            HexCoordinate coord;
+            if (villagerGroupCoordinates.TryGetValue(id, out coord))
+                RemoveFromCoordinateSet(coordinateToVillagerGroups, coord, id);
             villagerGroupIDs.Remove(id);
             villagerGroupCoordinates.Remove(id);
         }
 
         public void UpdateVillagerGroupPosition(Guid id, HexCoordinate coordinate)
         {
+            HexCoordinate oldCoord;
+            if (villagerGroupCoordinates.TryGetValue(id, out oldCoord))
+                RemoveFromCoordinateSet(coordinateToVillagerGroups, oldCoord, id);
             villagerGroupCoordinates[id] = coordinate;
+            AddToCoordinateSet(coordinateToVillagerGroups, coordinate, id);
         }
 
         public Guid? GetVillagerGroupID(HexCoordinate coordinate)
         {
-            foreach (var kvp in villagerGroupCoordinates)
+            HashSet<Guid> set;
+            if (coordinateToVillagerGroups.TryGetValue(coordinate, out set))
             {
-                if (kvp.Value == coordinate) return kvp.Key;
+                foreach (var id in set) return id;
             }
             return null;
         }
 
-        public List<Guid> GetVillagerGroupIDs(HexCoordinate coordinate)
+        public IReadOnlyCollection<Guid> GetVillagerGroupIDs(HexCoordinate coordinate)
         {
-            var result = new List<Guid>();
-            foreach (var kvp in villagerGroupCoordinates)
-            {
-                if (kvp.Value == coordinate) result.Add(kvp.Key);
-            }
-            return result;
+            HashSet<Guid> set;
+            if (coordinateToVillagerGroups.TryGetValue(coordinate, out set))
+                return set;
+            return EmptyGuidSet;
         }
 
         public HexCoordinate? GetVillagerGroupCoordinate(Guid id)
@@ -242,14 +263,11 @@ namespace Sporefront.Data
         public int GetEntityCount(HexCoordinate coordinate)
         {
             int count = 0;
-            foreach (var kvp in armyCoordinates)
-            {
-                if (kvp.Value == coordinate) count++;
-            }
-            foreach (var kvp in villagerGroupCoordinates)
-            {
-                if (kvp.Value == coordinate) count++;
-            }
+            HashSet<Guid> set;
+            if (coordinateToArmies.TryGetValue(coordinate, out set))
+                count += set.Count;
+            if (coordinateToVillagerGroups.TryGetValue(coordinate, out set))
+                count += set.Count;
             return count;
         }
 
@@ -333,6 +351,12 @@ namespace Sporefront.Data
 
         // Pathfinding (A*)
 
+        // Reusable pathfinding collections (cleared per call, avoids allocation)
+        private Dictionary<HexCoordinate, HexCoordinate> _pfCameFrom = new Dictionary<HexCoordinate, HexCoordinate>();
+        private Dictionary<HexCoordinate, int> _pfGScore = new Dictionary<HexCoordinate, int>();
+        private HashSet<HexCoordinate> _pfClosedSet = new HashSet<HexCoordinate>();
+        private List<(HexCoordinate coord, int priority)> _pfHeap = new List<(HexCoordinate, int)>();
+
         public List<HexCoordinate> FindPath(HexCoordinate start, HexCoordinate goal, Guid? playerID,
             GameState gameState, bool allowImpassableDestination = false,
             HashSet<HexCoordinate> targetBuildingCoordinates = null)
@@ -344,20 +368,17 @@ namespace Sporefront.Data
 
             if (start == goal) return new List<HexCoordinate>();
 
-            var openSet = new HashSet<HexCoordinate> { start };
-            var cameFrom = new Dictionary<HexCoordinate, HexCoordinate>();
-            var gScore = new Dictionary<HexCoordinate, int> { { start, 0 } };
-            var fScore = new Dictionary<HexCoordinate, int> { { start, start.Distance(goal) } };
+            _pfCameFrom.Clear();
+            _pfGScore.Clear();
+            _pfClosedSet.Clear();
+            _pfHeap.Clear();
 
-            while (openSet.Count > 0)
+            _pfGScore[start] = 0;
+            HeapPush(_pfHeap, start, start.Distance(goal));
+
+            while (_pfHeap.Count > 0)
             {
-                HexCoordinate current = default;
-                int bestF = int.MaxValue;
-                foreach (var c in openSet)
-                {
-                    int f = fScore.ContainsKey(c) ? fScore[c] : int.MaxValue;
-                    if (f < bestF) { bestF = f; current = c; }
-                }
+                var (current, _) = HeapPop(_pfHeap);
 
                 if (current == goal)
                 {
@@ -366,17 +387,22 @@ namespace Sporefront.Data
                     while (node != start)
                     {
                         path.Add(node);
-                        if (!cameFrom.ContainsKey(node)) break;
-                        node = cameFrom[node];
+                        if (!_pfCameFrom.ContainsKey(node)) break;
+                        node = _pfCameFrom[node];
                     }
                     path.Reverse();
                     return path;
                 }
 
-                openSet.Remove(current);
+                if (!_pfClosedSet.Add(current)) continue; // Skip if already processed
+
+                int currentG;
+                if (!_pfGScore.TryGetValue(current, out currentG)) continue;
 
                 foreach (var neighbor in current.Neighbors())
                 {
+                    if (_pfClosedSet.Contains(neighbor)) continue;
+
                     bool neighborPassable = IsPassable(neighbor, playerID, gameState);
                     bool isGoalTile = neighbor == goal && allowImpassableDestination;
                     bool isTargetBuildingTile = targetBuildingCoordinates != null && targetBuildingCoordinates.Contains(neighbor);
@@ -384,22 +410,61 @@ namespace Sporefront.Data
                         continue;
 
                     int moveCost = GetMovementCost(neighbor);
-                    int currentG = gScore.ContainsKey(current) ? gScore[current] : int.MaxValue;
-                    if (currentG == int.MaxValue) continue;
                     int tentativeG = currentG + moveCost;
-                    int neighborG = gScore.ContainsKey(neighbor) ? gScore[neighbor] : int.MaxValue;
+                    int neighborG;
+                    if (!_pfGScore.TryGetValue(neighbor, out neighborG))
+                        neighborG = int.MaxValue;
 
                     if (tentativeG < neighborG)
                     {
-                        cameFrom[neighbor] = current;
-                        gScore[neighbor] = tentativeG;
-                        fScore[neighbor] = tentativeG + neighbor.Distance(goal);
-                        openSet.Add(neighbor);
+                        _pfCameFrom[neighbor] = current;
+                        _pfGScore[neighbor] = tentativeG;
+                        HeapPush(_pfHeap, neighbor, tentativeG + neighbor.Distance(goal));
                     }
                 }
             }
 
             return null;
+        }
+
+        // Binary min-heap operations (inline to avoid class overhead)
+        private static void HeapPush(List<(HexCoordinate coord, int priority)> heap, HexCoordinate coord, int priority)
+        {
+            heap.Add((coord, priority));
+            int i = heap.Count - 1;
+            while (i > 0)
+            {
+                int parent = (i - 1) / 2;
+                if (heap[parent].priority <= heap[i].priority) break;
+                var tmp = heap[parent];
+                heap[parent] = heap[i];
+                heap[i] = tmp;
+                i = parent;
+            }
+        }
+
+        private static (HexCoordinate coord, int priority) HeapPop(List<(HexCoordinate coord, int priority)> heap)
+        {
+            var min = heap[0];
+            int last = heap.Count - 1;
+            heap[0] = heap[last];
+            heap.RemoveAt(last);
+            last--;
+            int i = 0;
+            while (true)
+            {
+                int left = 2 * i + 1;
+                int right = 2 * i + 2;
+                int smallest = i;
+                if (left <= last && heap[left].priority < heap[smallest].priority) smallest = left;
+                if (right <= last && heap[right].priority < heap[smallest].priority) smallest = right;
+                if (smallest == i) break;
+                var tmp = heap[smallest];
+                heap[smallest] = heap[i];
+                heap[i] = tmp;
+                i = smallest;
+            }
+            return min;
         }
 
         public HexCoordinate? FindNearestWalkable(HexCoordinate target, int maxDistance, Guid? playerID, GameState gameState)
@@ -411,34 +476,50 @@ namespace Sporefront.Data
                 return target;
             }
 
+            // Use CoordinatesInRing to check only hexes at each distance,
+            // instead of scanning the entire tiles dictionary per ring
             for (int distance = 1; distance <= maxDistance; distance++)
             {
-                var candidates = new List<HexCoordinate>();
-                foreach (var kvp in tiles)
+                HexCoordinate? best = null;
+                int bestDist = int.MaxValue;
+
+                foreach (var coord in target.CoordinatesInRing(distance))
                 {
-                    if (kvp.Key.Distance(target) == distance &&
-                        IsPassable(kvp.Key, playerID, gameState) &&
-                        GetEntityCount(kvp.Key) < GameConfig.Stacking.MaxEntitiesPerTile &&
-                        !GetBuildingID(kvp.Key).HasValue)
-                    {
-                        candidates.Add(kvp.Key);
-                    }
+                    if (!IsValidCoordinate(coord)) continue;
+                    if (!IsPassable(coord, playerID, gameState)) continue;
+                    if (GetEntityCount(coord) >= GameConfig.Stacking.MaxEntitiesPerTile) continue;
+                    if (GetBuildingID(coord).HasValue) continue;
+
+                    int d = coord.Distance(target);
+                    if (d < bestDist) { best = coord; bestDist = d; }
                 }
 
-                if (candidates.Count > 0)
-                {
-                    HexCoordinate best = candidates[0];
-                    int bestDist = best.Distance(target);
-                    for (int i = 1; i < candidates.Count; i++)
-                    {
-                        int d = candidates[i].Distance(target);
-                        if (d < bestDist) { best = candidates[i]; bestDist = d; }
-                    }
-                    return best;
-                }
+                if (best.HasValue) return best;
             }
 
             return null;
+        }
+
+        // Shared helpers for coordinate reverse lookups
+        private static void AddToCoordinateSet(Dictionary<HexCoordinate, HashSet<Guid>> dict, HexCoordinate coord, Guid id)
+        {
+            HashSet<Guid> set;
+            if (!dict.TryGetValue(coord, out set))
+            {
+                set = new HashSet<Guid>();
+                dict[coord] = set;
+            }
+            set.Add(id);
+        }
+
+        private static void RemoveFromCoordinateSet(Dictionary<HexCoordinate, HashSet<Guid>> dict, HexCoordinate coord, Guid id)
+        {
+            HashSet<Guid> set;
+            if (dict.TryGetValue(coord, out set))
+            {
+                set.Remove(id);
+                if (set.Count == 0) dict.Remove(coord);
+            }
         }
     }
 }

--- a/Sporefront/Assets/Scripts/Data/OnlineCommand.cs
+++ b/Sporefront/Assets/Scripts/Data/OnlineCommand.cs
@@ -23,19 +23,19 @@ namespace Sporefront.Data
         public static OnlineCommandException SerializationFailed(string detail)
         {
             return new OnlineCommandException(
-                string.Format("Failed to serialize command: {0}", detail));
+                $"Failed to serialize command: {detail}");
         }
 
         public static OnlineCommandException DeserializationFailed(string detail)
         {
             return new OnlineCommandException(
-                string.Format("Failed to deserialize command: {0}", detail));
+                $"Failed to deserialize command: {detail}");
         }
 
         public static OnlineCommandException UnknownCommandType(string type)
         {
             return new OnlineCommandException(
-                string.Format("Unknown command type: {0}", type));
+                $"Unknown command type: {type}");
         }
     }
 
@@ -103,7 +103,7 @@ namespace Sporefront.Data
                 {
                     sequence = sequence,
                     commandID = envelope.commandID,
-                    commandType = string.Format("ai_{0}", (AICommandType)envelope.aiCommandType),
+                    commandType = $"ai_{(AICommandType)envelope.aiCommandType}",
                     playerID = envelope.playerID,
                     timestamp = envelope.timestamp,
                     isAICommand = true,
@@ -141,9 +141,8 @@ namespace Sporefront.Data
             }
             catch (Exception e)
             {
-                DebugLog.Log(string.Format(
-                    "OnlineCommand.ToEngineCommand() failed for type {0}: {1}",
-                    commandType, e.Message));
+                DebugLog.Log(
+                    $"OnlineCommand.ToEngineCommand() failed for type {commandType}: {e.Message}");
                 return null;
             }
         }
@@ -171,8 +170,8 @@ namespace Sporefront.Data
             }
             catch (Exception e)
             {
-                DebugLog.Log(string.Format(
-                    "Failed to decode AICommandEnvelope: {0}", e.Message));
+                DebugLog.Log(
+                    $"Failed to decode AICommandEnvelope: {e.Message}");
                 return null;
             }
         }

--- a/Sporefront/Assets/Scripts/Data/PlayerCommandRegistry.cs
+++ b/Sporefront/Assets/Scripts/Data/PlayerCommandRegistry.cs
@@ -265,21 +265,12 @@ namespace Sporefront.Data
             }
             if (command is DeployArmyCommand deployArmy)
             {
-                var keys = new List<string>();
-                var values = new List<int>();
-                if (deployArmy.composition != null)
-                {
-                    foreach (var kvp in deployArmy.composition)
-                    {
-                        keys.Add(kvp.Key.ToString());
-                        values.Add(kvp.Value);
-                    }
-                }
+                DictSerializationHelper.SerializeEnumDict(deployArmy.composition, out var keys, out var values);
                 return JsonUtility.ToJson(new DeployArmyParams
                 {
                     buildingID = deployArmy.buildingID.ToString(),
-                    compositionKeys = keys.ToArray(),
-                    compositionValues = values.ToArray()
+                    compositionKeys = keys,
+                    compositionValues = values
                 });
             }
             if (command is DeployVillagersCommand deployVillagers)
@@ -339,21 +330,12 @@ namespace Sporefront.Data
             }
             if (command is MarketTradeCommand trade)
             {
-                var keys = new List<string>();
-                var values = new List<int>();
-                if (trade.inputResources != null)
-                {
-                    foreach (var kvp in trade.inputResources)
-                    {
-                        keys.Add(kvp.Key.ToString());
-                        values.Add(kvp.Value);
-                    }
-                }
+                DictSerializationHelper.SerializeEnumDict(trade.inputResources, out var keys, out var values);
                 return JsonUtility.ToJson(new MarketTradeParams
                 {
                     buildingID = trade.buildingID.ToString(),
-                    inputResourceKeys = keys.ToArray(),
-                    inputResourceValues = values.ToArray(),
+                    inputResourceKeys = keys,
+                    inputResourceValues = values,
                     outputType = trade.outputType.ToString()
                 });
             }
@@ -376,22 +358,13 @@ namespace Sporefront.Data
             }
             if (command is ReinforceArmyCommand reinforce)
             {
-                var keys = new List<string>();
-                var values = new List<int>();
-                if (reinforce.units != null)
-                {
-                    foreach (var kvp in reinforce.units)
-                    {
-                        keys.Add(kvp.Key.ToString());
-                        values.Add(kvp.Value);
-                    }
-                }
+                DictSerializationHelper.SerializeEnumDict(reinforce.units, out var keys, out var values);
                 return JsonUtility.ToJson(new ReinforceArmyParams
                 {
                     buildingID = reinforce.buildingID.ToString(),
                     armyID = reinforce.armyID.ToString(),
-                    unitKeys = keys.ToArray(),
-                    unitValues = values.ToArray()
+                    unitKeys = keys,
+                    unitValues = values
                 });
             }
             if (command is CancelResearchCommand)
@@ -484,8 +457,7 @@ namespace Sporefront.Data
                 });
             }
 
-            DebugLog.Log(string.Format("PlayerCommandRegistry: Unknown command type: {0}",
-                command.GetType().Name));
+            DebugLog.Log($"PlayerCommandRegistry: Unknown command type: {command.GetType().Name}");
             // Fallback to raw JsonUtility (will miss Dictionary/nullable fields)
             return JsonUtility.ToJson(command);
         }
@@ -581,17 +553,7 @@ namespace Sporefront.Data
                     if (p == null) return null;
                     Guid bID;
                     if (!Guid.TryParse(p.buildingID, out bID)) return null;
-                    var composition = new Dictionary<MilitaryUnitType, int>();
-                    if (p.compositionKeys != null && p.compositionValues != null
-                        && p.compositionKeys.Length == p.compositionValues.Length)
-                    {
-                        for (int i = 0; i < p.compositionKeys.Length; i++)
-                        {
-                            MilitaryUnitType ut;
-                            if (Enum.TryParse<MilitaryUnitType>(p.compositionKeys[i], out ut))
-                                composition[ut] = p.compositionValues[i];
-                        }
-                    }
+                    var composition = DictSerializationHelper.DeserializeEnumDict<MilitaryUnitType>(p.compositionKeys, p.compositionValues);
                     return new DeployArmyCommand(cmdId, pid, timestamp, bID, composition);
                 }
 
@@ -670,17 +632,7 @@ namespace Sporefront.Data
                     if (!Guid.TryParse(p.buildingID, out bID)) return null;
                     ResourceType outType;
                     if (!Enum.TryParse<ResourceType>(p.outputType, out outType)) return null;
-                    var inputResources = new Dictionary<ResourceType, int>();
-                    if (p.inputResourceKeys != null && p.inputResourceValues != null
-                        && p.inputResourceKeys.Length == p.inputResourceValues.Length)
-                    {
-                        for (int i = 0; i < p.inputResourceKeys.Length; i++)
-                        {
-                            ResourceType rt;
-                            if (Enum.TryParse<ResourceType>(p.inputResourceKeys[i], out rt))
-                                inputResources[rt] = p.inputResourceValues[i];
-                        }
-                    }
+                    var inputResources = DictSerializationHelper.DeserializeEnumDict<ResourceType>(p.inputResourceKeys, p.inputResourceValues);
                     return new MarketTradeCommand(cmdId, pid, timestamp, bID, inputResources, outType);
                 }
 
@@ -710,17 +662,7 @@ namespace Sporefront.Data
                     Guid bID, aID;
                     if (!Guid.TryParse(p.buildingID, out bID)) return null;
                     if (!Guid.TryParse(p.armyID, out aID)) return null;
-                    var units = new Dictionary<MilitaryUnitType, int>();
-                    if (p.unitKeys != null && p.unitValues != null
-                        && p.unitKeys.Length == p.unitValues.Length)
-                    {
-                        for (int i = 0; i < p.unitKeys.Length; i++)
-                        {
-                            MilitaryUnitType ut;
-                            if (Enum.TryParse<MilitaryUnitType>(p.unitKeys[i], out ut))
-                                units[ut] = p.unitValues[i];
-                        }
-                    }
+                    var units = DictSerializationHelper.DeserializeEnumDict<MilitaryUnitType>(p.unitKeys, p.unitValues);
                     return new ReinforceArmyCommand(cmdId, pid, timestamp, bID, aID, units);
                 }
 
@@ -833,8 +775,8 @@ namespace Sporefront.Data
                 }
 
                 default:
-                    DebugLog.Log(string.Format(
-                        "PlayerCommandRegistry: Unknown command type: {0}", commandType));
+                    DebugLog.Log(
+                        $"PlayerCommandRegistry: Unknown command type: {commandType}");
                     return null;
             }
         }

--- a/Sporefront/Assets/Scripts/Data/PlayerState.cs
+++ b/Sporefront/Assets/Scripts/Data/PlayerState.cs
@@ -67,6 +67,8 @@ namespace Sporefront.Data
         public string activeResearchType;
         public double? activeResearchStartTime;
         private Dictionary<string, double> cachedResearchBonuses = new Dictionary<string, double>();
+        [System.NonSerialized]
+        private Dictionary<ResearchBonusType, double> cachedResearchBonusesByEnum = new Dictionary<ResearchBonusType, double>();
 
         // Unit Upgrade Tracking
         public HashSet<string> completedUnitUpgrades = new HashSet<string>();
@@ -138,6 +140,12 @@ namespace Sporefront.Data
                 if (!HasResource(kvp.Key, kvp.Value)) return false;
             }
             return true;
+        }
+
+        public void DeductCost(Dictionary<ResourceType, int> costs, int multiplier = 1)
+        {
+            foreach (var kvp in costs)
+                RemoveResource(kvp.Key, kvp.Value * multiplier);
         }
 
         // Food Consumption
@@ -271,14 +279,26 @@ namespace Sporefront.Data
             return cachedResearchBonuses.ContainsKey(bonusTypeRawValue) ? cachedResearchBonuses[bonusTypeRawValue] : 0.0;
         }
 
+        public double GetResearchBonus(ResearchBonusType bonusType)
+        {
+            double val;
+            return cachedResearchBonusesByEnum.TryGetValue(bonusType, out val) ? val : 0.0;
+        }
+
         public double GetResearchBonusMultiplier(string bonusTypeRawValue)
         {
             return 1.0 + GetResearchBonus(bonusTypeRawValue);
         }
 
+        public double GetResearchBonusMultiplier(ResearchBonusType bonusType)
+        {
+            return 1.0 + GetResearchBonus(bonusType);
+        }
+
         public void RecalculateResearchBonuses()
         {
             cachedResearchBonuses.Clear();
+            cachedResearchBonusesByEnum.Clear();
             foreach (string researchRawValue in completedResearch)
             {
                 ResearchType researchType;
@@ -291,6 +311,11 @@ namespace Sporefront.Data
                             cachedResearchBonuses[key] += bonus.Value;
                         else
                             cachedResearchBonuses[key] = bonus.Value;
+
+                        if (cachedResearchBonusesByEnum.ContainsKey(bonus.Type))
+                            cachedResearchBonusesByEnum[bonus.Type] += bonus.Value;
+                        else
+                            cachedResearchBonusesByEnum[bonus.Type] = bonus.Value;
                     }
                 }
             }

--- a/Sporefront/Assets/Scripts/Data/Serialization/DictSerializationHelper.cs
+++ b/Sporefront/Assets/Scripts/Data/Serialization/DictSerializationHelper.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+
+namespace Sporefront.Data
+{
+    /// <summary>
+    /// Helpers for serializing Dictionary&lt;TEnum, int&gt; to parallel arrays
+    /// (required because Unity's JsonUtility cannot serialize dictionaries).
+    /// </summary>
+    public static class DictSerializationHelper
+    {
+        public static void SerializeEnumDict<TKey>(Dictionary<TKey, int> dict, out string[] keys, out int[] values)
+            where TKey : struct
+        {
+            if (dict == null || dict.Count == 0)
+            {
+                keys = Array.Empty<string>();
+                values = Array.Empty<int>();
+                return;
+            }
+            var keyList = new List<string>(dict.Count);
+            var valueList = new List<int>(dict.Count);
+            foreach (var kvp in dict)
+            {
+                keyList.Add(kvp.Key.ToString());
+                valueList.Add(kvp.Value);
+            }
+            keys = keyList.ToArray();
+            values = valueList.ToArray();
+        }
+
+        public static Dictionary<TKey, int> DeserializeEnumDict<TKey>(string[] keys, int[] values)
+            where TKey : struct
+        {
+            var dict = new Dictionary<TKey, int>();
+            if (keys == null || values == null || keys.Length != values.Length)
+                return dict;
+            for (int i = 0; i < keys.Length; i++)
+            {
+                if (Enum.TryParse<TKey>(keys[i], out var enumVal))
+                    dict[enumVal] = values[i];
+            }
+            return dict;
+        }
+    }
+}

--- a/Sporefront/Assets/Scripts/Data/Serialization/DictSerializationHelper.cs.meta
+++ b/Sporefront/Assets/Scripts/Data/Serialization/DictSerializationHelper.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 60b79cd8eacc54ece9b3851fa9ce7726

--- a/Sporefront/Assets/Scripts/Data/Serialization/SporefrontJsonSettings.cs
+++ b/Sporefront/Assets/Scripts/Data/Serialization/SporefrontJsonSettings.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Sporefront.Data.Serialization
+{
+    public static class SporefrontJsonSettings
+    {
+        private static JsonSerializerSettings _compact;
+        private static JsonSerializerSettings _indented;
+
+        public static JsonSerializerSettings Compact =>
+            _compact ?? (_compact = Create(Formatting.None));
+
+        public static JsonSerializerSettings Indented =>
+            _indented ?? (_indented = Create(Formatting.Indented));
+
+        private static JsonSerializerSettings Create(Formatting formatting)
+        {
+            return new JsonSerializerSettings
+            {
+                Formatting = formatting,
+                NullValueHandling = NullValueHandling.Ignore,
+                TypeNameHandling = TypeNameHandling.None,
+                Converters = new List<JsonConverter>
+                {
+                    new HexCoordinateConverter(),
+                    new HexCoordinateKeyConverter()
+                }
+            };
+        }
+    }
+}

--- a/Sporefront/Assets/Scripts/Data/Serialization/SporefrontJsonSettings.cs.meta
+++ b/Sporefront/Assets/Scripts/Data/Serialization/SporefrontJsonSettings.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0e6b60763901144cf82fa6bd0b5a953e

--- a/Sporefront/Assets/Scripts/Engine/ArabiaMapGenerator.cs
+++ b/Sporefront/Assets/Scripts/Engine/ArabiaMapGenerator.cs
@@ -127,7 +127,6 @@ namespace Sporefront.Engine
 
         private readonly int startPadding;
         private readonly int startingResourceRadius = 7;
-        private readonly int neutralResourceExclusionRadius = 10;
 
         private SeededRandom rng;
         public ArabiaMapConfig config;

--- a/Sporefront/Assets/Scripts/Engine/BuildHelper.cs
+++ b/Sporefront/Assets/Scripts/Engine/BuildHelper.cs
@@ -1,0 +1,87 @@
+// ============================================================================
+// FILE: Engine/BuildHelper.cs
+// PURPOSE: Shared building logic used by both BuildCommand and AIBuildCommand.
+//          Extracted to avoid duplicating terrain cost and villager lookup code.
+// ============================================================================
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Sporefront.Data;
+using Sporefront.Models;
+
+namespace Sporefront.Engine
+{
+    public static class BuildHelper
+    {
+        /// <summary>
+        /// Calculates the terrain cost multiplier for a building placement,
+        /// accounting for mountain surcharge and faction highland discount.
+        /// Checks all coordinates the building will occupy.
+        /// </summary>
+        public static double GetTerrainCostMultiplier(
+            GameState state, BuildingType buildingType, HexCoordinate coordinate, int rotation, Guid playerID)
+        {
+            var occupiedCoords = buildingType.GetOccupiedCoordinates(coordinate, rotation);
+            bool hasMountain = occupiedCoords.Any(c => state.mapData.GetTerrain(c) == TerrainType.Mountain);
+            bool hasHighland = hasMountain || occupiedCoords.Any(c =>
+            {
+                var t = state.mapData.GetTerrain(c);
+                return t == TerrainType.Hill;
+            });
+            double multiplier = hasMountain ? GameConfig.Terrain.MountainBuildingCostMultiplier : 1.0;
+
+            if (hasHighland)
+            {
+                var player = state.GetPlayer(playerID);
+                if (player != null)
+                {
+                    double reduction = player.faction.MountainBuildCostReduction();
+                    if (reduction > 0)
+                        multiplier *= (1.0 - reduction);
+                }
+            }
+
+            return multiplier;
+        }
+
+        /// <summary>
+        /// Returns the effective build cost dictionary with terrain multiplier applied.
+        /// </summary>
+        public static Dictionary<ResourceType, int> GetEffectiveBuildCost(
+            GameState state, BuildingType buildingType, HexCoordinate coordinate, int rotation, Guid playerID)
+        {
+            double multiplier = GetTerrainCostMultiplier(state, buildingType, coordinate, rotation, playerID);
+            var baseCost = buildingType.BuildCost();
+            if (Math.Abs(multiplier - 1.0) < 0.001)
+                return baseCost;
+
+            var adjusted = new Dictionary<ResourceType, int>();
+            foreach (var kvp in baseCost)
+                adjusted[kvp.Key] = Math.Max(1, (int)Math.Ceiling(kvp.Value * multiplier));
+            return adjusted;
+        }
+
+        /// <summary>
+        /// Finds the nearest idle villager group to a target coordinate.
+        /// Returns null if no idle villagers are available.
+        /// </summary>
+        public static VillagerGroupData FindNearestIdleVillager(
+            GameState state, Guid playerID, HexCoordinate target)
+        {
+            VillagerGroupData nearest = null;
+            int bestDist = int.MaxValue;
+            foreach (var group in state.GetVillagerGroupsForPlayer(playerID))
+            {
+                if (!group.currentTask.IsIdle || group.currentPath != null) continue;
+                int dist = group.coordinate.Distance(target);
+                if (dist < bestDist)
+                {
+                    bestDist = dist;
+                    nearest = group;
+                }
+            }
+            return nearest;
+        }
+    }
+}

--- a/Sporefront/Assets/Scripts/Engine/BuildHelper.cs.meta
+++ b/Sporefront/Assets/Scripts/Engine/BuildHelper.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c69306bd4c756416aab7e81e81cfc370

--- a/Sporefront/Assets/Scripts/Engine/CombatEngine.cs
+++ b/Sporefront/Assets/Scripts/Engine/CombatEngine.cs
@@ -135,6 +135,13 @@ namespace Sporefront.Engine
         // MARK: - Stack Combats (multi-army engagement)
         public Dictionary<Guid, StackCombat> stackCombats { get; private set; } = new Dictionary<Guid, StackCombat>();
 
+        // Reusable key snapshots to avoid dictionary copies during iteration
+        private readonly List<Guid> combatKeySnapshot = new List<Guid>();
+        private readonly List<Guid> buildingCombatKeySnapshot = new List<Guid>();
+        private readonly List<Guid> villagerCombatKeySnapshot = new List<Guid>();
+        private readonly List<Guid> stackCombatKeySnapshot = new List<Guid>();
+        private readonly List<ArmyData> poisonArmySnapshot = new List<ArmyData>();
+
         // MARK: - Garrison Defense
         public GarrisonDefenseEngine garrisonDefenseEngine = new GarrisonDefenseEngine();
 
@@ -247,10 +254,11 @@ namespace Sporefront.Engine
             var completedCombats = new List<Guid>();
             var combatsToClean = new List<ActiveCombat>();
 
-            foreach (var kvp in new Dictionary<Guid, ActiveCombat>(activeCombats))
+            combatKeySnapshot.Clear();
+            combatKeySnapshot.AddRange(activeCombats.Keys);
+            foreach (var combatID in combatKeySnapshot)
             {
-                Guid combatID = kvp.Key;
-                ActiveCombat combat = kvp.Value;
+                if (!activeCombats.TryGetValue(combatID, out var combat)) continue;
 
                 if (combat.phase == CombatPhase.Ended)
                 {
@@ -277,8 +285,7 @@ namespace Sporefront.Engine
 
                 if (combat.phase != previousPhase)
                 {
-                    DebugLog.Log(string.Format("Combat phase changed: {0} -> {1}",
-                        previousPhase.DisplayName(), combat.phase.DisplayName()));
+                    DebugLog.Log($"Combat phase changed: {previousPhase.DisplayName()} -> {combat.phase.DisplayName()}");
                     changes.Add(new CombatPhaseCompletedChange
                     {
                         attackerID = combat.attackerArmies.Count > 0 ? combat.attackerArmies[0].armyID : Guid.Empty,
@@ -364,7 +371,7 @@ namespace Sporefront.Engine
                         ArmyData loserArmy = state.GetArmy(loserID);
                         if (loserArmy != null && !loserArmy.isRetreating)
                         {
-                            DebugLog.Log(string.Format("{0} is surrounded with no retreat — army destroyed", loserArmy.name));
+                            DebugLog.Log($"{loserArmy.name} is surrounded with no retreat — army destroyed");
                             changes.Add(new ArmyDestroyedChange { armyID = loserID, coordinate = loserArmy.coordinate });
                             state.RemoveArmy(loserID);
                         }
@@ -429,13 +436,13 @@ namespace Sporefront.Engine
             ArmyData attacker = gameState.GetArmy(attackerArmyID);
             if (attacker == null)
             {
-                DebugLog.Log(string.Format("CombatEngine: Attacker army not found in GameState (ID: {0})", attackerArmyID));
+                DebugLog.Log($"CombatEngine: Attacker army not found in GameState (ID: {attackerArmyID})");
                 return null;
             }
             ArmyData defender = gameState.GetArmy(defenderArmyID);
             if (defender == null)
             {
-                DebugLog.Log(string.Format("CombatEngine: Defender army not found in GameState (ID: {0})", defenderArmyID));
+                DebugLog.Log($"CombatEngine: Defender army not found in GameState (ID: {defenderArmyID})");
                 return null;
             }
 
@@ -486,8 +493,7 @@ namespace Sporefront.Engine
             if (defender.isEntrenched)
             {
                 combat.entrenchmentDefenseBonus = GameConfig.Entrenchment.DefenseBonus;
-                DebugLog.Log(string.Format("   Defender is entrenched: +{0}% defense bonus",
-                    (int)(GameConfig.Entrenchment.DefenseBonus * 100)));
+                DebugLog.Log($"   Defender is entrenched: +{(int)(GameConfig.Entrenchment.DefenseBonus * 100)}% defense bonus");
             }
 
             // Store with combat's own ID
@@ -500,15 +506,15 @@ namespace Sporefront.Engine
             defender.combatTargetID = attackerArmyID;
 
             // Debug logging for terrain bonuses
-            DebugLog.Log(string.Format("Combat started: Phase {0} at {1}", combat.phase.DisplayName(), defender.coordinate));
-            DebugLog.Log(string.Format("   Terrain: {0}", terrain.DisplayName()));
+            DebugLog.Log($"Combat started: Phase {combat.phase.DisplayName()} at {defender.coordinate}");
+            DebugLog.Log($"   Terrain: {terrain.DisplayName()}");
             if (combat.terrainDefenseBonus > 0)
             {
-                DebugLog.Log(string.Format("   Defender defense bonus: +{0}%", (int)(combat.terrainDefenseBonus * 100)));
+                DebugLog.Log($"   Defender defense bonus: +{(int)(combat.terrainDefenseBonus * 100)}%");
             }
             if (combat.terrainAttackPenalty > 0)
             {
-                DebugLog.Log(string.Format("   Attacker attack penalty: -{0}%", (int)(combat.terrainAttackPenalty * 100)));
+                DebugLog.Log($"   Attacker attack penalty: -{(int)(combat.terrainAttackPenalty * 100)}%");
             }
             if (combat.terrainDefenseBonus == 0 && combat.terrainAttackPenalty == 0)
             {
@@ -678,8 +684,7 @@ namespace Sporefront.Engine
             attacker.isInCombat = true;
             attacker.combatTargetID = defenderVillagerGroupID;
 
-            DebugLog.Log(string.Format("Army vs Villagers combat started: {0} attacking {1} villagers",
-                attacker.name, villagerGroup.villagerCount));
+            DebugLog.Log($"Army vs Villagers combat started: {attacker.name} attacking {villagerGroup.villagerCount} villagers");
 
             return new CombatStartedChange
             {
@@ -947,6 +952,20 @@ namespace Sporefront.Engine
 
         /// <summary>
         /// Automatically starts combat against an enemy building at the given location.
+        private Guid? FindFirstSurvivingAttacker(StackCombat stackCombat)
+        {
+            foreach (var p in stackCombat.activePairings)
+            {
+                if (p.winnerArmyID.HasValue &&
+                    !stackCombat.defeatedArmyIDs.Contains(p.winnerArmyID.Value) &&
+                    !stackCombat.retreatedArmyIDs.Contains(p.winnerArmyID.Value))
+                {
+                    return p.winnerArmyID.Value;
+                }
+            }
+            return null;
+        }
+
         /// Called after winning army vs army combat.
         /// </summary>
         private void AutoStartBuildingCombat(Guid armyID, HexCoordinate location, GameState state, double currentTime, List<StateChange> changes)
@@ -963,8 +982,7 @@ namespace Sporefront.Engine
             if (!building.IsOperational) return;
 
             // Start building combat
-            DebugLog.Log(string.Format("Auto-starting building attack: {0} vs {1}",
-                army.name, building.buildingType.DisplayName()));
+            DebugLog.Log($"Auto-starting building attack: {army.name} vs {building.buildingType.DisplayName()}");
 
             StateChange combatChange = StartBuildingCombat(armyID, building.id, currentTime);
             if (combatChange != null)
@@ -982,10 +1000,11 @@ namespace Sporefront.Engine
             var changes = new List<StateChange>();
             var completedCombats = new List<Guid>();
 
-            foreach (var kvp in new Dictionary<Guid, ActiveCombatData>(buildingCombats))
+            buildingCombatKeySnapshot.Clear();
+            buildingCombatKeySnapshot.AddRange(buildingCombats.Keys);
+            foreach (var combatID in buildingCombatKeySnapshot)
             {
-                Guid combatID = kvp.Key;
-                ActiveCombatData combat = kvp.Value;
+                if (!buildingCombats.TryGetValue(combatID, out var combat)) continue;
 
                 if (combat.isComplete)
                 {
@@ -1178,7 +1197,7 @@ namespace Sporefront.Engine
                 BuildingData newHomeBase = state.FindHomeBaseWithCapacity(buildingOwnerID, army.coordinate, building.id);
                 if (newHomeBase == null)
                 {
-                    DebugLog.Log(string.Format("No home base available for retreat - {0} has nowhere to go", army.name));
+                    DebugLog.Log($"No home base available for retreat - {army.name} has nowhere to go");
                     continue;
                 }
 
@@ -1189,7 +1208,7 @@ namespace Sporefront.Engine
                 List<HexCoordinate> path = state.mapData.FindPath(army.coordinate, newHomeBase.coordinate, buildingOwnerID, state);
                 if (path == null || path.Count == 0)
                 {
-                    DebugLog.Log(string.Format("{0} cannot find retreat path from destroyed building", army.name));
+                    DebugLog.Log($"{army.name} cannot find retreat path from destroyed building");
                     continue;
                 }
 
@@ -1199,8 +1218,7 @@ namespace Sporefront.Engine
                 army.pathIndex = 0;
                 army.movementProgress = 0.0;
 
-                DebugLog.Log(string.Format("{0} retreating from destroyed {1} to {2}",
-                    army.name, building.buildingType.DisplayName(), newHomeBase.buildingType.DisplayName()));
+                DebugLog.Log($"{army.name} retreating from destroyed {building.buildingType.DisplayName()} to {newHomeBase.buildingType.DisplayName()}");
             }
         }
 
@@ -1211,10 +1229,11 @@ namespace Sporefront.Engine
             var changes = new List<StateChange>();
             var completedCombats = new List<Guid>();
 
-            foreach (var kvp in new Dictionary<Guid, VillagerCombatData>(villagerCombats))
+            villagerCombatKeySnapshot.Clear();
+            villagerCombatKeySnapshot.AddRange(villagerCombats.Keys);
+            foreach (var combatID in villagerCombatKeySnapshot)
             {
-                Guid combatID = kvp.Key;
-                VillagerCombatData combat = kvp.Value;
+                if (!villagerCombats.TryGetValue(combatID, out var combat)) continue;
 
                 if (combat.isComplete)
                 {
@@ -1335,7 +1354,7 @@ namespace Sporefront.Engine
                     combat.isComplete = true;
                     completedCombats.Add(combatID);
 
-                    DebugLog.Log(string.Format("Villager group destroyed: {0} villagers killed", combat.villagersKilled));
+                    DebugLog.Log($"Villager group destroyed: {combat.villagersKilled} villagers killed");
 
                     // Save combat record before removing villager group
                     CombatRecord record = CreateVillagerCombatRecord(combat, currentTime, state);
@@ -1886,7 +1905,7 @@ namespace Sporefront.Engine
 
             if (defensiveStack.IsEmpty)
             {
-                DebugLog.Log(string.Format("Stack combat: No defenders at {0}", coordinate));
+                DebugLog.Log($"Stack combat: No defenders at {coordinate}");
                 return StateChange.EmptyChanges;
             }
 
@@ -1937,7 +1956,7 @@ namespace Sporefront.Engine
                             pairingCombat.AddReinforcement(attackerArmy, true);
                             attackerArmy.isInCombat = true;
                             attackerArmy.combatTargetID = firstPairing.defenderArmyID;
-                            DebugLog.Log(string.Format("Stack: Attacker {0} joining as reinforcement", attackerArmy.name));
+                            DebugLog.Log($"Stack: Attacker {attackerArmy.name} joining as reinforcement");
                         }
                     }
                 }
@@ -1957,8 +1976,7 @@ namespace Sporefront.Engine
                 defenderArmyIDs = defenderArmyIDs
             });
 
-            DebugLog.Log(string.Format("Stack combat started at {0}: {1} attackers vs {2} defenders ({3} villager groups)",
-                coordinate, attackerArmyIDs.Count, defensiveStack.entries.Count, defensiveStack.villagerGroupIDs.Count));
+            DebugLog.Log($"Stack combat started at {coordinate}: {attackerArmyIDs.Count} attackers vs {defensiveStack.entries.Count} defenders ({defensiveStack.villagerGroupIDs.Count} villager groups)");
 
             return changes;
         }
@@ -2035,8 +2053,7 @@ namespace Sporefront.Engine
             var pairing = new CombatPairing(attackerID, defenderEntry.armyID, combat.id);
             stackCombat.activePairings.Add(pairing);
 
-            DebugLog.Log(string.Format("Stack pairing: {0} vs {1} (Tier: {2}, Cross-tile: {3})",
-                attacker.name, defender.name, defenderEntry.tier.DisplayName(), defenderEntry.isCrossTile));
+            DebugLog.Log($"Stack pairing: {attacker.name} vs {defender.name} (Tier: {defenderEntry.tier.DisplayName()}, Cross-tile: {defenderEntry.isCrossTile})");
 
             return new CombatStartedChange
             {
@@ -2053,10 +2070,11 @@ namespace Sporefront.Engine
             var changes = new List<StateChange>();
             var completedStacks = new List<Guid>();
 
-            foreach (var stackKvp in new Dictionary<Guid, StackCombat>(stackCombats))
+            stackCombatKeySnapshot.Clear();
+            stackCombatKeySnapshot.AddRange(stackCombats.Keys);
+            foreach (var stackID in stackCombatKeySnapshot)
             {
-                Guid stackID = stackKvp.Key;
-                StackCombat stackCombat = stackKvp.Value;
+                if (!stackCombats.TryGetValue(stackID, out var stackCombat)) continue;
 
                 if (stackCombat.isComplete)
                 {
@@ -2139,7 +2157,7 @@ namespace Sporefront.Engine
                                     ? loserArmy.currentPath[loserArmy.currentPath.Count - 1]
                                     : loserArmy.coordinate;
                                 changes.Add(new ArmyForcedRetreatChange { armyID = loserID, from = fromCoord, to = toCoord });
-                                DebugLog.Log(string.Format("Stack: Cross-tile defender {0} forced to retreat (not destroyed)", loserArmy.name));
+                                DebugLog.Log($"Stack: Cross-tile defender {loserArmy.name} forced to retreat (not destroyed)");
                             }
                         }
                         else
@@ -2178,11 +2196,7 @@ namespace Sporefront.Engine
                     CleanupCombatFlags(combat, state);
                     activeCombats.Remove(pairing.activeCombatID);
 
-                    DebugLog.Log(string.Format("Stack pairing ended: winner={0} loser={1} defenderQueue={2} attackerQueue={3}",
-                        result.winnerID.HasValue ? result.winnerID.Value.ToString().Substring(0, 8) : "nil",
-                        result.loserID.HasValue ? result.loserID.Value.ToString().Substring(0, 8) : "nil",
-                        stackCombat.defenderQueue.Count,
-                        stackCombat.attackerQueue.Count));
+                    DebugLog.Log($"Stack pairing ended: winner={( result.winnerID.HasValue ? result.winnerID.Value.ToString().Substring(0, 8) : "nil")} loser={(result.loserID.HasValue ? result.loserID.Value.ToString().Substring(0, 8) : "nil")} defenderQueue={stackCombat.defenderQueue.Count} attackerQueue={stackCombat.attackerQueue.Count}");
 
                     // Chain: Winner engages next fresh enemy or reinforces an ally
                     if (result.winnerID.HasValue)
@@ -2192,10 +2206,7 @@ namespace Sporefront.Engine
 
                         bool winnerIsAttacker = pairing.attackerArmyID == winnerID;
                         ArmyData winnerArmy = state.GetArmy(winnerID);
-                        DebugLog.Log(string.Format("Stack chain: winnerIsAttacker={0} winnerUnits={1} winnerExists={2}",
-                            winnerIsAttacker,
-                            winnerArmy != null ? winnerArmy.GetTotalUnits() : -1,
-                            winnerArmy != null));
+                        DebugLog.Log($"Stack chain: winnerIsAttacker={winnerIsAttacker} winnerUnits={(winnerArmy != null ? winnerArmy.GetTotalUnits() : -1)} winnerExists={winnerArmy != null}");
 
                         if (winnerIsAttacker)
                         {
@@ -2203,15 +2214,12 @@ namespace Sporefront.Engine
                             DefensiveStackEntry? nextDefender = stackCombat.DequeueNextDefender();
                             if (nextDefender.HasValue)
                             {
-                                DebugLog.Log(string.Format("Stack chain: dequeued next defender {0} exists={1}",
-                                    nextDefender.Value.armyID.ToString().Substring(0, 8),
-                                    state.GetArmy(nextDefender.Value.armyID) != null));
+                                DebugLog.Log($"Stack chain: dequeued next defender {nextDefender.Value.armyID.ToString().Substring(0, 8)} exists={state.GetArmy(nextDefender.Value.armyID) != null}");
                                 StateChange combatChange = CreateStackPairing(stackCombat, winnerID, nextDefender.Value, currentTime, state);
                                 if (combatChange != null)
                                 {
                                     changes.Add(combatChange);
-                                    DebugLog.Log(string.Format("Stack chain: {0} engages next defender - NEW pairing created",
-                                        state.GetArmy(winnerID)?.name ?? "Winner"));
+                                    DebugLog.Log($"Stack chain: {state.GetArmy(winnerID)?.name ?? "Winner"} engages next defender - NEW pairing created");
                                 }
                                 else
                                 {
@@ -2229,7 +2237,7 @@ namespace Sporefront.Engine
                                         // No more defenders in queue -- reinforce an ally's fight
                                         allyCombat.AddReinforcement(winnerArmy, true);
                                         winnerArmy.isInCombat = true;
-                                        DebugLog.Log(string.Format("Stack chain: {0} reinforcing ally", winnerArmy.name));
+                                        DebugLog.Log($"Stack chain: {winnerArmy.name} reinforcing ally");
                                     }
                                 }
                                 else
@@ -2265,9 +2273,7 @@ namespace Sporefront.Engine
 
                 // Check for tier advancement
                 int activePairingsRemaining = stackCombat.activePairings.Count(p => !p.isComplete);
-                DebugLog.Log(string.Format("Stack status: totalPairings={0} active={1} defenderQueue={2} attackerQueue={3}",
-                    stackCombat.activePairings.Count, activePairingsRemaining,
-                    stackCombat.defenderQueue.Count, stackCombat.attackerQueue.Count));
+                DebugLog.Log($"Stack status: totalPairings={stackCombat.activePairings.Count} active={activePairingsRemaining} defenderQueue={stackCombat.defenderQueue.Count} attackerQueue={stackCombat.attackerQueue.Count}");
 
                 if (activePairingsRemaining == 0 && stackCombat.defenderQueue.Count == 0)
                 {
@@ -2283,17 +2289,13 @@ namespace Sporefront.Engine
                         });
 
                         // Start villager combats for remaining attackers
-                        var survivingAttackers = stackCombat.activePairings
-                            .Where(p => p.winnerArmyID.HasValue)
-                            .Select(p => p.winnerArmyID.Value)
-                            .Where(id => !stackCombat.defeatedArmyIDs.Contains(id) && !stackCombat.retreatedArmyIDs.Contains(id))
-                            .ToList();
+                        Guid? firstSurvivingAttacker = FindFirstSurvivingAttacker(stackCombat);
 
                         foreach (Guid villagerGroupID in stackCombat.villagerGroupIDs)
                         {
-                            if (survivingAttackers.Count > 0)
+                            if (firstSurvivingAttacker.HasValue)
                             {
-                                Guid attackerID = survivingAttackers[0];
+                                Guid attackerID = firstSurvivingAttacker.Value;
                                 StateChange villagerChange = StartVillagerCombat(attackerID, villagerGroupID, currentTime);
                                 if (villagerChange != null)
                                 {
@@ -2311,24 +2313,20 @@ namespace Sporefront.Engine
                         completedStacks.Add(stackID);
 
                         // Auto-attack building at location if attackers won
-                        var survivingAttackers = stackCombat.activePairings
-                            .Where(p => p.winnerArmyID.HasValue)
-                            .Select(p => p.winnerArmyID.Value)
-                            .Where(id => !stackCombat.defeatedArmyIDs.Contains(id) && !stackCombat.retreatedArmyIDs.Contains(id))
-                            .ToList();
+                        Guid? survivingAttacker = FindFirstSurvivingAttacker(stackCombat);
 
-                        if (survivingAttackers.Count > 0)
+                        if (survivingAttacker.HasValue)
                         {
-                            AutoStartBuildingCombat(survivingAttackers[0], stackCombat.coordinate, state, currentTime, changes);
+                            AutoStartBuildingCombat(survivingAttacker.Value, stackCombat.coordinate, state, currentTime, changes);
                         }
 
                         var overallResult = new CombatResultData(
-                            winnerID: survivingAttackers.Count > 0 ? (Guid?)survivingAttackers[0] : null,
+                            winnerID: survivingAttacker,
                             loserID: null,
                             combatDuration: currentTime - stackCombat.startTime
                         );
                         changes.Add(new StackCombatEndedChange { coordinate = stackCombat.coordinate, result = overallResult });
-                        DebugLog.Log(string.Format("Stack combat completed at {0}", stackCombat.coordinate));
+                        DebugLog.Log($"Stack combat completed at {stackCombat.coordinate}");
                     }
                 }
             }
@@ -2485,7 +2483,7 @@ namespace Sporefront.Engine
                 if (combatChange != null)
                 {
                     changes.Add(combatChange);
-                    DebugLog.Log(string.Format("Stack reinforcement: {0} paired with queued attacker", army.name));
+                    DebugLog.Log($"Stack reinforcement: {army.name} paired with queued attacker");
                 }
             }
             // Priority 2: Reinforce an outnumbered active fight
@@ -2512,14 +2510,14 @@ namespace Sporefront.Engine
                     army.isInCombat = true;
                     army.combatTargetID = outnumberedPairing.attackerArmyID;
                     stackCombat.AddFront(armyID);
-                    DebugLog.Log(string.Format("Stack reinforcement: {0} reinforcing outnumbered defender", army.name));
+                    DebugLog.Log($"Stack reinforcement: {army.name} reinforcing outnumbered defender");
                 }
                 // Priority 3: Queue for later chain combat pickup
                 else
                 {
                     stackCombat.AddDefender(defenderEntry);
                     army.isInCombat = true;
-                    DebugLog.Log(string.Format("Stack reinforcement: {0} queued as reserve defender", army.name));
+                    DebugLog.Log($"Stack reinforcement: {army.name} queued as reserve defender");
                 }
             }
 
@@ -2713,18 +2711,17 @@ namespace Sporefront.Engine
             ArmyData army = state.GetArmy(armyID);
             if (army == null || !army.ownerID.HasValue)
             {
-                DebugLog.Log(string.Format("DEBUG: InitiateAutoRetreat - Army {0} not found in GameState or has no owner", armyID));
+                DebugLog.Log($"DEBUG: InitiateAutoRetreat - Army {armyID} not found in GameState or has no owner");
                 return null; // Army doesn't exist - nothing to retreat
             }
             Guid ownerID = army.ownerID.Value;
-            DebugLog.Log(string.Format("DEBUG: InitiateAutoRetreat - Processing army {0} at {1}, homeBaseID: {2}",
-                army.name, army.coordinate, army.homeBaseID.HasValue ? army.homeBaseID.Value.ToString() : "null"));
+            DebugLog.Log($"DEBUG: InitiateAutoRetreat - Processing army {army.name} at {army.coordinate}, homeBaseID: {(army.homeBaseID.HasValue ? army.homeBaseID.Value.ToString() : "null")}");
 
             // Clear entrenchment when retreating from combat loss
             if (army.isEntrenching || army.isEntrenched)
             {
                 army.ClearEntrenchment();
-                DebugLog.Log(string.Format("Army {0} entrenchment cancelled due to combat loss", army.name));
+                DebugLog.Log($"Army {army.name} entrenchment cancelled due to combat loss");
             }
 
             // Check if army is currently at their home base (lost a fight defending it)
@@ -2734,7 +2731,7 @@ namespace Sporefront.Engine
                 BuildingData homeBase = state.GetBuilding(army.homeBaseID.Value);
                 if (homeBase != null && homeBase.OccupiedCoordinates.Contains(army.coordinate))
                 {
-                    DebugLog.Log(string.Format("{0} staying to defend {1}", army.name, homeBase.buildingType.DisplayName()));
+                    DebugLog.Log($"{army.name} staying to defend {homeBase.buildingType.DisplayName()}");
                     return null;
                 }
             }
@@ -2764,8 +2761,7 @@ namespace Sporefront.Engine
                     retreatDestination = nearestBase.coordinate;
                     // Update army's home base reference
                     army.homeBaseID = nearestBase.id;
-                    DebugLog.Log(string.Format("{0} home base reassigned to {1}",
-                        army.name, nearestBase.buildingType.DisplayName()));
+                    DebugLog.Log($"{army.name} home base reassigned to {nearestBase.buildingType.DisplayName()}");
                 }
             }
 
@@ -2788,14 +2784,14 @@ namespace Sporefront.Engine
                     if (enemiesNearby.Count > 0) continue;
                     retreatDestination = neighbor;
                     path = new List<HexCoordinate> { neighbor };
-                    DebugLog.Log(string.Format("{0} scatter-retreating to {1}", army.name, neighbor));
+                    DebugLog.Log($"{army.name} scatter-retreating to {neighbor}");
                     break;
                 }
             }
 
             if (path == null || path.Count == 0)
             {
-                DebugLog.Log(string.Format("{0} cannot find any retreat path - surrounded", army.name));
+                DebugLog.Log($"{army.name} cannot find any retreat path - surrounded");
                 return null;
             }
 
@@ -2806,7 +2802,7 @@ namespace Sporefront.Engine
             army.movementProgress = 0.0;
 
             string buildingName = retreatBuilding != null ? retreatBuilding.buildingType.DisplayName() : "scatter";
-            DebugLog.Log(string.Format("{0} retreating to {1}", army.name, buildingName));
+            DebugLog.Log($"{army.name} retreating to {buildingName}");
 
             return path;
         }
@@ -3018,11 +3014,18 @@ namespace Sporefront.Engine
             var changes = new List<StateChange>();
             double deltaTime = GameConfig.EngineIntervals.CombatUpdate;
 
-            // Collect all poisoned armies (use ToList for safe iteration)
-            var allArmies = state.armies.Values;
-            if (allArmies == null) return changes;
+            // Check if any armies are poisoned before creating defensive copy
+            bool hasPoisoned = false;
+            foreach (var army in state.armies.Values)
+            {
+                if (army.activePoisonState != null) { hasPoisoned = true; break; }
+            }
+            if (!hasPoisoned) return changes;
 
-            foreach (var army in allArmies.ToList())
+            // Defensive copy needed: RemoveArmy modifies state.armies during iteration
+            poisonArmySnapshot.Clear();
+            poisonArmySnapshot.AddRange(state.armies.Values);
+            foreach (var army in poisonArmySnapshot)
             {
                 if (army.activePoisonState == null) continue;
                 if (army.isInCombat) continue; // Don't double-dip during active combat
@@ -3078,7 +3081,7 @@ namespace Sporefront.Engine
             if (damage <= 0) return;
 
             // Distribute damage across all unit types proportionally
-            var composition = army.militaryComposition.ToList();
+            var composition = army.militaryComposition;
             int totalUnits = army.GetTotalUnits();
             if (totalUnits <= 0) return;
 

--- a/Sporefront/Assets/Scripts/Engine/ConstructionEngine.cs
+++ b/Sporefront/Assets/Scripts/Engine/ConstructionEngine.cs
@@ -19,6 +19,7 @@ namespace Sporefront.Engine
 
         // State
         private GameState gameState;
+        private readonly List<BuildingData> buildingSnapshot = new List<BuildingData>();
 
         // Setup
 
@@ -38,9 +39,10 @@ namespace Sporefront.Engine
             var changes = new List<StateChange>();
 
             // Snapshot building values to avoid collection-modified-during-enumeration
-            var buildingList = gameState.buildings.Values.ToList();
+            buildingSnapshot.Clear();
+            buildingSnapshot.AddRange(gameState.buildings.Values);
 
-            foreach (var building in buildingList)
+            foreach (var building in buildingSnapshot)
             {
                 // Check for builder arrival at planning-state buildings
                 if (building.state == BuildingState.Planning)
@@ -151,20 +153,34 @@ namespace Sporefront.Engine
         // Construction
         // ================================================================
 
+        private double GetBuildingSpeedMultiplier(BuildingData building)
+        {
+            if (building.ownerID.HasValue)
+            {
+                var owner = gameState.GetPlayer(building.ownerID.Value);
+                if (owner != null)
+                    return owner.GetResearchBonusMultiplier(ResearchBonusType.BuildingSpeed);
+            }
+            return 1.0;
+        }
+
+        private double GetBuildingHPMultiplier(BuildingData building)
+        {
+            if (building.ownerID.HasValue)
+            {
+                var owner = gameState.GetPlayer(building.ownerID.Value);
+                if (owner != null)
+                    return owner.GetResearchBonusMultiplier(ResearchBonusType.BuildingHP);
+            }
+            return 1.0;
+        }
+
         private List<StateChange> UpdateConstruction(BuildingData building, double currentTime)
         {
             if (gameState == null) return StateChange.EmptyChanges;
             var changes = new List<StateChange>();
 
-            // Look up owner's BuildingSpeed research bonus
-            double speedMultiplier = 1.0;
-            if (building.ownerID.HasValue)
-            {
-                var owner = gameState.GetPlayer(building.ownerID.Value);
-                if (owner != null)
-                    speedMultiplier = owner.GetResearchBonusMultiplier(
-                        ResearchBonusType.BuildingSpeed.ToString());
-            }
+            double speedMultiplier = GetBuildingSpeedMultiplier(building);
 
             double previousProgress = building.constructionProgress;
             bool completed = building.UpdateConstruction(currentTime, speedMultiplier);
@@ -182,16 +198,7 @@ namespace Sporefront.Engine
             if (completed)
             {
                 // Apply BuildingHP research bonus
-                if (building.ownerID.HasValue)
-                {
-                    var owner = gameState.GetPlayer(building.ownerID.Value);
-                    if (owner != null)
-                    {
-                        double hpMultiplier = owner.GetResearchBonusMultiplier(
-                            ResearchBonusType.BuildingHP.ToString());
-                        building.ApplyBuildingHPBonus(hpMultiplier);
-                    }
-                }
+                building.ApplyBuildingHPBonus(GetBuildingHPMultiplier(building));
 
                 // Find and release any villagers assigned to build this building
                 var builderChanges = ReleaseBuilders(building.id, gameState);
@@ -238,15 +245,7 @@ namespace Sporefront.Engine
         {
             var changes = new List<StateChange>();
 
-            // Look up owner's BuildingSpeed research bonus
-            double speedMultiplier = 1.0;
-            if (building.ownerID.HasValue)
-            {
-                var owner = gameState.GetPlayer(building.ownerID.Value);
-                if (owner != null)
-                    speedMultiplier = owner.GetResearchBonusMultiplier(
-                        ResearchBonusType.BuildingSpeed.ToString());
-            }
+            double speedMultiplier = GetBuildingSpeedMultiplier(building);
 
             double previousProgress = building.upgradeProgress;
             bool completed = building.UpdateUpgrade(currentTime, speedMultiplier);
@@ -264,16 +263,7 @@ namespace Sporefront.Engine
             if (completed)
             {
                 // Apply BuildingHP research bonus after upgrade
-                if (building.ownerID.HasValue)
-                {
-                    var owner = gameState.GetPlayer(building.ownerID.Value);
-                    if (owner != null)
-                    {
-                        double hpMultiplier = owner.GetResearchBonusMultiplier(
-                            ResearchBonusType.BuildingHP.ToString());
-                        building.ApplyBuildingHPBonus(hpMultiplier);
-                    }
-                }
+                building.ApplyBuildingHPBonus(GetBuildingHPMultiplier(building));
 
                 changes.Add(new BuildingUpgradeCompletedChange
                 {

--- a/Sporefront/Assets/Scripts/Engine/DominationEngine.cs
+++ b/Sporefront/Assets/Scripts/Engine/DominationEngine.cs
@@ -10,6 +10,13 @@ namespace Sporefront.Engine
     {
         private GameState gameState;
 
+        // Reusable collections to avoid per-tick allocations
+        private Dictionary<HexCoordinate, List<(Guid ownerID, int unitCount)>> _armyPositions
+            = new Dictionary<HexCoordinate, List<(Guid ownerID, int unitCount)>>();
+        private Dictionary<Guid, int> _playerTroops = new Dictionary<Guid, int>();
+        private Dictionary<Guid, double> _multiplierPerPlayer = new Dictionary<Guid, double>();
+        private List<List<(Guid, int)>> _listPool = new List<List<(Guid, int)>>();
+
         public void Setup(GameState gameState)
         {
             this.gameState = gameState;
@@ -22,16 +29,24 @@ namespace Sporefront.Engine
 
             var changes = new List<StateChange>();
 
+            // Return pooled lists from last tick
+            foreach (var list in _armyPositions.Values)
+            {
+                list.Clear();
+                _listPool.Add(list);
+            }
+            _armyPositions.Clear();
+
             // Build a lookup of army coordinate → (ownerID, unit count) for fast zone checking
-            var armyPositions = new Dictionary<HexCoordinate, List<(Guid ownerID, int unitCount)>>();
             foreach (var army in gameState.armies.Values)
             {
                 if (!army.ownerID.HasValue) continue;
                 List<(Guid, int)> list;
-                if (!armyPositions.TryGetValue(army.coordinate, out list))
+                if (!_armyPositions.TryGetValue(army.coordinate, out list))
                 {
-                    list = new List<(Guid, int)>();
-                    armyPositions[army.coordinate] = list;
+                    list = _listPool.Count > 0 ? _listPool[_listPool.Count - 1] : new List<(Guid, int)>();
+                    if (_listPool.Count > 0) _listPool.RemoveAt(_listPool.Count - 1);
+                    _armyPositions[army.coordinate] = list;
                 }
                 int totalUnits = 0;
                 foreach (var count in army.militaryComposition.Values)
@@ -43,28 +58,28 @@ namespace Sporefront.Engine
             foreach (var zone in gameState.controlZones)
             {
                 // Count troops per player in this zone
-                var playerTroops = new Dictionary<Guid, int>();
+                _playerTroops.Clear();
                 foreach (var tile in zone.tiles)
                 {
                     List<(Guid ownerID, int unitCount)> armiesOnTile;
-                    if (armyPositions.TryGetValue(tile, out armiesOnTile))
+                    if (_armyPositions.TryGetValue(tile, out armiesOnTile))
                     {
                         foreach (var entry in armiesOnTile)
                         {
                             int existing;
-                            playerTroops.TryGetValue(entry.ownerID, out existing);
-                            playerTroops[entry.ownerID] = existing + entry.unitCount;
+                            _playerTroops.TryGetValue(entry.ownerID, out existing);
+                            _playerTroops[entry.ownerID] = existing + entry.unitCount;
                         }
                     }
                 }
 
-                zone.presenceCount = playerTroops;
+                zone.presenceCount = new Dictionary<Guid, int>(_playerTroops);
 
                 // Determine controller: player with strictly more troops
                 Guid? newController = null;
                 int maxTroops = 0;
                 bool tied = false;
-                foreach (var kvp in playerTroops)
+                foreach (var kvp in _playerTroops)
                 {
                     if (kvp.Value > maxTroops)
                     {
@@ -92,18 +107,18 @@ namespace Sporefront.Engine
             }
 
             // Award points for controlled zones (using per-zone pointsMultiplier)
-            var multiplierPerPlayer = new Dictionary<Guid, double>();
+            _multiplierPerPlayer.Clear();
             foreach (var zone in gameState.controlZones)
             {
                 if (zone.controllingPlayerID.HasValue)
                 {
                     double current;
-                    multiplierPerPlayer.TryGetValue(zone.controllingPlayerID.Value, out current);
-                    multiplierPerPlayer[zone.controllingPlayerID.Value] = current + zone.pointsMultiplier;
+                    _multiplierPerPlayer.TryGetValue(zone.controllingPlayerID.Value, out current);
+                    _multiplierPerPlayer[zone.controllingPlayerID.Value] = current + zone.pointsMultiplier;
                 }
             }
 
-            foreach (var kvp in multiplierPerPlayer)
+            foreach (var kvp in _multiplierPerPlayer)
             {
                 double delta = GameConfig.Domination.PointsPerSecond * kvp.Value * GameConfig.Domination.UpdateInterval;
                 double oldScore;

--- a/Sporefront/Assets/Scripts/Engine/EngineCommand.cs
+++ b/Sporefront/Assets/Scripts/Engine/EngineCommand.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Sporefront.Data;
+using Sporefront.Models;
 
 namespace Sporefront.Engine
 {
@@ -75,6 +76,119 @@ namespace Sporefront.Engine
         public virtual EngineCommandResult Execute(GameState state, StateChangeBuilder changeBuilder)
         {
             return EngineCommandResult.Success(new List<StateChange>());
+        }
+
+        // ================================================================
+        // Validation Helpers
+        // ================================================================
+
+        protected EngineCommandResult ValidatePlayer(GameState state, out PlayerState player)
+        {
+            player = state.GetPlayer(PlayerID);
+            return player == null ? EngineCommandResult.Failure("Player not found") : null;
+        }
+
+        protected EngineCommandResult ValidateBuilding(GameState state, Guid buildingID, out BuildingData building)
+        {
+            building = state.GetBuilding(buildingID);
+            return building == null ? EngineCommandResult.Failure("Building not found") : null;
+        }
+
+        protected EngineCommandResult ValidateOwnedBuilding(GameState state, Guid buildingID, out BuildingData building)
+        {
+            building = state.GetBuilding(buildingID);
+            if (building == null) return EngineCommandResult.Failure("Building not found");
+            if (!building.ownerID.HasValue || building.ownerID.Value != PlayerID)
+                return EngineCommandResult.Failure("Not your building");
+            return null;
+        }
+
+        protected EngineCommandResult ValidateArmy(GameState state, Guid armyID, out ArmyData army)
+        {
+            army = state.GetArmy(armyID);
+            return army == null ? EngineCommandResult.Failure("Army not found") : null;
+        }
+
+        protected EngineCommandResult ValidateOwnedArmy(GameState state, Guid armyID, out ArmyData army)
+        {
+            army = state.GetArmy(armyID);
+            if (army == null) return EngineCommandResult.Failure("Army not found");
+            if (!army.ownerID.HasValue || army.ownerID.Value != PlayerID)
+                return EngineCommandResult.Failure("Not your army");
+            return null;
+        }
+
+        protected EngineCommandResult ValidateOperationalBuilding(GameState state, Guid buildingID, out BuildingData building, BuildingType? requiredType = null)
+        {
+            var fail = ValidateOwnedBuilding(state, buildingID, out building);
+            if (fail != null) return fail;
+            if (!building.IsOperational)
+                return EngineCommandResult.Failure("Building is not operational");
+            if (requiredType.HasValue && building.buildingType != requiredType.Value)
+                return EngineCommandResult.Failure($"Building is not a {requiredType.Value.DisplayName()}");
+            return null;
+        }
+
+        protected EngineCommandResult ValidateVillagerGroup(GameState state, Guid groupID, out VillagerGroupData group)
+        {
+            group = state.GetVillagerGroup(groupID);
+            if (group == null) return EngineCommandResult.Failure("Villager group not found");
+            if (!group.ownerID.HasValue || group.ownerID.Value != PlayerID)
+                return EngineCommandResult.Failure("Not your villagers");
+            return null;
+        }
+
+        protected EngineCommandResult ValidateCanAfford(PlayerState player, Dictionary<ResourceType, int> costs, int multiplier = 1)
+        {
+            if (multiplier == 1) return player.CanAfford(costs) ? null : EngineCommandResult.Failure("Insufficient resources");
+            foreach (var kvp in costs)
+            {
+                if (!player.HasResource(kvp.Key, kvp.Value * multiplier))
+                    return EngineCommandResult.Failure("Insufficient resources");
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Deducts resources from a player and emits ResourcesChangedChange for each resource type.
+        /// Returns false if the player cannot afford the cost (caller should validate first).
+        /// </summary>
+        protected void DeductResourcesWithChanges(PlayerState player, Dictionary<ResourceType, int> cost, StateChangeBuilder changeBuilder)
+        {
+            foreach (var kvp in cost)
+            {
+                int oldAmount = player.GetResource(kvp.Key);
+                player.RemoveResource(kvp.Key, kvp.Value);
+                int newAmount = player.GetResource(kvp.Key);
+
+                changeBuilder.Add(new ResourcesChangedChange
+                {
+                    playerID = PlayerID,
+                    resourceType = kvp.Key.ToString(),
+                    oldAmount = oldAmount,
+                    newAmount = newAmount
+                });
+            }
+        }
+        /// <summary>
+        /// Finds a spawn position near a building, avoiding tiles at entity capacity.
+        /// Returns the building coordinate if available, or a neighboring walkable tile.
+        /// Returns null if no position is available.
+        /// </summary>
+        protected static HexCoordinate? FindSpawnPosition(GameState state, HexCoordinate buildingCoord, Func<HexCoordinate, int> getEntityCount)
+        {
+            if (getEntityCount(buildingCoord) < GameConfig.Stacking.MaxEntitiesPerTile)
+                return buildingCoord;
+
+            foreach (var neighbor in buildingCoord.Neighbors())
+            {
+                if (state.mapData.IsValidCoordinate(neighbor) && state.mapData.IsWalkable(neighbor))
+                {
+                    if (getEntityCount(neighbor) < GameConfig.Stacking.MaxEntitiesPerTile)
+                        return neighbor;
+                }
+            }
+            return null;
         }
     }
 }

--- a/Sporefront/Assets/Scripts/Engine/GameConfig.cs
+++ b/Sporefront/Assets/Scripts/Engine/GameConfig.cs
@@ -305,12 +305,21 @@ namespace Sporefront.Engine
                 public const double RandomizationWeight = 0.2;
             }
 
+            public static class Hunting
+            {
+                public const double VillagerAttackPower = 25.0;      // Damage per villager per hunt tick
+                public const double VillagerDefenseFactor = 0.5;     // Defense per villager against animal
+                public const double VillagerDeathThreshold = 5.0;    // Damage per villager lost
+                public const int MaxScoutCandidateUnits = 5;         // Max units in early scout army
+            }
+
             public static class Scouting
             {
                 public const int MaxScouts = 2;
                 public const int PatrolRadius = 6;
                 public const double EarlyGameThreshold = 300.0;
                 public const double EarlyScoutTime = 30.0;             // Send first scout by 30s
+                public const double EarlyScoutWindow = 120.0;           // Stop trying early scout after this time
                 public const double ExplorationUpdateInterval = 10.0;   // How often to recalc exploration %
                 public const double MinExplorationBeforeAttack = 0.3;   // 30% explored before attacking blind
             }

--- a/Sporefront/Assets/Scripts/Engine/GameEngine.cs
+++ b/Sporefront/Assets/Scripts/Engine/GameEngine.cs
@@ -84,7 +84,6 @@ namespace Sporefront.Engine
         // ================================================================
 
         private double lastTickTime;
-        private readonly double tickInterval = GameConfig.EngineIntervals.Tick;
 
         // ================================================================
         // Update Intervals
@@ -652,20 +651,24 @@ namespace Sporefront.Engine
             double elapsed = currentTime - gameState.gameStartTime;
             if (elapsed < GameConfig.Online.WinConditionGracePeriod) return StateChange.EmptyChanges;
 
-            var allPlayers = gameState.players.Values.ToList();
+            var allPlayers = gameState.players.Values;
 
             // Need at least 2 players for win conditions
             if (allPlayers.Count < 2) return StateChange.EmptyChanges;
 
-            // --- City Center Destroyed (Conquest mode only) ---
-            if (gameState.gameMode == GameMode.Conquest)
+            // Single pass over all players: check city center, update starvation, emit warnings
+            double checkInterval = winConditionCheckInterval;
+            var warnings = new List<StateChange>();
+            PlayerState starvationLoser = null;
+
+            foreach (var player in allPlayers)
             {
-                foreach (var player in allPlayers)
+                // --- City Center Destroyed (Conquest mode only) ---
+                if (gameState.gameMode == GameMode.Conquest)
                 {
                     var cityCenter = gameState.GetCityCenter(player.id);
                     if (cityCenter == null)
                     {
-                        // This player's city center is destroyed — find the opponent
                         var opponent = allPlayers.FirstOrDefault(p => p.id != player.id);
                         if (opponent != null)
                         {
@@ -682,12 +685,8 @@ namespace Sporefront.Engine
                         }
                     }
                 }
-            }
 
-            // --- Starvation (zero food for starvationThreshold seconds) ---
-            double checkInterval = winConditionCheckInterval;
-            foreach (var player in allPlayers)
-            {
+                // --- Starvation timer update ---
                 if (player.GetResource(Models.ResourceType.Food) <= 0)
                 {
                     if (!starvationTimers.ContainsKey(player.id))
@@ -698,52 +697,50 @@ namespace Sporefront.Engine
                 {
                     starvationTimers[player.id] = 0;
                 }
-            }
 
-            // Emit starvation warnings for players approaching the threshold
-            var warnings = new List<StateChange>();
-            foreach (var player in allPlayers)
-            {
+                // --- Starvation warnings and threshold check ---
                 double timer;
-                if (starvationTimers.TryGetValue(player.id, out timer) && timer > 0 && timer < starvationThreshold)
+                if (starvationTimers.TryGetValue(player.id, out timer) && timer > 0)
                 {
-                    double remaining = starvationThreshold - timer;
-                    // Warn at 45s, 30s, 15s, 10s, 5s marks (every check interval)
-                    if (remaining <= 45)
+                    if (timer < starvationThreshold)
                     {
-                        warnings.Add(new StarvationWarningChange
+                        double remaining = starvationThreshold - timer;
+                        if (remaining <= 45)
                         {
-                            playerID = player.id,
-                            secondsRemaining = remaining
-                        });
+                            warnings.Add(new StarvationWarningChange
+                            {
+                                playerID = player.id,
+                                secondsRemaining = remaining
+                            });
+                        }
+                    }
+                    else if (starvationLoser == null)
+                    {
+                        starvationLoser = player;
                     }
                 }
             }
 
-            foreach (var player in allPlayers)
+            // --- Resolve starvation game over (only if opponent is NOT also past threshold) ---
+            if (starvationLoser != null)
             {
-                double timer;
-                if (starvationTimers.TryGetValue(player.id, out timer) && timer >= starvationThreshold)
+                var opponent = allPlayers.FirstOrDefault(p => p.id != starvationLoser.id);
+                if (opponent != null)
                 {
-                    // Check that the opponent is NOT also starving past threshold
-                    var opponent = allPlayers.FirstOrDefault(p => p.id != player.id);
-                    if (opponent != null)
+                    double opponentTimer;
+                    starvationTimers.TryGetValue(opponent.id, out opponentTimer);
+                    if (opponentTimer < starvationThreshold)
                     {
-                        double opponentTimer;
-                        starvationTimers.TryGetValue(opponent.id, out opponentTimer);
-                        if (opponentTimer < starvationThreshold)
+                        gameState.isGameOver = true;
+                        return new List<StateChange>
                         {
-                            gameState.isGameOver = true;
-                            return new List<StateChange>
+                            new GameOverChange
                             {
-                                new GameOverChange
-                                {
-                                    reason = GameOverReason.Starvation.DisplayMessage(),
-                                    winnerID = opponent.id,
-                                    reasonType = GameOverReason.Starvation
-                                }
-                            };
-                        }
+                                reason = GameOverReason.Starvation.DisplayMessage(),
+                                winnerID = opponent.id,
+                                reasonType = GameOverReason.Starvation
+                            }
+                        };
                     }
                 }
             }

--- a/Sporefront/Assets/Scripts/Engine/MatchmakingService.cs
+++ b/Sporefront/Assets/Scripts/Engine/MatchmakingService.cs
@@ -313,8 +313,7 @@ namespace Sporefront.Engine
             {
                 if (task.IsFaulted)
                 {
-                    Debug.Log(string.Format("[MatchmakingService] Match transaction failed (race condition expected): {0}",
-                        task.Exception?.InnerException?.Message));
+                    Debug.Log($"[MatchmakingService] Match transaction failed (race condition expected): {task.Exception?.InnerException?.Message}");
                     // Will retry on next poll
                 }
                 // Match result comes via the listener, not from here
@@ -387,8 +386,7 @@ namespace Sporefront.Engine
                             IsInQueue = false;
                             CurrentMatch = result;
 
-                            Debug.Log(string.Format("[MatchmakingService] Match found! Game: {0}, Host: {1}, Opponent: {2}",
-                                gameID, isHost, oppName));
+                            Debug.Log($"[MatchmakingService] Match found! Game: {gameID}, Host: {isHost}, Opponent: {oppName}");
 
                             OnMatchFound?.Invoke(result);
                         });
@@ -427,8 +425,7 @@ namespace Sporefront.Engine
             {
                 if (task.IsFaulted)
                 {
-                    Debug.LogWarning(string.Format("[MatchmakingService] Failed to confirm ready: {0}",
-                        task.Exception?.InnerException?.Message));
+                    Debug.LogWarning($"[MatchmakingService] Failed to confirm ready: {task.Exception?.InnerException?.Message}");
                 }
                 callback?.Invoke(!task.IsFaulted);
             });
@@ -497,7 +494,7 @@ namespace Sporefront.Engine
                         if ((DateTime.UtcNow - enqueuedAt).TotalSeconds > StaleEntryAge)
                         {
                             doc.Reference.DeleteAsync();
-                            Debug.Log(string.Format("[MatchmakingService] Cleaned stale entry: {0}", doc.Id));
+                            Debug.Log($"[MatchmakingService] Cleaned stale entry: {doc.Id}");
                         }
                     }
                 }

--- a/Sporefront/Assets/Scripts/Engine/MovementEngine.cs
+++ b/Sporefront/Assets/Scripts/Engine/MovementEngine.cs
@@ -199,74 +199,7 @@ namespace Sporefront.Engine
 
             var targetCoord = path[army.pathIndex];
 
-            // Calculate movement speed based on slowest unit in army
-            double slowestUnitSpeed = army.SlowestUnitMoveSpeed;
-            // Normalize: default army speed (1.6) = base speed, slower units reduce speed proportionally
-            double speedMultiplier = 1.6 / slowestUnitSpeed;
-
-            bool onRoad = gameState.mapData.GetBuildingID(targetCoord) != null;
-            double speed;
-            if (onRoad)
-            {
-                // On road
-                speed = baseMovementSpeed * speedMultiplier;
-            }
-            else
-            {
-                speed = baseMovementSpeed * speedMultiplier * terrainSpeedMultiplier;
-            }
-
-            if (army.isRetreating)
-            {
-                speed *= retreatSpeedBonus;
-            }
-
-            // Apply research bonuses for march/retreat/road speed
-            if (army.ownerID.HasValue)
-            {
-                var owner = gameState.GetPlayer(army.ownerID.Value);
-                if (owner != null)
-                {
-                    speed *= owner.GetResearchBonusMultiplier(
-                        ResearchBonusType.MilitaryMarchSpeed.ToString());
-                    if (army.isRetreating)
-                        speed *= owner.GetResearchBonusMultiplier(
-                            ResearchBonusType.MilitaryRetreatSpeed.ToString());
-                    if (onRoad)
-                        speed *= owner.GetResearchBonusMultiplier(
-                            ResearchBonusType.RoadSpeed.ToString());
-                }
-            }
-
-            // Apply faction highland speed bonus
-            if (army.ownerID.HasValue)
-            {
-                var owner = gameState.GetPlayer(army.ownerID.Value);
-                if (owner != null)
-                {
-                    var terrain = gameState.mapData.GetTerrain(targetCoord);
-                    if (terrain.HasValue &&
-                        (terrain.Value == TerrainType.Mountain || terrain.Value == TerrainType.Hill))
-                    {
-                        double highlandBonus = owner.faction.HighlandSpeedBonus();
-                        if (highlandBonus > 0)
-                            speed *= (1.0 + highlandBonus);
-                    }
-                }
-            }
-
-            // Apply commander logistics bonus
-            if (army.commanderID.HasValue)
-            {
-                var commander = gameState.GetCommander(army.commanderID.Value);
-                if (commander != null)
-                {
-                    double logisticsBonus = 1.0 + (double)commander.Logistics * GameConfig.Commander.LogisticsSpeedScaling;
-                    speed *= logisticsBonus;
-                }
-            }
-
-            // Store speed for visual interpolation
+            double speed = CalculateArmySpeed(army, targetCoord);
             army.movementSpeed = speed;
 
             // Update progress (0.1 second update interval)
@@ -294,8 +227,8 @@ namespace Sporefront.Engine
                     from = fromCoord,
                     to = targetCoord,
                     path = army.pathIndex < path.Count
-                        ? path.GetRange(army.pathIndex, path.Count - army.pathIndex)
-                        : new List<HexCoordinate>()
+                        ? path
+                        : null
                 });
 
                 // Auto-engage: non-retreating army that steps onto an enemy tile triggers combat
@@ -407,6 +340,61 @@ namespace Sporefront.Engine
             return changes;
         }
 
+        /// <summary>
+        /// Calculates final movement speed for an army moving toward a target coordinate,
+        /// accounting for unit speed, terrain, roads, research, faction bonuses, and commander logistics.
+        /// </summary>
+        private double CalculateArmySpeed(ArmyData army, HexCoordinate targetCoord)
+        {
+            double slowestUnitSpeed = army.SlowestUnitMoveSpeed;
+            double speedMultiplier = 1.6 / slowestUnitSpeed;
+
+            bool onRoad = gameState.mapData.GetBuildingID(targetCoord) != null;
+            double speed = onRoad
+                ? baseMovementSpeed * speedMultiplier
+                : baseMovementSpeed * speedMultiplier * terrainSpeedMultiplier;
+
+            if (army.isRetreating)
+                speed *= retreatSpeedBonus;
+
+            // Research bonuses
+            if (army.ownerID.HasValue)
+            {
+                var owner = gameState.GetPlayer(army.ownerID.Value);
+                if (owner != null)
+                {
+                    speed *= owner.GetResearchBonusMultiplier(ResearchBonusType.MilitaryMarchSpeed);
+                    if (army.isRetreating)
+                        speed *= owner.GetResearchBonusMultiplier(ResearchBonusType.MilitaryRetreatSpeed);
+                    if (onRoad)
+                        speed *= owner.GetResearchBonusMultiplier(ResearchBonusType.RoadSpeed);
+
+                    // Faction highland speed bonus
+                    var terrain = gameState.mapData.GetTerrain(targetCoord);
+                    if (terrain.HasValue &&
+                        (terrain.Value == TerrainType.Mountain || terrain.Value == TerrainType.Hill))
+                    {
+                        double highlandBonus = owner.faction.HighlandSpeedBonus();
+                        if (highlandBonus > 0)
+                            speed *= (1.0 + highlandBonus);
+                    }
+                }
+            }
+
+            // Commander logistics bonus
+            if (army.commanderID.HasValue)
+            {
+                var commander = gameState.GetCommander(army.commanderID.Value);
+                if (commander != null)
+                {
+                    double logisticsBonus = 1.0 + (double)commander.Logistics * GameConfig.Commander.LogisticsSpeedScaling;
+                    speed *= logisticsBonus;
+                }
+            }
+
+            return speed;
+        }
+
         // Villager Group Movement
 
         private List<StateChange> UpdateVillagerGroupMovement(VillagerGroupData group, double currentTime)
@@ -437,8 +425,7 @@ namespace Sporefront.Engine
             {
                 var owner = gameState.GetPlayer(group.ownerID.Value);
                 if (owner != null)
-                    speed *= owner.GetResearchBonusMultiplier(
-                        ResearchBonusType.VillagerMarchSpeed.ToString());
+                    speed *= owner.GetResearchBonusMultiplier(ResearchBonusType.VillagerMarchSpeed);
             }
 
             // Store speed for visual interpolation
@@ -464,8 +451,8 @@ namespace Sporefront.Engine
                     from = fromCoord,
                     to = targetCoord,
                     path = group.pathIndex < path.Count
-                        ? path.GetRange(group.pathIndex, path.Count - group.pathIndex)
-                        : new List<HexCoordinate>()
+                        ? path
+                        : null
                 });
 
                 // Check if path is complete
@@ -537,8 +524,8 @@ namespace Sporefront.Engine
                     from = fromCoord,
                     to = targetCoord,
                     path = scout.pathIndex < path.Count
-                        ? path.GetRange(scout.pathIndex, path.Count - scout.pathIndex)
-                        : new List<HexCoordinate>()
+                        ? path
+                        : null
                 });
 
                 // Check if path is complete or out of stamina
@@ -593,11 +580,9 @@ namespace Sporefront.Engine
                     var owner = gameState.GetPlayer(army.ownerID.Value);
                     if (owner != null)
                     {
-                        speed *= owner.GetResearchBonusMultiplier(
-                            ResearchBonusType.MilitaryMarchSpeed.ToString());
+                        speed *= owner.GetResearchBonusMultiplier(ResearchBonusType.MilitaryMarchSpeed);
                         if (reinforceOnRoad)
-                            speed *= owner.GetResearchBonusMultiplier(
-                                ResearchBonusType.RoadSpeed.ToString());
+                            speed *= owner.GetResearchBonusMultiplier(ResearchBonusType.RoadSpeed);
                     }
                 }
 

--- a/Sporefront/Assets/Scripts/Engine/ResourceEngine.cs
+++ b/Sporefront/Assets/Scripts/Engine/ResourceEngine.cs
@@ -125,10 +125,8 @@ namespace Sporefront.Engine
                 double baseRate = 0.1;
                 double civilianRate = consumptionInfo.civilian * baseRate;
                 double militaryRate = consumptionInfo.military * baseRate;
-                double civMultiplier = player.GetResearchBonusMultiplier(
-                    ResearchBonusType.FoodConsumption.ToString());
-                double milMultiplier = player.GetResearchBonusMultiplier(
-                    ResearchBonusType.MilitaryFoodConsumption.ToString());
+                double civMultiplier = player.GetResearchBonusMultiplier(ResearchBonusType.FoodConsumption);
+                double milMultiplier = player.GetResearchBonusMultiplier(ResearchBonusType.MilitaryFoodConsumption);
                 double adjustedRate = (civilianRate * civMultiplier + militaryRate * milMultiplier)
                     * (1.0 - rationingReduction);
 
@@ -328,22 +326,9 @@ namespace Sporefront.Engine
             if (owner != null)
             {
                 ResearchBonusType bonusType;
-                switch (resourceType)
-                {
-                    case ResourcePointType.Farmland:
-                        bonusType = ResearchBonusType.FarmGatheringRate;
-                        break;
-                    case ResourcePointType.Trees:
-                        bonusType = ResearchBonusType.LumberCampGatheringRate;
-                        break;
-                    case ResourcePointType.OreMine:
-                    case ResourcePointType.StoneQuarry:
-                        bonusType = ResearchBonusType.MiningCampGatheringRate;
-                        break;
-                    default:
-                        return rate;
-                }
-                rate *= owner.GetResearchBonusMultiplier(bonusType.ToString());
+                if (!EnumMappings.ResourceToResearchBonus.TryGetValue(resourceType, out bonusType))
+                    return rate;
+                rate *= owner.GetResearchBonusMultiplier(bonusType);
 
                 // Apply faction wood gathering bonus
                 if (resourceType == ResourcePointType.Trees && owner.faction.WoodGatheringBonus() > 0)
@@ -557,8 +542,8 @@ namespace Sporefront.Engine
 
         public bool HasCampCoverage(HexCoordinate coordinate, ResourcePointType resourceType, GameState state)
         {
-            string requiredCampType = GetRequiredCampType(resourceType);
-            if (requiredCampType == null)
+            BuildingType? requiredCampType = GetRequiredCampType(resourceType);
+            if (!requiredCampType.HasValue)
             {
                 return true; // No camp required
             }
@@ -567,7 +552,7 @@ namespace Sporefront.Engine
             var matchingCamps = new List<BuildingData>();
             foreach (var building in state.buildings.Values)
             {
-                if (building.buildingType.ToString() == requiredCampType && building.IsOperational)
+                if (building.buildingType == requiredCampType.Value && building.IsOperational)
                 {
                     matchingCamps.Add(building);
                 }
@@ -587,17 +572,17 @@ namespace Sporefront.Engine
         }
 
         /// <summary>
-        /// Returns the required camp type string for a resource point type, or null if no camp is required.
+        /// Returns the required camp type for a resource point type, or null if no camp is required.
         /// </summary>
-        private string GetRequiredCampType(ResourcePointType resourceType)
+        private BuildingType? GetRequiredCampType(ResourcePointType resourceType)
         {
             switch (resourceType)
             {
                 case ResourcePointType.Trees:
-                    return BuildingType.LumberCamp.ToString();
+                    return BuildingType.LumberCamp;
                 case ResourcePointType.OreMine:
                 case ResourcePointType.StoneQuarry:
-                    return BuildingType.MiningCamp.ToString();
+                    return BuildingType.MiningCamp;
                 default:
                     return null;
             }

--- a/Sporefront/Assets/Scripts/Engine/SaveManager.cs
+++ b/Sporefront/Assets/Scripts/Engine/SaveManager.cs
@@ -19,25 +19,7 @@ namespace Sporefront.Engine
         private const string SaveDirectory = "saves";
         private const string AutoSaveName = "autosave";
 
-        private static JsonSerializerSettings serializerSettings;
-
-        private static JsonSerializerSettings GetSettings()
-        {
-            if (serializerSettings == null)
-            {
-                serializerSettings = new JsonSerializerSettings
-                {
-                    Formatting = Formatting.Indented,
-                    NullValueHandling = NullValueHandling.Ignore,
-                    TypeNameHandling = TypeNameHandling.None,
-                    Converters = new List<JsonConverter>
-                    {
-                        new HexCoordinateConverter()
-                    }
-                };
-            }
-            return serializerSettings;
-        }
+        private static JsonSerializerSettings GetSettings() => Data.Serialization.SporefrontJsonSettings.Indented;
 
         private static string GetSavesPath()
         {

--- a/Sporefront/Assets/Scripts/Engine/TrainingEngine.cs
+++ b/Sporefront/Assets/Scripts/Engine/TrainingEngine.cs
@@ -16,9 +16,6 @@ namespace Sporefront.Engine
         // State
         private GameState gameState;
 
-        // Constants
-        private double villagerTrainingTime = GameConfig.Training.VillagerTrainingTime;
-
         // Setup
 
         public void Setup(GameState gameState)
@@ -80,8 +77,7 @@ namespace Sporefront.Engine
             {
                 var owner = gameState.GetPlayer(building.ownerID.Value);
                 if (owner != null)
-                    researchMultiplier = owner.GetResearchBonusMultiplier(
-                        ResearchBonusType.MilitaryTrainingSpeed.ToString());
+                    researchMultiplier = owner.GetResearchBonusMultiplier(ResearchBonusType.MilitaryTrainingSpeed);
             }
 
             var completedEntries = building.UpdateTraining(currentTime, researchMultiplier);

--- a/Sporefront/Assets/Scripts/Engine/VisionEngine.cs
+++ b/Sporefront/Assets/Scripts/Engine/VisionEngine.cs
@@ -42,6 +42,7 @@ namespace Sporefront.Engine
         private HashSet<HexCoordinate> reusableNewlyHidden = new HashSet<HexCoordinate>();
         private List<HexCoordinate> reusableRing = new List<HexCoordinate>();
         private List<HexCoordinate> reusablePath = new List<HexCoordinate>();
+        private List<ArmyData> reusableCamoArmies = new List<ArmyData>();
 
         // Setup
 
@@ -108,25 +109,34 @@ namespace Sporefront.Engine
                 }
             }
 
-            // Emit camouflage changes for each player
-            foreach (var player in gameState.players.Values)
+            // Emit camouflage changes — pre-filter to armies whose owner has woodland camouflage
+            reusableCamoArmies.Clear();
+            foreach (var army in gameState.armies.Values)
             {
-                var camouflagedIDs = new List<Guid>();
-                foreach (var army in gameState.armies.Values)
+                if (!army.ownerID.HasValue) continue;
+                var owner = gameState.GetPlayer(army.ownerID.Value);
+                if (owner != null && owner.faction.HasWoodlandCamouflage())
+                    reusableCamoArmies.Add(army);
+            }
+            if (reusableCamoArmies.Count > 0)
+            {
+                foreach (var player in gameState.players.Values)
                 {
-                    if (!army.ownerID.HasValue || army.ownerID.Value == player.id) continue;
-                    if (player.IsVisible(army.coordinate) && IsArmyCamouflaged(army, player.id))
+                    var camouflagedIDs = new List<Guid>();
+                    foreach (var army in reusableCamoArmies)
                     {
-                        camouflagedIDs.Add(army.id);
+                        if (army.ownerID.Value == player.id) continue;
+                        if (player.IsVisible(army.coordinate) && IsArmyCamouflaged(army, player.id))
+                            camouflagedIDs.Add(army.id);
                     }
-                }
-                if (camouflagedIDs.Count > 0)
-                {
-                    changes.Add(new CamouflagedArmiesChange
+                    if (camouflagedIDs.Count > 0)
                     {
-                        observingPlayerID = player.id,
-                        camouflagedArmyIDs = camouflagedIDs
-                    });
+                        changes.Add(new CamouflagedArmiesChange
+                        {
+                            observingPlayerID = player.id,
+                            camouflagedArmyIDs = camouflagedIDs
+                        });
+                    }
                 }
             }
 
@@ -391,16 +401,26 @@ namespace Sporefront.Engine
             if (resourcePoint == null || resourcePoint.resourceType != ResourcePointType.Trees)
                 return false;
 
-            // Check if observing player has any unit within 1 tile
-            foreach (var observerArmy in gameState.GetArmiesForPlayer(observingPlayerID))
+            // Check if observing player has any unit within 1 tile using spatial lookup
+            // Check center hex + 6 neighbors (7 total) instead of iterating all player entities
+            var coordsToCheck = army.coordinate.Neighbors();
+            coordsToCheck.Add(army.coordinate);
+            foreach (var coord in coordsToCheck)
             {
-                if (observerArmy.coordinate.Distance(army.coordinate) <= 1)
-                    return false;
-            }
-            foreach (var observerVillager in gameState.GetVillagerGroupsForPlayer(observingPlayerID))
-            {
-                if (observerVillager.coordinate.Distance(army.coordinate) <= 1)
-                    return false;
+                foreach (var armyId in gameState.mapData.GetArmyIDs(coord))
+                {
+                    ArmyData observer;
+                    if (gameState.armies.TryGetValue(armyId, out observer) &&
+                        observer.ownerID.HasValue && observer.ownerID.Value == observingPlayerID)
+                        return false;
+                }
+                foreach (var vgId in gameState.mapData.GetVillagerGroupIDs(coord))
+                {
+                    VillagerGroupData observer;
+                    if (gameState.villagerGroups.TryGetValue(vgId, out observer) &&
+                        observer.ownerID.HasValue && observer.ownerID.Value == observingPlayerID)
+                        return false;
+                }
             }
 
             return true;

--- a/Sporefront/Assets/Scripts/Models/BuildingType.cs
+++ b/Sporefront/Assets/Scripts/Models/BuildingType.cs
@@ -52,306 +52,227 @@ namespace Sporefront.Models
         FalseMorel
     }
 
+    // ================================================================
+    // Data record for BuildingType lookup table
+    // ================================================================
+
+    public class BuildingTypeData
+    {
+        public string DisplayName;
+        public string Icon;
+        public BuildingCategory Category;
+        public int PopulationCapacity;
+        public int PopulationCapacityPerLevel;
+        public int RequiredCityCenterLevel;
+        public Dictionary<ResourceType, int> BuildCost;
+        public double BuildTime;
+        public int HexSize;
+        public string Description;
+        public Dictionary<ResourceType, double> ResourceBonus;
+        public int MaxLevel;
+        public int BaseStorageCapacityPerResource;
+        public int StorageCapacityPerLevelPerResource;
+
+        public BuildingTypeData(
+            string displayName, string icon, BuildingCategory category,
+            Dictionary<ResourceType, int> buildCost, double buildTime,
+            string description,
+            int requiredCCLevel = 1, int hexSize = 1, int maxLevel = 5,
+            int popCap = 0, int popCapPerLevel = 0,
+            Dictionary<ResourceType, double> resourceBonus = null,
+            int baseStorage = 0, int storagePerLevel = 0)
+        {
+            DisplayName = displayName;
+            Icon = icon;
+            Category = category;
+            BuildCost = buildCost;
+            BuildTime = buildTime;
+            Description = description;
+            RequiredCityCenterLevel = requiredCCLevel;
+            HexSize = hexSize;
+            MaxLevel = maxLevel;
+            PopulationCapacity = popCap;
+            PopulationCapacityPerLevel = popCapPerLevel;
+            ResourceBonus = resourceBonus;
+            BaseStorageCapacityPerResource = baseStorage;
+            StorageCapacityPerLevelPerResource = storagePerLevel;
+        }
+    }
+
+    // ================================================================
+    // Extension methods — data-driven via static lookup table
+    // ================================================================
+
     public static class BuildingTypeExtensions
     {
-        public static string DisplayName(this BuildingType type)
+        private static readonly Dictionary<BuildingType, BuildingTypeData> Data =
+            new Dictionary<BuildingType, BuildingTypeData>
         {
-            switch (type)
-            {
-                case BuildingType.CityCenter: return "City Center";
-                case BuildingType.Farm: return "Farm";
-                case BuildingType.Neighborhood: return "Neighborhood";
-                case BuildingType.Blacksmith: return "Blacksmith";
-                case BuildingType.Market: return "Market";
-                case BuildingType.MiningCamp: return "Mining Camp";
-                case BuildingType.LumberCamp: return "Lumber Camp";
-                case BuildingType.Warehouse: return "Warehouse";
-                case BuildingType.University: return "University";
-                case BuildingType.Library: return "Library";
-                case BuildingType.Mill: return "Mill";
-                case BuildingType.Road: return "Road";
-                case BuildingType.Castle: return "Castle";
-                case BuildingType.Barracks: return "Barracks";
-                case BuildingType.ArcheryRange: return "Archery Range";
-                case BuildingType.Stable: return "Stable";
-                case BuildingType.SiegeWorkshop: return "Siege Workshop";
-                case BuildingType.Tower: return "Tower";
-                case BuildingType.WoodenFort: return "Wooden Fort";
-                case BuildingType.Wall: return "Wall";
-                case BuildingType.Gate: return "Gate";
-                case BuildingType.FalseMorel: return "False Morel";
-                default: return type.ToString();
-            }
-        }
+            // ---- Economic Buildings ----
+            { BuildingType.CityCenter, new BuildingTypeData(
+                "City Center", "city_center", BuildingCategory.Economic,
+                new Dictionary<ResourceType, int> { { ResourceType.Wood, 200 }, { ResourceType.Stone, 150 }, { ResourceType.Ore, 50 } },
+                60.0, "Main hub for economy and villagers",
+                maxLevel: 10, popCap: 10, popCapPerLevel: 5, baseStorage: 1200, storagePerLevel: 100) },
 
-        public static string Icon(this BuildingType type)
-        {
-            switch (type)
-            {
-                case BuildingType.CityCenter: return "city_center";
-                case BuildingType.Farm: return "farm";
-                case BuildingType.Neighborhood: return "neighborhood";
-                case BuildingType.Blacksmith: return "blacksmith";
-                case BuildingType.Market: return "market";
-                case BuildingType.MiningCamp: return "mining_camp";
-                case BuildingType.LumberCamp: return "lumber_camp";
-                case BuildingType.Warehouse: return "warehouse";
-                case BuildingType.University: return "university";
-                case BuildingType.Library: return "library";
-                case BuildingType.Mill: return "mill";
-                case BuildingType.Road: return "road";
-                case BuildingType.Castle: return "castle";
-                case BuildingType.Barracks: return "barracks";
-                case BuildingType.ArcheryRange: return "archery_range";
-                case BuildingType.Stable: return "stable";
-                case BuildingType.SiegeWorkshop: return "siege_workshop";
-                case BuildingType.Tower: return "tower";
-                case BuildingType.WoodenFort: return "wooden_fort";
-                case BuildingType.Wall: return "wall";
-                case BuildingType.Gate: return "gate";
-                case BuildingType.FalseMorel: return "false_morel";
-                default: return "";
-            }
-        }
+            { BuildingType.Farm, new BuildingTypeData(
+                "Farm", "farm", BuildingCategory.Economic,
+                new Dictionary<ResourceType, int> { { ResourceType.Wood, 50 }, { ResourceType.Stone, 20 } },
+                20.0, "Produces food resources",
+                resourceBonus: new Dictionary<ResourceType, double> { { ResourceType.Food, 2.0 } }) },
 
-        public static BuildingCategory Category(this BuildingType type)
-        {
-            switch (type)
-            {
-                case BuildingType.CityCenter:
-                case BuildingType.Farm:
-                case BuildingType.Neighborhood:
-                case BuildingType.Blacksmith:
-                case BuildingType.Market:
-                case BuildingType.MiningCamp:
-                case BuildingType.LumberCamp:
-                case BuildingType.Warehouse:
-                case BuildingType.University:
-                case BuildingType.Library:
-                case BuildingType.Road:
-                case BuildingType.Mill:
-                case BuildingType.FalseMorel:
-                    return BuildingCategory.Economic;
-                default:
-                    return BuildingCategory.Military;
-            }
-        }
+            { BuildingType.Neighborhood, new BuildingTypeData(
+                "Neighborhood", "neighborhood", BuildingCategory.Economic,
+                new Dictionary<ResourceType, int> { { ResourceType.Wood, 100 }, { ResourceType.Stone, 80 } },
+                35.0, "Houses population",
+                popCap: 5, popCapPerLevel: 3) },
 
-        public static int PopulationCapacity(this BuildingType type)
-        {
-            switch (type)
-            {
-                case BuildingType.CityCenter: return 10;
-                case BuildingType.Neighborhood: return 5;
-                default: return 0;
-            }
-        }
+            { BuildingType.Blacksmith, new BuildingTypeData(
+                "Blacksmith", "blacksmith", BuildingCategory.Economic,
+                new Dictionary<ResourceType, int> { { ResourceType.Wood, 80 }, { ResourceType.Stone, 60 }, { ResourceType.Ore, 40 } },
+                40.0, "Upgrades units and tools",
+                requiredCCLevel: 3) },
 
-        public static int PopulationCapacityPerLevel(this BuildingType type)
-        {
-            switch (type)
-            {
-                case BuildingType.CityCenter: return 5;
-                case BuildingType.Neighborhood: return 3;
-                default: return 0;
-            }
-        }
+            { BuildingType.Market, new BuildingTypeData(
+                "Market", "market", BuildingCategory.Economic,
+                new Dictionary<ResourceType, int> { { ResourceType.Wood, 100 }, { ResourceType.Stone, 50 } },
+                30.0, "Trade resources",
+                requiredCCLevel: 3) },
+
+            { BuildingType.MiningCamp, new BuildingTypeData(
+                "Mining Camp", "mining_camp", BuildingCategory.Economic,
+                new Dictionary<ResourceType, int> { { ResourceType.Wood, 100 }, { ResourceType.Stone, 30 } },
+                25.0, "Increases ore collection",
+                resourceBonus: new Dictionary<ResourceType, double> { { ResourceType.Ore, 1.5 } }) },
+
+            { BuildingType.LumberCamp, new BuildingTypeData(
+                "Lumber Camp", "lumber_camp", BuildingCategory.Economic,
+                new Dictionary<ResourceType, int> { { ResourceType.Wood, 80 }, { ResourceType.Stone, 20 } },
+                25.0, "Increases wood collection",
+                resourceBonus: new Dictionary<ResourceType, double> { { ResourceType.Wood, 1.5 } }) },
+
+            { BuildingType.Warehouse, new BuildingTypeData(
+                "Warehouse", "warehouse", BuildingCategory.Economic,
+                new Dictionary<ResourceType, int> { { ResourceType.Wood, 120 }, { ResourceType.Stone, 80 } },
+                30.0, "Stores extra resources",
+                baseStorage: 150, storagePerLevel: 75) },
+
+            { BuildingType.University, new BuildingTypeData(
+                "University", "university", BuildingCategory.Economic,
+                new Dictionary<ResourceType, int> { { ResourceType.Wood, 150 }, { ResourceType.Stone, 120 }, { ResourceType.Ore, 60 } },
+                50.0, "Research technologies",
+                requiredCCLevel: 3) },
+
+            { BuildingType.Library, new BuildingTypeData(
+                "Library", "library", BuildingCategory.Economic,
+                new Dictionary<ResourceType, int> { { ResourceType.Wood, 120 }, { ResourceType.Stone, 100 }, { ResourceType.Ore, 40 } },
+                45.0, "Boosts research speed and unlocks advanced research",
+                requiredCCLevel: 3) },
+
+            { BuildingType.Mill, new BuildingTypeData(
+                "Mill", "mill", BuildingCategory.Economic,
+                new Dictionary<ResourceType, int> { { ResourceType.Wood, 80 }, { ResourceType.Stone, 40 } },
+                25.0, "Boosts adjacent farm gather rates by 25%",
+                requiredCCLevel: 2) },
+
+            // ---- Infrastructure ----
+            { BuildingType.Road, new BuildingTypeData(
+                "Road", "road", BuildingCategory.Economic,
+                new Dictionary<ResourceType, int> { { ResourceType.Stone, 10 } },
+                5.0, "Increases movement speed for units",
+                maxLevel: 1) },
+
+            // ---- Military Buildings ----
+            { BuildingType.Castle, new BuildingTypeData(
+                "Castle", "castle", BuildingCategory.Military,
+                new Dictionary<ResourceType, int> { { ResourceType.Wood, 300 }, { ResourceType.Stone, 400 }, { ResourceType.Ore, 150 } },
+                90.0, "Defensive stronghold and military hub",
+                hexSize: 3) },
+
+            { BuildingType.Barracks, new BuildingTypeData(
+                "Barracks", "barracks", BuildingCategory.Military,
+                new Dictionary<ResourceType, int> { { ResourceType.Wood, 150 }, { ResourceType.Stone, 100 } },
+                4.0, "Trains infantry units") },
+
+            { BuildingType.ArcheryRange, new BuildingTypeData(
+                "Archery Range", "archery_range", BuildingCategory.Military,
+                new Dictionary<ResourceType, int> { { ResourceType.Wood, 120 }, { ResourceType.Stone, 80 } },
+                35.0, "Trains ranged units",
+                requiredCCLevel: 2) },
+
+            { BuildingType.Stable, new BuildingTypeData(
+                "Stable", "stable", BuildingCategory.Military,
+                new Dictionary<ResourceType, int> { { ResourceType.Wood, 140 }, { ResourceType.Stone, 90 } },
+                35.0, "Trains cavalry units",
+                requiredCCLevel: 2) },
+
+            { BuildingType.SiegeWorkshop, new BuildingTypeData(
+                "Siege Workshop", "siege_workshop", BuildingCategory.Military,
+                new Dictionary<ResourceType, int> { { ResourceType.Wood, 180 }, { ResourceType.Stone, 120 }, { ResourceType.Ore, 80 } },
+                45.0, "Builds siege weapons",
+                requiredCCLevel: 5) },
+
+            { BuildingType.Tower, new BuildingTypeData(
+                "Tower", "tower", BuildingCategory.Military,
+                new Dictionary<ResourceType, int> { { ResourceType.Wood, 80 }, { ResourceType.Stone, 120 } },
+                30.0, "Defensive structure",
+                requiredCCLevel: 3) },
+
+            { BuildingType.WoodenFort, new BuildingTypeData(
+                "Wooden Fort", "wooden_fort", BuildingCategory.Military,
+                new Dictionary<ResourceType, int> { { ResourceType.Wood, 200 }, { ResourceType.Stone, 100 } },
+                50.0, "Basic defensive structure",
+                hexSize: 3) },
+
+            { BuildingType.Wall, new BuildingTypeData(
+                "Wall", "wall", BuildingCategory.Military,
+                new Dictionary<ResourceType, int> { { ResourceType.Wood, 30 }, { ResourceType.Stone, 50 } },
+                15.0, "Blocks all movement",
+                requiredCCLevel: 2, maxLevel: 1) },
+
+            { BuildingType.Gate, new BuildingTypeData(
+                "Gate", "gate", BuildingCategory.Military,
+                new Dictionary<ResourceType, int> { { ResourceType.Wood, 60 }, { ResourceType.Stone, 40 } },
+                20.0, "Allows passage for owner and allies",
+                requiredCCLevel: 2, maxLevel: 1) },
+
+            // ---- Faction-Exclusive ----
+            { BuildingType.FalseMorel, new BuildingTypeData(
+                "False Morel", "false_morel", BuildingCategory.Economic,
+                new Dictionary<ResourceType, int> { { ResourceType.Wood, 60 }, { ResourceType.Stone, 20 } },
+                20.0, "A decoy structure that appears as an army to enemies until they are adjacent",
+                requiredCCLevel: 2, maxLevel: 1) },
+        };
+
+        // ================================================================
+        // One-liner data lookups
+        // ================================================================
+
+        public static string DisplayName(this BuildingType type) => Data[type].DisplayName;
+        public static string Icon(this BuildingType type) => Data[type].Icon;
+        public static BuildingCategory Category(this BuildingType type) => Data[type].Category;
+        public static int PopulationCapacity(this BuildingType type) => Data[type].PopulationCapacity;
+        public static int PopulationCapacityPerLevel(this BuildingType type) => Data[type].PopulationCapacityPerLevel;
+        public static int RequiredCityCenterLevel(this BuildingType type) => Data[type].RequiredCityCenterLevel;
+        public static Dictionary<ResourceType, int> BuildCost(this BuildingType type) => Data[type].BuildCost;
+        public static double BuildTime(this BuildingType type) => Data[type].BuildTime;
+        public static int HexSize(this BuildingType type) => Data[type].HexSize;
+        public static string Description(this BuildingType type) => Data[type].Description;
+        public static Dictionary<ResourceType, double> ResourceBonus(this BuildingType type) => Data[type].ResourceBonus;
+        public static int MaxLevel(this BuildingType type) => Data[type].MaxLevel;
+        public static int BaseStorageCapacityPerResource(this BuildingType type) => Data[type].BaseStorageCapacityPerResource;
+        public static int StorageCapacityPerLevelPerResource(this BuildingType type) => Data[type].StorageCapacityPerLevelPerResource;
+
+        // ================================================================
+        // Computed methods (derive from base data)
+        // ================================================================
 
         public static int PopulationCapacityForLevel(this BuildingType type, int level)
         {
             return type.PopulationCapacity() + type.PopulationCapacityPerLevel() * (level - 1);
         }
 
-        public static int RequiredCityCenterLevel(this BuildingType type)
-        {
-            switch (type)
-            {
-                case BuildingType.CityCenter: return 1;
-                case BuildingType.Neighborhood:
-                case BuildingType.Warehouse:
-                case BuildingType.Farm:
-                case BuildingType.Barracks:
-                case BuildingType.Road:
-                case BuildingType.WoodenFort:
-                case BuildingType.Castle:
-                case BuildingType.MiningCamp:
-                case BuildingType.LumberCamp:
-                    return 1;
-                case BuildingType.ArcheryRange:
-                case BuildingType.Stable:
-                case BuildingType.Mill:
-                case BuildingType.Wall:
-                case BuildingType.Gate:
-                case BuildingType.FalseMorel:
-                    return 2;
-                case BuildingType.Market:
-                case BuildingType.Blacksmith:
-                case BuildingType.Tower:
-                case BuildingType.University:
-                case BuildingType.Library:
-                    return 3;
-                case BuildingType.SiegeWorkshop:
-                    return 5;
-                default: return 1;
-            }
-        }
-
-        public static Dictionary<ResourceType, int> BuildCost(this BuildingType type)
-        {
-            switch (type)
-            {
-                case BuildingType.CityCenter:
-                    return new Dictionary<ResourceType, int> { { ResourceType.Wood, 200 }, { ResourceType.Stone, 150 }, { ResourceType.Ore, 50 } };
-                case BuildingType.Farm:
-                    return new Dictionary<ResourceType, int> { { ResourceType.Wood, 50 }, { ResourceType.Stone, 20 } };
-                case BuildingType.Neighborhood:
-                    return new Dictionary<ResourceType, int> { { ResourceType.Wood, 100 }, { ResourceType.Stone, 80 } };
-                case BuildingType.Blacksmith:
-                    return new Dictionary<ResourceType, int> { { ResourceType.Wood, 80 }, { ResourceType.Stone, 60 }, { ResourceType.Ore, 40 } };
-                case BuildingType.Market:
-                    return new Dictionary<ResourceType, int> { { ResourceType.Wood, 100 }, { ResourceType.Stone, 50 } };
-                case BuildingType.MiningCamp:
-                    return new Dictionary<ResourceType, int> { { ResourceType.Wood, 100 }, { ResourceType.Stone, 30 } };
-                case BuildingType.LumberCamp:
-                    return new Dictionary<ResourceType, int> { { ResourceType.Wood, 80 }, { ResourceType.Stone, 20 } };
-                case BuildingType.Warehouse:
-                    return new Dictionary<ResourceType, int> { { ResourceType.Wood, 120 }, { ResourceType.Stone, 80 } };
-                case BuildingType.University:
-                    return new Dictionary<ResourceType, int> { { ResourceType.Wood, 150 }, { ResourceType.Stone, 120 }, { ResourceType.Ore, 60 } };
-                case BuildingType.Library:
-                    return new Dictionary<ResourceType, int> { { ResourceType.Wood, 120 }, { ResourceType.Stone, 100 }, { ResourceType.Ore, 40 } };
-                case BuildingType.Road:
-                    return new Dictionary<ResourceType, int> { { ResourceType.Stone, 10 } };
-                case BuildingType.Castle:
-                    return new Dictionary<ResourceType, int> { { ResourceType.Wood, 300 }, { ResourceType.Stone, 400 }, { ResourceType.Ore, 150 } };
-                case BuildingType.Barracks:
-                    return new Dictionary<ResourceType, int> { { ResourceType.Wood, 150 }, { ResourceType.Stone, 100 } };
-                case BuildingType.ArcheryRange:
-                    return new Dictionary<ResourceType, int> { { ResourceType.Wood, 120 }, { ResourceType.Stone, 80 } };
-                case BuildingType.Stable:
-                    return new Dictionary<ResourceType, int> { { ResourceType.Wood, 140 }, { ResourceType.Stone, 90 } };
-                case BuildingType.SiegeWorkshop:
-                    return new Dictionary<ResourceType, int> { { ResourceType.Wood, 180 }, { ResourceType.Stone, 120 }, { ResourceType.Ore, 80 } };
-                case BuildingType.Tower:
-                    return new Dictionary<ResourceType, int> { { ResourceType.Wood, 80 }, { ResourceType.Stone, 120 } };
-                case BuildingType.WoodenFort:
-                    return new Dictionary<ResourceType, int> { { ResourceType.Wood, 200 }, { ResourceType.Stone, 100 } };
-                case BuildingType.Mill:
-                    return new Dictionary<ResourceType, int> { { ResourceType.Wood, 80 }, { ResourceType.Stone, 40 } };
-                case BuildingType.Wall:
-                    return new Dictionary<ResourceType, int> { { ResourceType.Wood, 30 }, { ResourceType.Stone, 50 } };
-                case BuildingType.Gate:
-                    return new Dictionary<ResourceType, int> { { ResourceType.Wood, 60 }, { ResourceType.Stone, 40 } };
-                case BuildingType.FalseMorel:
-                    return new Dictionary<ResourceType, int> { { ResourceType.Wood, 60 }, { ResourceType.Stone, 20 } };
-                default:
-                    return new Dictionary<ResourceType, int>();
-            }
-        }
-
-        public static double BuildTime(this BuildingType type)
-        {
-            switch (type)
-            {
-                case BuildingType.CityCenter: return 60.0;
-                case BuildingType.Farm: return 20.0;
-                case BuildingType.Neighborhood: return 35.0;
-                case BuildingType.Blacksmith: return 40.0;
-                case BuildingType.Market: return 30.0;
-                case BuildingType.MiningCamp: return 25.0;
-                case BuildingType.LumberCamp: return 25.0;
-                case BuildingType.Warehouse: return 30.0;
-                case BuildingType.University: return 50.0;
-                case BuildingType.Library: return 45.0;
-                case BuildingType.Road: return 5.0;
-                case BuildingType.Castle: return 90.0;
-                case BuildingType.Barracks: return 4.0;
-                case BuildingType.ArcheryRange: return 35.0;
-                case BuildingType.Stable: return 35.0;
-                case BuildingType.SiegeWorkshop: return 45.0;
-                case BuildingType.Tower: return 30.0;
-                case BuildingType.WoodenFort: return 50.0;
-                case BuildingType.Mill: return 25.0;
-                case BuildingType.Wall: return 15.0;
-                case BuildingType.Gate: return 20.0;
-                case BuildingType.FalseMorel: return 20.0;
-                default: return 30.0;
-            }
-        }
-
-        public static int HexSize(this BuildingType type)
-        {
-            switch (type)
-            {
-                case BuildingType.Castle:
-                case BuildingType.WoodenFort:
-                    return 3;
-                default: return 1;
-            }
-        }
-
-        public static bool RequiresRotation(this BuildingType type)
-        {
-            return type.HexSize() > 1;
-        }
-
-        public static string Description(this BuildingType type)
-        {
-            switch (type)
-            {
-                case BuildingType.CityCenter: return "Main hub for economy and villagers";
-                case BuildingType.Farm: return "Produces food resources";
-                case BuildingType.Neighborhood: return "Houses population";
-                case BuildingType.Blacksmith: return "Upgrades units and tools";
-                case BuildingType.Market: return "Trade resources";
-                case BuildingType.MiningCamp: return "Increases ore collection";
-                case BuildingType.LumberCamp: return "Increases wood collection";
-                case BuildingType.Warehouse: return "Stores extra resources";
-                case BuildingType.University: return "Research technologies";
-                case BuildingType.Library: return "Boosts research speed and unlocks advanced research";
-                case BuildingType.Road: return "Increases movement speed for units";
-                case BuildingType.Castle: return "Defensive stronghold and military hub";
-                case BuildingType.Barracks: return "Trains infantry units";
-                case BuildingType.ArcheryRange: return "Trains ranged units";
-                case BuildingType.Stable: return "Trains cavalry units";
-                case BuildingType.SiegeWorkshop: return "Builds siege weapons";
-                case BuildingType.Tower: return "Defensive structure";
-                case BuildingType.WoodenFort: return "Basic defensive structure";
-                case BuildingType.Mill: return "Boosts adjacent farm gather rates by 25%";
-                case BuildingType.Wall: return "Blocks all movement";
-                case BuildingType.Gate: return "Allows passage for owner and allies";
-                case BuildingType.FalseMorel: return "A decoy structure that appears as an army to enemies until they are adjacent";
-                default: return "";
-            }
-        }
-
-        public static Dictionary<ResourceType, double> ResourceBonus(this BuildingType type)
-        {
-            switch (type)
-            {
-                case BuildingType.Farm:
-                    return new Dictionary<ResourceType, double> { { ResourceType.Food, 2.0 } };
-                case BuildingType.MiningCamp:
-                    return new Dictionary<ResourceType, double> { { ResourceType.Ore, 1.5 } };
-                case BuildingType.LumberCamp:
-                    return new Dictionary<ResourceType, double> { { ResourceType.Wood, 1.5 } };
-                default: return null;
-            }
-        }
-
-        public static int MaxLevel(this BuildingType type)
-        {
-            switch (type)
-            {
-                case BuildingType.CityCenter: return 10;
-                case BuildingType.Road:
-                case BuildingType.Wall:
-                case BuildingType.Gate:
-                case BuildingType.FalseMorel:
-                    return 1;
-                default: return 5;
-            }
-        }
+        public static bool RequiresRotation(this BuildingType type) => type.HexSize() > 1;
 
         public static bool IsRoad(this BuildingType type) => type == BuildingType.Road;
 
@@ -386,35 +307,19 @@ namespace Sporefront.Models
             return type.BuildTime() * multiplier * 0.8;
         }
 
+        public static int StorageCapacityPerResource(this BuildingType type, int level)
+        {
+            return type.BaseStorageCapacityPerResource() + type.StorageCapacityPerLevelPerResource() * (level - 1);
+        }
+
+        // ================================================================
+        // Static helpers (not extension methods)
+        // ================================================================
+
         public static int MaxCastleLevel(int cityCenterLevel)
         {
             if (cityCenterLevel < 6) return 0;
             return System.Math.Min(cityCenterLevel - 5, 5);
-        }
-
-        public static int BaseStorageCapacityPerResource(this BuildingType type)
-        {
-            switch (type)
-            {
-                case BuildingType.CityCenter: return 1200;
-                case BuildingType.Warehouse: return 150;
-                default: return 0;
-            }
-        }
-
-        public static int StorageCapacityPerLevelPerResource(this BuildingType type)
-        {
-            switch (type)
-            {
-                case BuildingType.CityCenter: return 100;
-                case BuildingType.Warehouse: return 75;
-                default: return 0;
-            }
-        }
-
-        public static int StorageCapacityPerResource(this BuildingType type, int level)
-        {
-            return type.BaseStorageCapacityPerResource() + type.StorageCapacityPerLevelPerResource() * (level - 1);
         }
 
         public static int MaxWarehousesAllowed(int cityCenterLevel)

--- a/Sporefront/Assets/Scripts/Models/Combat/CombatState.cs
+++ b/Sporefront/Assets/Scripts/Models/Combat/CombatState.cs
@@ -719,8 +719,7 @@ namespace Sporefront.Models.Combat
                 MergeIntoSideState(defenderState, armyData);
             }
 
-            DebugLog.Log(string.Format("Reinforcements arrived: {0} joined {1} side at time {2:F1}s",
-                armyData.name, isAttacker ? "attacker" : "defender", elapsedTime));
+            DebugLog.Log($"Reinforcements arrived: {armyData.name} joined {(isAttacker ? "attacker" : "defender")} side at time {elapsedTime:F1}s");
         }
 
         /// Merges an ArmyData's units into an aggregated side state

--- a/Sporefront/Assets/Scripts/Models/FactionType.cs
+++ b/Sporefront/Assets/Scripts/Models/FactionType.cs
@@ -9,134 +9,69 @@ namespace Sporefront.Models
         Muscaria
     }
 
+    /// <summary>
+    /// Data-driven faction configuration. All faction properties are stored in a lookup table
+    /// rather than individual switch statements, following the same pattern as BuildingType/MilitaryUnitType.
+    /// </summary>
+    public class FactionTypeData
+    {
+        public string DisplayName;
+        public string Description;
+        public string StartingBonusDescription;
+        public string ResearchRestrictionDescription;
+        public int ArmyVisionBonus;
+        public double WoodGatheringBonus;
+        public int LumberCampReach;
+        public bool HasWoodlandCamouflage;
+        public double StoneGatheringBonus;
+        public double OreGatheringBonus;
+        public bool HasToxicStrikes;
+        public double HighlandSpeedBonus;
+        public double MountainBuildCostReduction;
+        public List<ResearchType> BlockedResearch;
+    }
+
     public static class FactionTypeExtensions
     {
-        public static string DisplayName(this FactionType faction)
+        private static readonly FactionTypeData NoneData = new FactionTypeData
         {
-            switch (faction)
-            {
-                case FactionType.Morel: return "The Morels";
-                case FactionType.Muscaria: return "Amanita Muscaria";
-                default: return "No Faction";
-            }
-        }
+            DisplayName = "No Faction",
+            Description = "",
+            StartingBonusDescription = "",
+            ResearchRestrictionDescription = "No restrictions.",
+            ArmyVisionBonus = 0,
+            WoodGatheringBonus = 0.0,
+            LumberCampReach = 1,
+            HasWoodlandCamouflage = false,
+            StoneGatheringBonus = 0.0,
+            OreGatheringBonus = 0.0,
+            HasToxicStrikes = false,
+            HighlandSpeedBonus = 0.0,
+            MountainBuildCostReduction = 0.0,
+            BlockedResearch = new List<ResearchType>()
+        };
 
-        public static string Description(this FactionType faction)
+        private static readonly Dictionary<FactionType, FactionTypeData> Data = new Dictionary<FactionType, FactionTypeData>
         {
-            switch (faction)
             {
-                case FactionType.Morel:
-                    return "An infantry and woodland stealth faction. The Morels thrive in forested terrain, " +
-                           "using superior vision and camouflage to control the map and strike from ambush.";
-                case FactionType.Muscaria:
-                    return "An aggressive poison and mountain faction. The Amanita Muscaria thrive in highland terrain, " +
-                           "using toxic strikes and mountain mastery to dominate through attrition.";
-                default: return "";
-            }
-        }
-
-        public static string StartingBonusDescription(this FactionType faction)
-        {
-            switch (faction)
-            {
-                case FactionType.Morel:
-                    return "Extended Vision (+1 army sight), Woodland Camouflage, " +
-                           "+5% wood gathering, Extended Lumberyards (2-tile reach)";
-                case FactionType.Muscaria:
-                    return "Toxic Strikes (poison DoT after combat), Mountain Builders (-15% mountain/hill build cost), " +
-                           "Highland Movement (+20% speed on mountain/hill), +5% stone & ore gathering";
-                default: return "";
-            }
-        }
-
-        public static int ArmyVisionBonus(this FactionType faction)
-        {
-            switch (faction)
-            {
-                case FactionType.Morel: return 1;
-                default: return 0;
-            }
-        }
-
-        public static double WoodGatheringBonus(this FactionType faction)
-        {
-            switch (faction)
-            {
-                case FactionType.Morel: return 0.05;
-                default: return 0.0;
-            }
-        }
-
-        public static int LumberCampReach(this FactionType faction)
-        {
-            switch (faction)
-            {
-                case FactionType.Morel: return 2;
-                default: return 1;
-            }
-        }
-
-        public static bool HasWoodlandCamouflage(this FactionType faction)
-        {
-            switch (faction)
-            {
-                case FactionType.Morel: return true;
-                default: return false;
-            }
-        }
-
-        public static double StoneGatheringBonus(this FactionType faction)
-        {
-            switch (faction)
-            {
-                case FactionType.Muscaria: return 0.05;
-                default: return 0.0;
-            }
-        }
-
-        public static double OreGatheringBonus(this FactionType faction)
-        {
-            switch (faction)
-            {
-                case FactionType.Muscaria: return 0.05;
-                default: return 0.0;
-            }
-        }
-
-        public static bool HasToxicStrikes(this FactionType faction)
-        {
-            switch (faction)
-            {
-                case FactionType.Muscaria: return true;
-                default: return false;
-            }
-        }
-
-        public static double HighlandSpeedBonus(this FactionType faction)
-        {
-            switch (faction)
-            {
-                case FactionType.Muscaria: return 0.20;
-                default: return 0.0;
-            }
-        }
-
-        public static double MountainBuildCostReduction(this FactionType faction)
-        {
-            switch (faction)
-            {
-                case FactionType.Muscaria: return 0.15;
-                default: return 0.0;
-            }
-        }
-
-        public static List<ResearchType> BlockedResearch(this FactionType faction)
-        {
-            switch (faction)
-            {
-                case FactionType.Morel:
-                    // Morels blocked from Tier III: Ranged, Cavalry, Stone/Ore
-                    return new List<ResearchType>
+                FactionType.Morel, new FactionTypeData
+                {
+                    DisplayName = "The Morels",
+                    Description = "An infantry and woodland stealth faction. The Morels thrive in forested terrain, " +
+                                  "using superior vision and camouflage to control the map and strike from ambush.",
+                    StartingBonusDescription = "Extended Vision (+1 army sight), Woodland Camouflage, " +
+                                               "+5% wood gathering, Extended Lumberyards (2-tile reach)",
+                    ResearchRestrictionDescription = "Blocked from Tier III: Ranged, Cavalry, Stone, Siege research.",
+                    ArmyVisionBonus = 1,
+                    WoodGatheringBonus = 0.05,
+                    LumberCampReach = 2,
+                    HasWoodlandCamouflage = true,
+                    StoneGatheringBonus = 0.0,
+                    OreGatheringBonus = 0.0,
+                    HasToxicStrikes = false,
+                    HighlandSpeedBonus = 0.0,
+                    MountainBuildCostReduction = 0.0,
+                    BlockedResearch = new List<ResearchType>
                     {
                         // Ranged
                         ResearchType.PiercingDamageIII,
@@ -150,10 +85,28 @@ namespace Sporefront.Models
                         ResearchType.MiningCampGatheringIII,
                         // Siege (ore-heavy)
                         ResearchType.SiegeBludgeonDamageIII
-                    };
-                case FactionType.Muscaria:
-                    // Muscaria blocked from Tier III: Infantry, Cavalry, Wood, Food
-                    return new List<ResearchType>
+                    }
+                }
+            },
+            {
+                FactionType.Muscaria, new FactionTypeData
+                {
+                    DisplayName = "Amanita Muscaria",
+                    Description = "An aggressive poison and mountain faction. The Amanita Muscaria thrive in highland terrain, " +
+                                  "using toxic strikes and mountain mastery to dominate through attrition.",
+                    StartingBonusDescription = "Toxic Strikes (poison DoT after combat), Mountain Builders (-15% mountain/hill build cost), " +
+                                               "Highland Movement (+20% speed on mountain/hill), +5% stone & ore gathering",
+                    ResearchRestrictionDescription = "Blocked from Tier III: Infantry, Cavalry, Wood, Food research.",
+                    ArmyVisionBonus = 0,
+                    WoodGatheringBonus = 0.0,
+                    LumberCampReach = 1,
+                    HasWoodlandCamouflage = false,
+                    StoneGatheringBonus = 0.05,
+                    OreGatheringBonus = 0.05,
+                    HasToxicStrikes = true,
+                    HighlandSpeedBonus = 0.20,
+                    MountainBuildCostReduction = 0.15,
+                    BlockedResearch = new List<ResearchType>
                     {
                         // Infantry
                         ResearchType.InfantryMeleeAttackIII,
@@ -167,23 +120,30 @@ namespace Sporefront.Models
                         ResearchType.LumberCampGatheringIII,
                         // Food
                         ResearchType.FarmGatheringIII
-                    };
-                default:
-                    return new List<ResearchType>();
+                    }
+                }
             }
+        };
+
+        private static FactionTypeData Get(FactionType faction)
+        {
+            return Data.TryGetValue(faction, out var data) ? data : NoneData;
         }
 
-        public static string ResearchRestrictionDescription(this FactionType faction)
-        {
-            switch (faction)
-            {
-                case FactionType.Morel:
-                    return "Blocked from Tier III: Ranged, Cavalry, Stone, Siege research.";
-                case FactionType.Muscaria:
-                    return "Blocked from Tier III: Infantry, Cavalry, Wood, Food research.";
-                default: return "No restrictions.";
-            }
-        }
+        public static string DisplayName(this FactionType faction) => Get(faction).DisplayName;
+        public static string Description(this FactionType faction) => Get(faction).Description;
+        public static string StartingBonusDescription(this FactionType faction) => Get(faction).StartingBonusDescription;
+        public static string ResearchRestrictionDescription(this FactionType faction) => Get(faction).ResearchRestrictionDescription;
+        public static int ArmyVisionBonus(this FactionType faction) => Get(faction).ArmyVisionBonus;
+        public static double WoodGatheringBonus(this FactionType faction) => Get(faction).WoodGatheringBonus;
+        public static int LumberCampReach(this FactionType faction) => Get(faction).LumberCampReach;
+        public static bool HasWoodlandCamouflage(this FactionType faction) => Get(faction).HasWoodlandCamouflage;
+        public static double StoneGatheringBonus(this FactionType faction) => Get(faction).StoneGatheringBonus;
+        public static double OreGatheringBonus(this FactionType faction) => Get(faction).OreGatheringBonus;
+        public static bool HasToxicStrikes(this FactionType faction) => Get(faction).HasToxicStrikes;
+        public static double HighlandSpeedBonus(this FactionType faction) => Get(faction).HighlandSpeedBonus;
+        public static double MountainBuildCostReduction(this FactionType faction) => Get(faction).MountainBuildCostReduction;
+        public static List<ResearchType> BlockedResearch(this FactionType faction) => Get(faction).BlockedResearch;
 
         public static FactionType ExclusiveFaction(this BuildingType buildingType)
         {

--- a/Sporefront/Assets/Scripts/Models/HexCoordinate.cs
+++ b/Sporefront/Assets/Scripts/Models/HexCoordinate.cs
@@ -9,6 +9,13 @@ namespace Sporefront.Models
         public int q; // column
         public int r; // row
 
+        // Static offset tables for odd-r hex grid (zero allocation)
+        // Direction order (clockwise from East): 0=E, 1=SE, 2=SW, 3=W, 4=NW, 5=NE
+        private static readonly int[] EvenDQ = { 1, 0, -1, -1, -1, 0 };
+        private static readonly int[] EvenDR = { 0, 1, 1, 0, -1, -1 };
+        private static readonly int[] OddDQ  = { 1, 1, 0, -1, 0, 1 };
+        private static readonly int[] OddDR  = { 0, 1, 1, 0, -1, -1 };
+
         public HexCoordinate(int q, int r)
         {
             this.q = q;
@@ -31,20 +38,8 @@ namespace Sporefront.Models
 
         public List<HexCoordinate> Neighbors()
         {
-            int[] dq, dr;
-
-            if (r % 2 == 0)
-            {
-                // Even rows
-                dq = new int[] { 1, 0, -1, -1, -1, 0 };
-                dr = new int[] { 0, 1, 1, 0, -1, -1 };
-            }
-            else
-            {
-                // Odd rows (shifted right)
-                dq = new int[] { 1, 1, 0, -1, 0, 1 };
-                dr = new int[] { 0, 1, 1, 0, -1, -1 };
-            }
+            var dq = (r % 2 == 0) ? EvenDQ : OddDQ;
+            var dr = (r % 2 == 0) ? EvenDR : OddDR;
 
             var neighbors = new List<HexCoordinate>(6);
             for (int i = 0; i < 6; i++)
@@ -57,9 +52,10 @@ namespace Sporefront.Models
         /// Direction order (clockwise from East): 0=East, 1=Southeast, 2=Southwest, 3=West, 4=Northwest, 5=Northeast
         public HexCoordinate Neighbor(int direction)
         {
-            var allNeighbors = Neighbors();
             int normalizedDir = ((direction % 6) + 6) % 6;
-            return allNeighbors[normalizedDir];
+            var dq = (r % 2 == 0) ? EvenDQ : OddDQ;
+            var dr = (r % 2 == 0) ? EvenDR : OddDR;
+            return new HexCoordinate(q + dq[normalizedDir], r + dr[normalizedDir]);
         }
 
         public List<HexCoordinate> CoordinatesInRing(int distance)

--- a/Sporefront/Assets/Scripts/Models/MilitaryUnit.cs
+++ b/Sporefront/Assets/Scripts/Models/MilitaryUnit.cs
@@ -159,231 +159,149 @@ namespace Sporefront.Models
     [System.Serializable]
     public class VillagerTrainable : TrainableUnitType
     {
+        private static readonly Dictionary<ResourceType, int> CachedCost =
+            new Dictionary<ResourceType, int> { { ResourceType.Food, 50 } };
+
         public override string DisplayName => "Villager";
         public override string Icon => "villager";
-        public override Dictionary<ResourceType, int> TrainingCost => new Dictionary<ResourceType, int> { { ResourceType.Food, 50 } };
+        public override Dictionary<ResourceType, int> TrainingCost => CachedCost;
         public override double TrainingTime => 15.0;
         public override string Description => "Gathers resources and constructs buildings";
         public override int PopSpace => 1;
     }
 
+    // ================================================================
+    // Data record for MilitaryUnitType lookup table
+    // ================================================================
+
+    public class MilitaryUnitTypeData
+    {
+        public string DisplayName;
+        public string Icon;
+        public double MoveSpeed;
+        public double AttackSpeed;
+        public double HP;
+        public double TrainingTime;
+        public Dictionary<ResourceType, int> TrainingCost;
+        public BuildingType TrainingBuilding;
+        public UnitCategory Category;
+        public int PopSpace;
+        public string Description;
+        public UnitCombatStats CombatStats;
+
+        public MilitaryUnitTypeData(
+            string displayName, string icon,
+            double moveSpeed, double attackSpeed, double hp,
+            double trainingTime, Dictionary<ResourceType, int> trainingCost,
+            BuildingType trainingBuilding, UnitCategory category,
+            string description, UnitCombatStats combatStats,
+            int popSpace = 1)
+        {
+            DisplayName = displayName;
+            Icon = icon;
+            MoveSpeed = moveSpeed;
+            AttackSpeed = attackSpeed;
+            HP = hp;
+            TrainingTime = trainingTime;
+            TrainingCost = trainingCost;
+            TrainingBuilding = trainingBuilding;
+            Category = category;
+            PopSpace = popSpace;
+            Description = description;
+            CombatStats = combatStats;
+        }
+    }
+
+    // ================================================================
+    // Extension methods — data-driven via static lookup table
+    // ================================================================
+
     public static class MilitaryUnitTypeExtensions
     {
-        public static string DisplayName(this MilitaryUnitType type)
+        private static readonly Dictionary<MilitaryUnitType, MilitaryUnitTypeData> Data =
+            new Dictionary<MilitaryUnitType, MilitaryUnitTypeData>
         {
-            switch (type)
-            {
-                case MilitaryUnitType.Swordsman: return "Swordsman";
-                case MilitaryUnitType.Archer: return "Archer";
-                case MilitaryUnitType.Crossbow: return "Crossbow";
-                case MilitaryUnitType.Pikeman: return "Pikeman";
-                case MilitaryUnitType.Scout: return "Scout";
-                case MilitaryUnitType.Knight: return "Knight";
-                case MilitaryUnitType.HeavyCavalry: return "Heavy Cavalry";
-                case MilitaryUnitType.Mangonel: return "Mangonel";
-                case MilitaryUnitType.Trebuchet: return "Trebuchet";
-                default: return type.ToString();
-            }
-        }
+            { MilitaryUnitType.Swordsman, new MilitaryUnitTypeData(
+                "Swordsman", "swordsman", 1.40, 1.0, 50, 15,
+                new Dictionary<ResourceType, int> { { ResourceType.Food, 50 }, { ResourceType.Ore, 25 } },
+                BuildingType.Barracks, UnitCategory.Infantry,
+                "Balanced melee infantry unit with good armor",
+                new UnitCombatStats(meleeDamage: 2, meleeArmor: 2, pierceArmor: 1)) },
 
-        public static string Icon(this MilitaryUnitType type)
-        {
-            switch (type)
-            {
-                case MilitaryUnitType.Swordsman: return "swordsman";
-                case MilitaryUnitType.Pikeman: return "pikeman";
-                case MilitaryUnitType.Archer: return "archer";
-                case MilitaryUnitType.Crossbow: return "crossbow";
-                case MilitaryUnitType.Scout: return "scout";
-                case MilitaryUnitType.Knight: return "knight";
-                case MilitaryUnitType.HeavyCavalry: return "heavy_cavalry";
-                case MilitaryUnitType.Mangonel: return "mangonel";
-                case MilitaryUnitType.Trebuchet: return "trebuchet";
-                default: return "";
-            }
-        }
+            { MilitaryUnitType.Archer, new MilitaryUnitTypeData(
+                "Archer", "archer", 1.40, 1.0, 30, 12,
+                new Dictionary<ResourceType, int> { { ResourceType.Food, 40 }, { ResourceType.Wood, 30 } },
+                BuildingType.ArcheryRange, UnitCategory.Ranged,
+                "Ranged unit with pierce damage",
+                new UnitCombatStats(pierceDamage: 2, pierceArmor: 1)) },
 
-        public static double MoveSpeed(this MilitaryUnitType type)
-        {
-            switch (type)
-            {
-                case MilitaryUnitType.Swordsman: return 1.40;
-                case MilitaryUnitType.Pikeman: return 1.60;
-                case MilitaryUnitType.Archer: return 1.40;
-                case MilitaryUnitType.Crossbow: return 1.52;
-                case MilitaryUnitType.Scout: return 0.88;
-                case MilitaryUnitType.Knight: return 1.00;
-                case MilitaryUnitType.HeavyCavalry: return 1.12;
-                case MilitaryUnitType.Mangonel: return 2.00;
-                case MilitaryUnitType.Trebuchet: return 2.40;
-                default: return 1.40;
-            }
-        }
+            { MilitaryUnitType.Crossbow, new MilitaryUnitTypeData(
+                "Crossbow", "crossbow", 1.52, 1.5, 40, 18,
+                new Dictionary<ResourceType, int> { { ResourceType.Food, 50 }, { ResourceType.Wood, 40 }, { ResourceType.Ore, 20 } },
+                BuildingType.ArcheryRange, UnitCategory.Ranged,
+                "Heavy ranged unit with high pierce damage and armor",
+                new UnitCombatStats(pierceDamage: 2, meleeArmor: 1, pierceArmor: 2)) },
 
-        public static double AttackSpeed(this MilitaryUnitType type)
-        {
-            switch (type)
-            {
-                case MilitaryUnitType.Swordsman: return 1.0;
-                case MilitaryUnitType.Pikeman: return 1.2;
-                case MilitaryUnitType.Archer: return 1.0;
-                case MilitaryUnitType.Crossbow: return 1.5;
-                case MilitaryUnitType.Scout: return 0.7;
-                case MilitaryUnitType.Knight: return 1.1;
-                case MilitaryUnitType.HeavyCavalry: return 1.2;
-                case MilitaryUnitType.Mangonel: return 2.5;
-                case MilitaryUnitType.Trebuchet: return 4.0;
-                default: return 1.0;
-            }
-        }
+            { MilitaryUnitType.Pikeman, new MilitaryUnitTypeData(
+                "Pikeman", "pikeman", 1.60, 1.2, 35, 14,
+                new Dictionary<ResourceType, int> { { ResourceType.Food, 45 }, { ResourceType.Wood, 20 }, { ResourceType.Ore, 15 } },
+                BuildingType.Barracks, UnitCategory.Infantry,
+                "Anti-cavalry infantry with bonus damage vs mounted units",
+                new UnitCombatStats(meleeDamage: 1, meleeArmor: 1, pierceArmor: 1, bludgeonArmor: 3, bonusVsCavalry: 8)) },
 
-        public static double HP(this MilitaryUnitType type)
-        {
-            switch (type)
-            {
-                case MilitaryUnitType.Swordsman: return 50;
-                case MilitaryUnitType.Archer: return 30;
-                case MilitaryUnitType.Crossbow: return 40;
-                case MilitaryUnitType.Pikeman: return 35;
-                case MilitaryUnitType.Scout: return 30;
-                case MilitaryUnitType.Knight: return 60;
-                case MilitaryUnitType.HeavyCavalry: return 80;
-                case MilitaryUnitType.Mangonel: return 70;
-                case MilitaryUnitType.Trebuchet: return 120;
-                default: return 50;
-            }
-        }
+            { MilitaryUnitType.Scout, new MilitaryUnitTypeData(
+                "Scout", "scout", 0.88, 0.7, 30, 18,
+                new Dictionary<ResourceType, int> { { ResourceType.Food, 60 }, { ResourceType.Ore, 20 } },
+                BuildingType.Stable, UnitCategory.Cavalry,
+                "Fast light cavalry for reconnaissance",
+                new UnitCombatStats(meleeDamage: 2, meleeArmor: 1, bonusVsRanged: 1)) },
 
-        public static double TrainingTime(this MilitaryUnitType type)
-        {
-            switch (type)
-            {
-                case MilitaryUnitType.Swordsman: return 15;
-                case MilitaryUnitType.Archer: return 12;
-                case MilitaryUnitType.Crossbow: return 18;
-                case MilitaryUnitType.Pikeman: return 14;
-                case MilitaryUnitType.Scout: return 18;
-                case MilitaryUnitType.Knight: return 25;
-                case MilitaryUnitType.HeavyCavalry: return 35;
-                case MilitaryUnitType.Mangonel: return 45;
-                case MilitaryUnitType.Trebuchet: return 60;
-                default: return 15;
-            }
-        }
+            { MilitaryUnitType.Knight, new MilitaryUnitTypeData(
+                "Knight", "knight", 1.00, 1.1, 60, 25,
+                new Dictionary<ResourceType, int> { { ResourceType.Food, 80 }, { ResourceType.Ore, 60 } },
+                BuildingType.Stable, UnitCategory.Cavalry,
+                "Powerful mounted unit with high melee damage",
+                new UnitCombatStats(meleeDamage: 4, meleeArmor: 2, pierceArmor: 2, bludgeonArmor: 1, bonusVsRanged: 1)) },
 
-        public static Dictionary<ResourceType, int> TrainingCost(this MilitaryUnitType type)
-        {
-            switch (type)
-            {
-                case MilitaryUnitType.Swordsman: return new Dictionary<ResourceType, int> { { ResourceType.Food, 50 }, { ResourceType.Ore, 25 } };
-                case MilitaryUnitType.Archer: return new Dictionary<ResourceType, int> { { ResourceType.Food, 40 }, { ResourceType.Wood, 30 } };
-                case MilitaryUnitType.Crossbow: return new Dictionary<ResourceType, int> { { ResourceType.Food, 50 }, { ResourceType.Wood, 40 }, { ResourceType.Ore, 20 } };
-                case MilitaryUnitType.Pikeman: return new Dictionary<ResourceType, int> { { ResourceType.Food, 45 }, { ResourceType.Wood, 20 }, { ResourceType.Ore, 15 } };
-                case MilitaryUnitType.Scout: return new Dictionary<ResourceType, int> { { ResourceType.Food, 60 }, { ResourceType.Ore, 20 } };
-                case MilitaryUnitType.Knight: return new Dictionary<ResourceType, int> { { ResourceType.Food, 80 }, { ResourceType.Ore, 60 } };
-                case MilitaryUnitType.HeavyCavalry: return new Dictionary<ResourceType, int> { { ResourceType.Food, 100 }, { ResourceType.Ore, 80 } };
-                case MilitaryUnitType.Mangonel: return new Dictionary<ResourceType, int> { { ResourceType.Food, 60 }, { ResourceType.Wood, 100 }, { ResourceType.Ore, 40 } };
-                case MilitaryUnitType.Trebuchet: return new Dictionary<ResourceType, int> { { ResourceType.Food, 80 }, { ResourceType.Wood, 150 }, { ResourceType.Ore, 60 } };
-                default: return new Dictionary<ResourceType, int>();
-            }
-        }
+            { MilitaryUnitType.HeavyCavalry, new MilitaryUnitTypeData(
+                "Heavy Cavalry", "heavy_cavalry", 1.12, 1.2, 80, 35,
+                new Dictionary<ResourceType, int> { { ResourceType.Food, 100 }, { ResourceType.Ore, 80 } },
+                BuildingType.Stable, UnitCategory.Cavalry,
+                "Very heavy mounted unit with devastating charge",
+                new UnitCombatStats(meleeDamage: 5, meleeArmor: 3, pierceArmor: 3, bludgeonArmor: 1, bonusVsRanged: 1)) },
 
-        public static BuildingType TrainingBuilding(this MilitaryUnitType type)
-        {
-            switch (type)
-            {
-                case MilitaryUnitType.Swordsman:
-                case MilitaryUnitType.Pikeman:
-                    return BuildingType.Barracks;
-                case MilitaryUnitType.Archer:
-                case MilitaryUnitType.Crossbow:
-                    return BuildingType.ArcheryRange;
-                case MilitaryUnitType.Scout:
-                case MilitaryUnitType.Knight:
-                case MilitaryUnitType.HeavyCavalry:
-                    return BuildingType.Stable;
-                case MilitaryUnitType.Mangonel:
-                case MilitaryUnitType.Trebuchet:
-                    return BuildingType.SiegeWorkshop;
-                default:
-                    return BuildingType.Barracks;
-            }
-        }
+            { MilitaryUnitType.Mangonel, new MilitaryUnitTypeData(
+                "Mangonel", "mangonel", 2.00, 2.5, 70, 45,
+                new Dictionary<ResourceType, int> { { ResourceType.Food, 60 }, { ResourceType.Wood, 100 }, { ResourceType.Ore, 40 } },
+                BuildingType.SiegeWorkshop, UnitCategory.Siege,
+                "Siege weapon with bludgeon damage, effective vs buildings",
+                new UnitCombatStats(bludgeonDamage: 8, meleeArmor: 2, pierceArmor: 10, bludgeonArmor: 3, bonusVsBuildings: 20),
+                popSpace: 3) },
 
-        public static UnitCategory Category(this MilitaryUnitType type)
-        {
-            switch (type)
-            {
-                case MilitaryUnitType.Swordsman:
-                case MilitaryUnitType.Pikeman:
-                    return UnitCategory.Infantry;
-                case MilitaryUnitType.Archer:
-                case MilitaryUnitType.Crossbow:
-                    return UnitCategory.Ranged;
-                case MilitaryUnitType.Scout:
-                case MilitaryUnitType.Knight:
-                case MilitaryUnitType.HeavyCavalry:
-                    return UnitCategory.Cavalry;
-                case MilitaryUnitType.Mangonel:
-                case MilitaryUnitType.Trebuchet:
-                    return UnitCategory.Siege;
-                default:
-                    return UnitCategory.Infantry;
-            }
-        }
+            { MilitaryUnitType.Trebuchet, new MilitaryUnitTypeData(
+                "Trebuchet", "trebuchet", 2.40, 4.0, 120, 60,
+                new Dictionary<ResourceType, int> { { ResourceType.Food, 80 }, { ResourceType.Wood, 150 }, { ResourceType.Ore, 60 } },
+                BuildingType.SiegeWorkshop, UnitCategory.Siege,
+                "Long-range siege weapon, devastating vs buildings",
+                new UnitCombatStats(bludgeonDamage: 12, meleeArmor: 2, pierceArmor: 15, bludgeonArmor: 4, bonusVsBuildings: 30),
+                popSpace: 5) },
+        };
 
-        public static int PopSpace(this MilitaryUnitType type)
-        {
-            switch (type)
-            {
-                case MilitaryUnitType.Mangonel: return 3;
-                case MilitaryUnitType.Trebuchet: return 5;
-                default: return 1;
-            }
-        }
+        // ================================================================
+        // One-liner data lookups
+        // ================================================================
 
-        public static string Description(this MilitaryUnitType type)
-        {
-            switch (type)
-            {
-                case MilitaryUnitType.Swordsman: return "Balanced melee infantry unit with good armor";
-                case MilitaryUnitType.Pikeman: return "Anti-cavalry infantry with bonus damage vs mounted units";
-                case MilitaryUnitType.Archer: return "Ranged unit with pierce damage";
-                case MilitaryUnitType.Crossbow: return "Heavy ranged unit with high pierce damage and armor";
-                case MilitaryUnitType.Scout: return "Fast light cavalry for reconnaissance";
-                case MilitaryUnitType.Knight: return "Powerful mounted unit with high melee damage";
-                case MilitaryUnitType.HeavyCavalry: return "Very heavy mounted unit with devastating charge";
-                case MilitaryUnitType.Mangonel: return "Siege weapon with bludgeon damage, effective vs buildings";
-                case MilitaryUnitType.Trebuchet: return "Long-range siege weapon, devastating vs buildings";
-                default: return "";
-            }
-        }
-
-        public static UnitCombatStats CombatStats(this MilitaryUnitType type)
-        {
-            switch (type)
-            {
-                case MilitaryUnitType.Swordsman:
-                    return new UnitCombatStats(meleeDamage: 2, meleeArmor: 2, pierceArmor: 1);
-                case MilitaryUnitType.Archer:
-                    return new UnitCombatStats(pierceDamage: 2, pierceArmor: 1);
-                case MilitaryUnitType.Crossbow:
-                    return new UnitCombatStats(pierceDamage: 2, meleeArmor: 1, pierceArmor: 2);
-                case MilitaryUnitType.Pikeman:
-                    return new UnitCombatStats(meleeDamage: 1, meleeArmor: 1, pierceArmor: 1, bludgeonArmor: 3, bonusVsCavalry: 8);
-                case MilitaryUnitType.Scout:
-                    return new UnitCombatStats(meleeDamage: 2, meleeArmor: 1, bonusVsRanged: 1);
-                case MilitaryUnitType.Knight:
-                    return new UnitCombatStats(meleeDamage: 4, meleeArmor: 2, pierceArmor: 2, bludgeonArmor: 1, bonusVsRanged: 1);
-                case MilitaryUnitType.HeavyCavalry:
-                    return new UnitCombatStats(meleeDamage: 5, meleeArmor: 3, pierceArmor: 3, bludgeonArmor: 1, bonusVsRanged: 1);
-                case MilitaryUnitType.Mangonel:
-                    return new UnitCombatStats(bludgeonDamage: 8, meleeArmor: 2, pierceArmor: 10, bludgeonArmor: 3, bonusVsBuildings: 20);
-                case MilitaryUnitType.Trebuchet:
-                    return new UnitCombatStats(bludgeonDamage: 12, meleeArmor: 2, pierceArmor: 15, bludgeonArmor: 4, bonusVsBuildings: 30);
-                default:
-                    return new UnitCombatStats();
-            }
-        }
+        public static string DisplayName(this MilitaryUnitType type) => Data[type].DisplayName;
+        public static string Icon(this MilitaryUnitType type) => Data[type].Icon;
+        public static double MoveSpeed(this MilitaryUnitType type) => Data[type].MoveSpeed;
+        public static double AttackSpeed(this MilitaryUnitType type) => Data[type].AttackSpeed;
+        public static double HP(this MilitaryUnitType type) => Data[type].HP;
+        public static double TrainingTime(this MilitaryUnitType type) => Data[type].TrainingTime;
+        public static Dictionary<ResourceType, int> TrainingCost(this MilitaryUnitType type) => Data[type].TrainingCost;
+        public static BuildingType TrainingBuilding(this MilitaryUnitType type) => Data[type].TrainingBuilding;
+        public static UnitCategory Category(this MilitaryUnitType type) => Data[type].Category;
+        public static int PopSpace(this MilitaryUnitType type) => Data[type].PopSpace;
+        public static string Description(this MilitaryUnitType type) => Data[type].Description;
+        public static UnitCombatStats CombatStats(this MilitaryUnitType type) => Data[type].CombatStats;
     }
 }

--- a/Sporefront/Assets/Scripts/Visual/AboutPanel.cs
+++ b/Sporefront/Assets/Scripts/Visual/AboutPanel.cs
@@ -10,7 +10,7 @@ using UnityEngine.UI;
 
 namespace Sporefront.Visual
 {
-    public class AboutPanel : MonoBehaviour
+    public class AboutPanel : SporefrontPanel
     {
         // ================================================================
         // Events
@@ -22,7 +22,6 @@ namespace Sporefront.Visual
         // State
         // ================================================================
 
-        private GameObject backdrop;
         private GameObject panel;
 
         // ================================================================
@@ -54,17 +53,10 @@ namespace Sporefront.Visual
         // Public API
         // ================================================================
 
-        public void Show()
+        public override void Show()
         {
             backdrop.SetActive(true);
         }
-
-        public void Hide()
-        {
-            backdrop.SetActive(false);
-        }
-
-        public bool IsVisible => backdrop != null && backdrop.activeSelf;
 
         // ================================================================
         // Build Content

--- a/Sporefront/Assets/Scripts/Visual/AccountPanel.cs
+++ b/Sporefront/Assets/Scripts/Visual/AccountPanel.cs
@@ -13,7 +13,7 @@ using Sporefront.Engine;
 
 namespace Sporefront.Visual
 {
-    public class AccountPanel : MonoBehaviour
+    public class AccountPanel : SporefrontPanel
     {
         // ================================================================
         // Events
@@ -27,9 +27,7 @@ namespace Sporefront.Visual
         // State
         // ================================================================
 
-        private GameObject backdrop;
         private GameObject panel;
-        private RectTransform contentRT;
 
         // Inline editing state
         private bool isChangingName;
@@ -113,7 +111,7 @@ namespace Sporefront.Visual
         // Public API
         // ================================================================
 
-        public void Show()
+        public override void Show()
         {
             isChangingName = false;
             isChangingPassword = false;
@@ -122,13 +120,11 @@ namespace Sporefront.Visual
             backdrop.SetActive(true);
         }
 
-        public void Hide()
+        public override void Hide()
         {
             backdrop.SetActive(false);
             OnClose?.Invoke();
         }
-
-        public bool IsVisible => backdrop != null && backdrop.activeSelf;
 
         // ================================================================
         // Update — name availability debounce

--- a/Sporefront/Assets/Scripts/Visual/ArenaResultsPanel.cs
+++ b/Sporefront/Assets/Scripts/Visual/ArenaResultsPanel.cs
@@ -15,7 +15,7 @@ using Sporefront.Models;
 
 namespace Sporefront.Visual
 {
-    public class ArenaResultsPanel : MonoBehaviour
+    public class ArenaResultsPanel : SporefrontPanel
     {
         // ================================================================
         // Events
@@ -28,7 +28,6 @@ namespace Sporefront.Visual
         // ================================================================
 
         private GameObject panel;
-        private RectTransform contentRT;
 
         // Winner colors
         private static readonly Color AttackerWinColor = new Color(0.2f, 0.8f, 0.3f, 1.0f);
@@ -108,18 +107,18 @@ namespace Sporefront.Visual
             panel.SetActive(true);
         }
 
-        public void Hide()
+        public override void Hide()
         {
             panel.SetActive(false);
         }
 
-        public bool IsVisible => panel != null && panel.activeSelf;
+        public new bool IsVisible => panel != null && panel.activeSelf;
 
         // ================================================================
         // Clear Content
         // ================================================================
 
-        private void ClearContent()
+        private new void ClearContent()
         {
             if (contentRT == null) return;
             for (int i = contentRT.childCount - 1; i >= 0; i--)
@@ -149,7 +148,7 @@ namespace Sporefront.Visual
             GetWinnerDisplay(result.winner, out winnerText, out winnerColor);
 
             AddCenteredLabel(winnerText, 22, winnerColor, true);
-            AddCenteredLabel(string.Format("Duration: {0:F1}s", result.combatDuration),
+            AddCenteredLabel($"Duration: {result.combatDuration:F1}s",
                 14, UIHelper.InkMutedText, false);
             AddSpacer(10);
 
@@ -175,7 +174,7 @@ namespace Sporefront.Visual
         private void BuildBatchView(List<SimulationResult> results)
         {
             int total = results.Count;
-            AddTitle(string.Format("SIMULATION RESULTS ({0} runs)", total));
+            AddTitle($"SIMULATION RESULTS ({total} runs)");
 
             int attackerWins = results.Count(r => r.winner == SimWinner.Attacker);
             int defenderWins = results.Count(r => r.winner == SimWinner.Defender);
@@ -192,12 +191,12 @@ namespace Sporefront.Visual
             AddSectionHeader("AVERAGES", UIHelper.InkHeaderText);
 
             double avgDuration = results.Sum(r => r.combatDuration) / total;
-            AddInfoLabel(string.Format("Avg Duration: {0:F1}s", avgDuration));
+            AddInfoLabel($"Avg Duration: {avgDuration:F1}s");
 
             int avgAttackerCas = results.Sum(r => r.attackerCasualties.Values.Sum()) / total;
             int avgDefenderCas = results.Sum(r => r.defenderCasualties.Values.Sum()) / total;
-            AddInfoLabel(string.Format("Avg Attacker Casualties: {0}", avgAttackerCas));
-            AddInfoLabel(string.Format("Avg Defender Casualties: {0}", avgDefenderCas));
+            AddInfoLabel($"Avg Attacker Casualties: {avgAttackerCas}");
+            AddInfoLabel($"Avg Defender Casualties: {avgDefenderCas}");
             AddSpacer(10);
 
             // Modifiers
@@ -228,7 +227,7 @@ namespace Sporefront.Visual
                         break;
                 }
 
-                string text = string.Format("Run {0}: {1} - {2:F1}s", i + 1, winnerStr, result.combatDuration);
+                string text = $"Run {i + 1}: {winnerStr} - {result.combatDuration:F1}s";
                 var label = UIHelper.CreateLabel(contentRT, "  " + text, UIConstants.FontCaption, color, TextAnchor.MiddleLeft);
                 var le = label.gameObject.AddComponent<LayoutElement>();
                 le.preferredHeight = 22;
@@ -252,7 +251,7 @@ namespace Sporefront.Visual
                     remaining.TryGetValue(kvp.Key, out finalCount);
                 int killed = kvp.Value - finalCount;
 
-                string text = string.Format("  {0}:  {1} -> {2}  ({3} killed)", kvp.Key, kvp.Value, finalCount, killed);
+                string text = $"  {kvp.Key}:  {kvp.Value} -> {finalCount}  ({killed} killed)";
                 var label = UIHelper.CreateLabel(contentRT, text, 13, UIHelper.InkBodyText, TextAnchor.MiddleLeft);
                 var le = label.gameObject.AddComponent<LayoutElement>();
                 le.preferredHeight = 22;
@@ -261,7 +260,7 @@ namespace Sporefront.Visual
             int totalInitial = initial.Values.Sum();
             int totalFinal = remaining != null ? remaining.Values.Sum() : 0;
             var totalLabel = UIHelper.CreateLabel(contentRT,
-                string.Format("  Total: {0} -> {1}", totalInitial, totalFinal),
+                $"  Total: {totalInitial} -> {totalFinal}",
                 13, UIHelper.InkHeaderText, TextAnchor.MiddleLeft);
             totalLabel.fontStyle = FontStyle.Bold;
             var totalLE = totalLabel.gameObject.AddComponent<LayoutElement>();
@@ -298,7 +297,7 @@ namespace Sporefront.Visual
             barFillRT.offsetMax = Vector2.zero;
 
             // Count label
-            string countText = string.Format("{0}/{1} ({2}%)", count, total, (int)(pct * 100));
+            string countText = $"{count}/{total} ({(int)(pct * 100)}%)";
             var countLabel = UIHelper.CreateLabel(row.transform, countText,
                 UIConstants.FontCaption, UIHelper.InkMutedText, TextAnchor.MiddleRight);
             var countLE = countLabel.gameObject.AddComponent<LayoutElement>();
@@ -317,29 +316,25 @@ namespace Sporefront.Visual
 
             // Terrain
             string terrainName = scenarioConfig.enemyTerrain.ToString();
-            AddInfoLabel(string.Format("Terrain: {0}", terrainName));
+            AddInfoLabel($"Terrain: {terrainName}");
 
             // Entrenchment
             if (scenarioConfig.enemyEntrenched)
                 AddInfoLabel("Entrenchment: +10% def");
 
             // Player Commander
-            string playerCmdr = string.Format("Player Cmdr: {0} Lv{1}",
-                scenarioConfig.playerCommanderSpecialty.ToString(),
-                scenarioConfig.playerCommanderLevel);
+            string playerCmdr = $"Player Cmdr: {scenarioConfig.playerCommanderSpecialty.ToString()} Lv{scenarioConfig.playerCommanderLevel}";
             AddInfoLabel(playerCmdr);
 
             // Enemy Commander
-            string enemyCmdr = string.Format("Enemy Cmdr: {0} Lv{1}",
-                scenarioConfig.enemyCommanderSpecialty.ToString(),
-                scenarioConfig.enemyCommanderLevel);
+            string enemyCmdr = $"Enemy Cmdr: {scenarioConfig.enemyCommanderSpecialty.ToString()} Lv{scenarioConfig.enemyCommanderLevel}";
             AddInfoLabel(enemyCmdr);
 
             // Enemy unit tiers
             if (scenarioConfig.enemyUnitTiers != null && scenarioConfig.enemyUnitTiers.Count > 0)
             {
                 var tierParts = scenarioConfig.enemyUnitTiers
-                    .Select(kvp => string.Format("{0}:T{1}", kvp.Key, kvp.Value));
+                    .Select(kvp => $"{kvp.Key}:T{kvp.Value}");
                 AddInfoLabel("Enemy Tiers: " + string.Join(", ", tierParts));
             }
 
@@ -347,24 +342,23 @@ namespace Sporefront.Visual
             if (scenarioConfig.playerUnitTiers != null && scenarioConfig.playerUnitTiers.Count > 0)
             {
                 var tierParts = scenarioConfig.playerUnitTiers
-                    .Select(kvp => string.Format("{0}:T{1}", kvp.Key, kvp.Value));
+                    .Select(kvp => $"{kvp.Key}:T{kvp.Value}");
                 AddInfoLabel("Player Tiers: " + string.Join(", ", tierParts));
             }
 
             // Building
             if (scenarioConfig.enemyBuilding.HasValue)
-                AddInfoLabel(string.Format("Building: {0}", scenarioConfig.enemyBuilding.Value));
+                AddInfoLabel($"Building: {scenarioConfig.enemyBuilding.Value}");
 
             // Garrison
             if (scenarioConfig.garrisonArchers > 0)
-                AddInfoLabel(string.Format("Garrison: {0} archers", scenarioConfig.garrisonArchers));
+                AddInfoLabel($"Garrison: {scenarioConfig.garrisonArchers} archers");
 
             // Stacking
             if (Math.Abs(scenarioConfig.enemyArmyCount) >= 2)
             {
                 string stackType = scenarioConfig.enemyArmyCount > 0 ? "Same tile" : "Adjacent";
-                AddInfoLabel(string.Format("Stacking: {0} ({1} armies)",
-                    stackType, Math.Abs(scenarioConfig.enemyArmyCount)));
+                AddInfoLabel($"Stacking: {stackType} ({Math.Abs(scenarioConfig.enemyArmyCount)} armies)");
             }
         }
 

--- a/Sporefront/Assets/Scripts/Visual/ArmyDetailPanel.cs
+++ b/Sporefront/Assets/Scripts/Visual/ArmyDetailPanel.cs
@@ -14,7 +14,7 @@ using Sporefront.Commands;
 
 namespace Sporefront.Visual
 {
-    public class ArmyDetailPanel : MonoBehaviour
+    public class ArmyDetailPanel : SporefrontPanel
     {
         // ================================================================
         // Events
@@ -28,14 +28,7 @@ namespace Sporefront.Visual
         // ================================================================
 
         private GameObject panel;
-        private GameObject backdrop;
-        private RectTransform contentRT;
         private Guid? currentArmyID;
-        private Guid localPlayerID;
-
-        // Fade animation
-        private CanvasGroup backdropCG;
-        private Coroutine fadeCoroutine;
 
         // Cached references for incremental updates
         private Image staminaFillImage;
@@ -96,11 +89,6 @@ namespace Sporefront.Visual
             backdrop.SetActive(false);
         }
 
-        public void UpdateLocalPlayerID(Guid playerID)
-        {
-            localPlayerID = playerID;
-        }
-
         // ================================================================
         // Public API
         // ================================================================
@@ -109,16 +97,14 @@ namespace Sporefront.Visual
         {
             currentArmyID = armyID;
             Rebuild(gameState);
-            if (fadeCoroutine != null) StopCoroutine(fadeCoroutine);
             backdrop.SetActive(true);
-            fadeCoroutine = StartCoroutine(UIHelper.FadeIn(backdropCG));
+            FadeIn();
         }
 
         public void Close()
         {
             currentArmyID = null;
-            if (fadeCoroutine != null) StopCoroutine(fadeCoroutine);
-            fadeCoroutine = StartCoroutine(UIHelper.FadeOut(backdropCG));
+            FadeOut();
         }
 
         public void Refresh(GameState gameState)
@@ -135,8 +121,6 @@ namespace Sporefront.Visual
             }
             Rebuild(gameState);
         }
-
-        public bool IsVisible => backdrop != null && backdrop.activeSelf;
 
         // ================================================================
         // Fingerprint & Incremental Update

--- a/Sporefront/Assets/Scripts/Visual/AuthPanel.cs
+++ b/Sporefront/Assets/Scripts/Visual/AuthPanel.cs
@@ -13,7 +13,7 @@ using Sporefront.Engine;
 
 namespace Sporefront.Visual
 {
-    public class AuthPanel : MonoBehaviour
+    public class AuthPanel : SporefrontPanel
     {
         // ================================================================
         // Events
@@ -69,7 +69,7 @@ namespace Sporefront.Visual
         // Public API
         // ================================================================
 
-        public void Show()
+        public override void Show()
         {
             isRegisterMode = false;
             isProcessing = false;
@@ -78,12 +78,12 @@ namespace Sporefront.Visual
             panel.SetActive(true);
         }
 
-        public void Hide()
+        public override void Hide()
         {
             panel.SetActive(false);
         }
 
-        public bool IsVisible => panel != null && panel.activeSelf;
+        public new bool IsVisible => panel != null && panel.activeSelf;
 
         // ================================================================
         // Build Content

--- a/Sporefront/Assets/Scripts/Visual/BuildVillagerSelectPanel.cs
+++ b/Sporefront/Assets/Scripts/Visual/BuildVillagerSelectPanel.cs
@@ -16,7 +16,7 @@ using Sporefront.Models;
 
 namespace Sporefront.Visual
 {
-    public class BuildVillagerSelectPanel : MonoBehaviour
+    public class BuildVillagerSelectPanel : SporefrontPanel
     {
         // ================================================================
         // Events
@@ -32,11 +32,8 @@ namespace Sporefront.Visual
         // State
         // ================================================================
 
-        private GameObject backdrop;
         private GameObject modalPanel;
-        private RectTransform contentRT;
         private Text infoLabel;
-        private Guid localPlayerID;
 
         private BuildingType pendingBuildingType;
         private HexCoordinate pendingCoordinate;
@@ -113,11 +110,6 @@ namespace Sporefront.Visual
             backdrop.SetActive(false);
         }
 
-        public void UpdateLocalPlayerID(Guid playerID)
-        {
-            localPlayerID = playerID;
-        }
-
         // ================================================================
         // Public API
         // ================================================================
@@ -132,7 +124,7 @@ namespace Sporefront.Visual
             backdrop.SetActive(true);
         }
 
-        public void Hide()
+        public override void Hide()
         {
             ClearPreview();
             backdrop.SetActive(false);
@@ -144,8 +136,6 @@ namespace Sporefront.Visual
             if (!backdrop.activeSelf) return;
             Rebuild(gameState);
         }
-
-        public bool IsVisible => backdrop != null && backdrop.activeSelf;
 
         // ================================================================
         // Back Navigation
@@ -201,8 +191,8 @@ namespace Sporefront.Visual
             var sectionLE = sectionLabel.gameObject.AddComponent<LayoutElement>();
             sectionLE.preferredHeight = 28;
 
-            var groups = gameState.GetVillagerGroupsForPlayer(localPlayerID);
-            if (groups == null || groups.Count == 0)
+            var groups = new List<VillagerGroupData>(gameState.GetVillagerGroupsForPlayer(localPlayerID));
+            if (groups.Count == 0)
             {
                 var emptyLabel = UIHelper.CreateLabel(contentRT,
                     "  No villager groups available", UIConstants.FontSmall, UIHelper.InkMutedText);

--- a/Sporefront/Assets/Scripts/Visual/BuildingDetailPanel.cs
+++ b/Sporefront/Assets/Scripts/Visual/BuildingDetailPanel.cs
@@ -15,7 +15,7 @@ using Sporefront.Commands;
 
 namespace Sporefront.Visual
 {
-    public class BuildingDetailPanel : MonoBehaviour
+    public class BuildingDetailPanel : SporefrontPanel
     {
         // ================================================================
         // Events
@@ -31,10 +31,7 @@ namespace Sporefront.Visual
         // ================================================================
 
         private GameObject panel;
-        private GameObject backdrop;
-        private RectTransform contentRT;
         private Guid? currentBuildingID;
-        private Guid localPlayerID;
 
         // Cached references for incremental refresh
         private Image hpFill;
@@ -45,10 +42,6 @@ namespace Sporefront.Visual
         // Extracted section state
         private BuildingTrainingSection.State trainingState;
         private BuildingMarketSection.State marketState;
-
-        // Fade animation
-        private CanvasGroup backdropCG;
-        private Coroutine fadeCoroutine;
 
         // Structural fingerprint — only full-rebuild when these change
         private BuildingState cachedState;
@@ -107,11 +100,6 @@ namespace Sporefront.Visual
             backdrop.SetActive(false);
         }
 
-        public void UpdateLocalPlayerID(Guid playerID)
-        {
-            localPlayerID = playerID;
-        }
-
         // ================================================================
         // Public API
         // ================================================================
@@ -121,9 +109,8 @@ namespace Sporefront.Visual
             currentBuildingID = buildingID;
             hasCachedFingerprint = false;
             Rebuild(gameState);
-            if (fadeCoroutine != null) StopCoroutine(fadeCoroutine);
             backdrop.SetActive(true);
-            fadeCoroutine = StartCoroutine(UIHelper.FadeIn(backdropCG));
+            FadeIn();
         }
 
         public void Close()
@@ -132,8 +119,7 @@ namespace Sporefront.Visual
             hasCachedFingerprint = false;
             constructionProgressFill = null;
             upgradeProgressFill = null;
-            if (fadeCoroutine != null) StopCoroutine(fadeCoroutine);
-            fadeCoroutine = StartCoroutine(UIHelper.FadeOut(backdropCG));
+            FadeOut();
         }
 
         public void Refresh(GameState gameState)
@@ -277,7 +263,6 @@ namespace Sporefront.Visual
             return (constructionProgressFill, upgradeProgressFill);
         }
 
-        public bool IsVisible => backdrop != null && backdrop.activeSelf;
         public Guid? CurrentBuildingID => currentBuildingID;
 
         // ================================================================

--- a/Sporefront/Assets/Scripts/Visual/BuildingsOverviewPanel.cs
+++ b/Sporefront/Assets/Scripts/Visual/BuildingsOverviewPanel.cs
@@ -15,7 +15,7 @@ using Sporefront.Models;
 
 namespace Sporefront.Visual
 {
-    public class BuildingsOverviewPanel : MonoBehaviour
+    public class BuildingsOverviewPanel : SporefrontPanel
     {
         // ================================================================
         // Events
@@ -28,14 +28,7 @@ namespace Sporefront.Visual
         // State
         // ================================================================
 
-        private GameObject backdrop;
         private GameObject panel;
-        private RectTransform contentRT;
-        private Guid localPlayerID;
-
-        // Fade animation
-        private CanvasGroup backdropCG;
-        private Coroutine fadeCoroutine;
 
         // Filter
         private enum FilterMode { All, Economic, Military }
@@ -128,11 +121,6 @@ namespace Sporefront.Visual
             backdrop.SetActive(false);
         }
 
-        public void UpdateLocalPlayerID(Guid playerID)
-        {
-            localPlayerID = playerID;
-        }
-
         // ================================================================
         // Public API
         // ================================================================
@@ -143,16 +131,14 @@ namespace Sporefront.Visual
             lastRebuildTime = Time.unscaledTime;
             isDirty = false;
             Rebuild(gameState);
-            if (fadeCoroutine != null) StopCoroutine(fadeCoroutine);
             backdrop.SetActive(true);
-            fadeCoroutine = StartCoroutine(UIHelper.FadeIn(backdropCG));
+            FadeIn();
         }
 
-        public void Hide()
+        public override void Hide()
         {
             OnClose?.Invoke();
-            if (fadeCoroutine != null) StopCoroutine(fadeCoroutine);
-            fadeCoroutine = StartCoroutine(UIHelper.FadeOut(backdropCG));
+            FadeOut();
         }
 
         public void Refresh(GameState gameState)
@@ -161,8 +147,6 @@ namespace Sporefront.Visual
             cachedGameState = gameState;
             isDirty = true;
         }
-
-        public bool IsVisible => backdrop != null && backdrop.activeSelf;
 
         private void Update()
         {

--- a/Sporefront/Assets/Scripts/Visual/CombatDetailPanel.cs
+++ b/Sporefront/Assets/Scripts/Visual/CombatDetailPanel.cs
@@ -17,7 +17,7 @@ using Sporefront.Models.Combat;
 
 namespace Sporefront.Visual
 {
-    public class CombatDetailPanel : MonoBehaviour
+    public class CombatDetailPanel : SporefrontPanel
     {
         // ================================================================
         // Events
@@ -29,10 +29,7 @@ namespace Sporefront.Visual
         // State
         // ================================================================
 
-        private GameObject backdrop;
         private GameObject panel;
-        private RectTransform contentRT;
-        private Guid localPlayerID;
 
         // ================================================================
         // Initialization
@@ -76,11 +73,6 @@ namespace Sporefront.Visual
             backdrop.SetActive(false);
         }
 
-        public void UpdateLocalPlayerID(Guid playerID)
-        {
-            localPlayerID = playerID;
-        }
-
         // ================================================================
         // Public API
         // ================================================================
@@ -107,7 +99,7 @@ namespace Sporefront.Visual
             backdrop.SetActive(true);
         }
 
-        public void Hide()
+        public override void Hide()
         {
             backdrop.SetActive(false);
             OnClose?.Invoke();
@@ -118,8 +110,6 @@ namespace Sporefront.Visual
             if (!backdrop.activeSelf) return;
             Rebuild(record);
         }
-
-        public bool IsVisible => backdrop != null && backdrop.activeSelf;
 
         // ================================================================
         // Rebuild from DetailedCombatRecord

--- a/Sporefront/Assets/Scripts/Visual/CombatHistoryPanel.cs
+++ b/Sporefront/Assets/Scripts/Visual/CombatHistoryPanel.cs
@@ -16,7 +16,7 @@ using Sporefront.Models.Combat;
 
 namespace Sporefront.Visual
 {
-    public class CombatHistoryPanel : MonoBehaviour
+    public class CombatHistoryPanel : SporefrontPanel
     {
         // ================================================================
         // Events
@@ -30,10 +30,7 @@ namespace Sporefront.Visual
         // State
         // ================================================================
 
-        private GameObject backdrop;
         private GameObject panel;
-        private RectTransform contentRT;
-        private Guid localPlayerID;
 
         // ================================================================
         // Initialization
@@ -89,11 +86,6 @@ namespace Sporefront.Visual
             backdrop.SetActive(false);
         }
 
-        public void UpdateLocalPlayerID(Guid playerID)
-        {
-            localPlayerID = playerID;
-        }
-
         // ================================================================
         // Public API
         // ================================================================
@@ -104,7 +96,7 @@ namespace Sporefront.Visual
             backdrop.SetActive(true);
         }
 
-        public void Hide()
+        public override void Hide()
         {
             backdrop.SetActive(false);
             OnClose?.Invoke();
@@ -115,8 +107,6 @@ namespace Sporefront.Visual
             if (!backdrop.activeSelf) return;
             Rebuild(gameState);
         }
-
-        public bool IsVisible => backdrop != null && backdrop.activeSelf;
 
         // ================================================================
         // Rebuild

--- a/Sporefront/Assets/Scripts/Visual/CommanderPanel.cs
+++ b/Sporefront/Assets/Scripts/Visual/CommanderPanel.cs
@@ -16,7 +16,7 @@ using Sporefront.Commands;
 
 namespace Sporefront.Visual
 {
-    public class CommanderPanel : MonoBehaviour
+    public class CommanderPanel : SporefrontPanel
     {
         // ================================================================
         // Events
@@ -30,11 +30,9 @@ namespace Sporefront.Visual
         // State
         // ================================================================
 
-        private GameObject backdrop;
         private GameObject panel;
         private RectTransform listContentRT;
         private RectTransform detailContentRT;
-        private Guid localPlayerID;
         private Guid? selectedCommanderID;
         private bool isRecruitFlowActive;
         private GameState cachedGameState;
@@ -116,11 +114,6 @@ namespace Sporefront.Visual
             backdrop.SetActive(false);
         }
 
-        public void UpdateLocalPlayerID(Guid playerID)
-        {
-            localPlayerID = playerID;
-        }
-
         // ================================================================
         // Public API
         // ================================================================
@@ -132,7 +125,7 @@ namespace Sporefront.Visual
             backdrop.SetActive(true);
         }
 
-        public void Hide()
+        public override void Hide()
         {
             backdrop.SetActive(false);
             OnClose?.Invoke();
@@ -143,8 +136,6 @@ namespace Sporefront.Visual
             if (!backdrop.activeSelf) return;
             Rebuild(gameState);
         }
-
-        public bool IsVisible => backdrop != null && backdrop.activeSelf;
 
         // ================================================================
         // Rebuild

--- a/Sporefront/Assets/Scripts/Visual/DisplayNamePanel.cs
+++ b/Sporefront/Assets/Scripts/Visual/DisplayNamePanel.cs
@@ -12,7 +12,7 @@ using Sporefront.Engine;
 
 namespace Sporefront.Visual
 {
-    public class DisplayNamePanel : MonoBehaviour
+    public class DisplayNamePanel : SporefrontPanel
     {
         // ================================================================
         // Events
@@ -63,7 +63,7 @@ namespace Sporefront.Visual
         // Public API
         // ================================================================
 
-        public void Show()
+        public override void Show()
         {
             isClaiming = false;
             isAvailable = false;
@@ -76,12 +76,12 @@ namespace Sporefront.Visual
             panel.SetActive(true);
         }
 
-        public void Hide()
+        public override void Hide()
         {
             panel.SetActive(false);
         }
 
-        public bool IsVisible => panel != null && panel.activeSelf;
+        public new bool IsVisible => panel != null && panel.activeSelf;
 
         // ================================================================
         // Update — debounced availability check

--- a/Sporefront/Assets/Scripts/Visual/EntitiesOverviewPanel.cs
+++ b/Sporefront/Assets/Scripts/Visual/EntitiesOverviewPanel.cs
@@ -15,7 +15,7 @@ using Sporefront.Models;
 
 namespace Sporefront.Visual
 {
-    public class EntitiesOverviewPanel : MonoBehaviour
+    public class EntitiesOverviewPanel : SporefrontPanel
     {
         // ================================================================
         // Events
@@ -29,10 +29,7 @@ namespace Sporefront.Visual
         // State
         // ================================================================
 
-        private GameObject backdrop;
         private GameObject panel;
-        private RectTransform contentRT;
-        private Guid localPlayerID;
 
         // Filter
         private enum FilterMode { All, Villagers, Armies }
@@ -128,11 +125,6 @@ namespace Sporefront.Visual
             backdrop.SetActive(false);
         }
 
-        public void UpdateLocalPlayerID(Guid playerID)
-        {
-            localPlayerID = playerID;
-        }
-
         // ================================================================
         // Public API
         // ================================================================
@@ -146,7 +138,7 @@ namespace Sporefront.Visual
             backdrop.SetActive(true);
         }
 
-        public void Hide()
+        public override void Hide()
         {
             backdrop.SetActive(false);
             OnClose?.Invoke();
@@ -158,8 +150,6 @@ namespace Sporefront.Visual
             cachedGameState = gameState;
             isDirty = true;
         }
-
-        public bool IsVisible => backdrop != null && backdrop.activeSelf;
 
         private void Update()
         {

--- a/Sporefront/Assets/Scripts/Visual/EntityRenderer.cs
+++ b/Sporefront/Assets/Scripts/Visual/EntityRenderer.cs
@@ -59,6 +59,24 @@ namespace Sporefront.Visual
         private Dictionary<Guid, EntityRenderState> desiredStates = new Dictionary<Guid, EntityRenderState>();
         private List<Guid> toRemove = new List<Guid>();
 
+        // List pool: avoids allocating new List<EntityPlacement> per tile per frame
+        private Stack<List<EntityPlacement>> listPool = new Stack<List<EntityPlacement>>();
+
+        private List<EntityPlacement> RentList()
+        {
+            return listPool.Count > 0 ? listPool.Pop() : new List<EntityPlacement>();
+        }
+
+        private void ReturnAllLists()
+        {
+            foreach (var list in entitiesPerTile.Values)
+            {
+                list.Clear();
+                listPool.Push(list);
+            }
+            entitiesPerTile.Clear();
+        }
+
         // Movement interpolation state
         private Dictionary<Guid, MovementInterpolationState> movementStates =
             new Dictionary<Guid, MovementInterpolationState>();
@@ -68,6 +86,7 @@ namespace Sporefront.Visual
 
         // Building progress/HP bar state
         private Dictionary<Guid, BuildingBarVisuals> buildingBars = new Dictionary<Guid, BuildingBarVisuals>();
+        private readonly List<Guid> barKeyBuffer = new List<Guid>();
 
         // Fog of war filtering
         private Guid fogLocalPlayerID;
@@ -273,8 +292,8 @@ namespace Sporefront.Visual
 
         private void ComputeDesiredStates(GameState gameState)
         {
-            // Clear reusable collections
-            entitiesPerTile.Clear();
+            // Return pooled lists, then clear
+            ReturnAllLists();
             desiredStates.Clear();
             activelyMovingEntities.Clear();
 
@@ -301,7 +320,7 @@ namespace Sporefront.Visual
 
                 var coord = building.coordinate;
                 if (!entitiesPerTile.ContainsKey(coord))
-                    entitiesPerTile[coord] = new List<EntityPlacement>();
+                    entitiesPerTile[coord] = RentList();
 
                 Color color = GetOwnerColor(building.ownerID, gameState);
 
@@ -377,7 +396,7 @@ namespace Sporefront.Visual
                         }
 
                         if (!entitiesPerTile.ContainsKey(oCoord))
-                            entitiesPerTile[oCoord] = new List<EntityPlacement>();
+                            entitiesPerTile[oCoord] = RentList();
 
                         // Deterministic ID for secondary tiles: XOR building ID with tile index
                         // to avoid Guid.NewGuid() churn causing constant GO destroy+recreate
@@ -409,7 +428,7 @@ namespace Sporefront.Visual
 
                 var coord = army.coordinate;
                 if (!entitiesPerTile.ContainsKey(coord))
-                    entitiesPerTile[coord] = new List<EntityPlacement>();
+                    entitiesPerTile[coord] = RentList();
 
                 Color color = GetOwnerColor(army.ownerID, gameState);
 
@@ -438,7 +457,7 @@ namespace Sporefront.Visual
 
                 var coord = group.coordinate;
                 if (!entitiesPerTile.ContainsKey(coord))
-                    entitiesPerTile[coord] = new List<EntityPlacement>();
+                    entitiesPerTile[coord] = RentList();
 
                 Color color = GetOwnerColor(group.ownerID, gameState);
 
@@ -465,7 +484,7 @@ namespace Sporefront.Visual
 
                 var coord = scout.coordinate;
                 if (!entitiesPerTile.ContainsKey(coord))
-                    entitiesPerTile[coord] = new List<EntityPlacement>();
+                    entitiesPerTile[coord] = RentList();
 
                 Color color = GetOwnerColor(scout.ownerID, gameState);
 
@@ -497,7 +516,7 @@ namespace Sporefront.Visual
 
                 var coord = resource.coordinate;
                 if (!entitiesPerTile.ContainsKey(coord))
-                    entitiesPerTile[coord] = new List<EntityPlacement>();
+                    entitiesPerTile[coord] = RentList();
 
                 entitiesPerTile[coord].Add(new EntityPlacement
                 {
@@ -577,57 +596,8 @@ namespace Sporefront.Visual
                 if (army.currentPath != null && army.pathIndex < army.currentPath.Count &&
                     army.movementSpeed > 0 && desiredStates.ContainsKey(army.id))
                 {
-                    activelyMovingEntities.Add(army.id);
-                    var desired = desiredStates[army.id];
-                    var fromPos = desired.worldPosition; // tile-offset position at current coordinate
-                    var nextTileCenter = HexMetrics.HexToWorldPosition(army.currentPath[army.pathIndex]);
-                    // Apply same offset as armies get (upper-left for index 0)
-                    var typeOffset = new Vector3(desired.worldPosition.x - HexMetrics.HexToWorldPosition(army.coordinate).x,
-                                                 desired.worldPosition.y - HexMetrics.HexToWorldPosition(army.coordinate).y, 0f);
-                    var toPos = new Vector3(nextTileCenter.x + typeOffset.x, nextTileCenter.y + typeOffset.y, ZPosition);
-                    float t = Mathf.Clamp01((float)army.movementProgress);
-                    var interpolatedPos = Vector3.Lerp(fromPos, toPos, t);
-
-                    desired.worldPosition = interpolatedPos;
-                    desiredStates[army.id] = desired;
-
-                    int remainingTiles = army.currentPath.Count - army.pathIndex;
-
-                    // Compute next tile position for cross-tile extrapolation
-                    Vector3 nextPos = Vector3.zero;
-                    if (army.pathIndex + 1 < army.currentPath.Count)
-                    {
-                        var nextCoord = army.currentPath[army.pathIndex + 1];
-                        var nextCenter = HexMetrics.HexToWorldPosition(nextCoord);
-                        nextPos = new Vector3(nextCenter.x + typeOffset.x, nextCenter.y + typeOffset.y, ZPosition);
-                    }
-
-                    // Only reset interpolation baseline when engine movement data actually changed
-                    bool engineUnchanged = movementStates.TryGetValue(army.id, out var existingState)
-                        && existingState.lastEngineProgress == army.movementProgress
-                        && existingState.fromPosition == fromPos
-                        && existingState.toPosition == toPos;
-
-                    if (engineUnchanged)
-                    {
-                        existingState.lastEngineSpeed = army.movementSpeed;
-                        existingState.remainingTiles = remainingTiles;
-                        existingState.nextTilePosition = nextPos;
-                        movementStates[army.id] = existingState;
-                    }
-                    else
-                    {
-                        movementStates[army.id] = new MovementInterpolationState
-                        {
-                            fromPosition = fromPos,
-                            toPosition = toPos,
-                            lastEngineProgress = army.movementProgress,
-                            lastEngineSpeed = army.movementSpeed,
-                            lastUpdateTime = now,
-                            remainingTiles = remainingTiles,
-                            nextTilePosition = nextPos
-                        };
-                    }
+                    InterpolateMovingEntity(army.id, army.coordinate, army.currentPath,
+                        army.pathIndex, army.movementProgress, army.movementSpeed, now);
                 }
             }
 
@@ -637,60 +607,12 @@ namespace Sporefront.Visual
                 if (group.currentPath != null && group.pathIndex < group.currentPath.Count &&
                     group.movementSpeed > 0 && desiredStates.ContainsKey(group.id))
                 {
-                    activelyMovingEntities.Add(group.id);
-                    var desired = desiredStates[group.id];
-                    var fromPos = desired.worldPosition;
-                    var nextTileCenter = HexMetrics.HexToWorldPosition(group.currentPath[group.pathIndex]);
-                    var typeOffset = new Vector3(desired.worldPosition.x - HexMetrics.HexToWorldPosition(group.coordinate).x,
-                                                 desired.worldPosition.y - HexMetrics.HexToWorldPosition(group.coordinate).y, 0f);
-                    var toPos = new Vector3(nextTileCenter.x + typeOffset.x, nextTileCenter.y + typeOffset.y, ZPosition);
-                    float t = Mathf.Clamp01((float)group.movementProgress);
-                    var interpolatedPos = Vector3.Lerp(fromPos, toPos, t);
-
-                    desired.worldPosition = interpolatedPos;
-                    desiredStates[group.id] = desired;
-
-                    int remainingTiles = group.currentPath.Count - group.pathIndex;
-
-                    // Compute next tile position for cross-tile extrapolation
-                    Vector3 nextPos = Vector3.zero;
-                    if (group.pathIndex + 1 < group.currentPath.Count)
-                    {
-                        var nextCoord = group.currentPath[group.pathIndex + 1];
-                        var nextCenter = HexMetrics.HexToWorldPosition(nextCoord);
-                        nextPos = new Vector3(nextCenter.x + typeOffset.x, nextCenter.y + typeOffset.y, ZPosition);
-                    }
-
-                    // Only reset interpolation baseline when engine movement data actually changed
-                    bool engineUnchanged = movementStates.TryGetValue(group.id, out var existingState)
-                        && existingState.lastEngineProgress == group.movementProgress
-                        && existingState.fromPosition == fromPos
-                        && existingState.toPosition == toPos;
-
-                    if (engineUnchanged)
-                    {
-                        existingState.lastEngineSpeed = group.movementSpeed;
-                        existingState.remainingTiles = remainingTiles;
-                        existingState.nextTilePosition = nextPos;
-                        movementStates[group.id] = existingState;
-                    }
-                    else
-                    {
-                        movementStates[group.id] = new MovementInterpolationState
-                        {
-                            fromPosition = fromPos,
-                            toPosition = toPos,
-                            lastEngineProgress = group.movementProgress,
-                            lastEngineSpeed = group.movementSpeed,
-                            lastUpdateTime = now,
-                            remainingTiles = remainingTiles,
-                            nextTilePosition = nextPos
-                        };
-                    }
+                    InterpolateMovingEntity(group.id, group.coordinate, group.currentPath,
+                        group.pathIndex, group.movementProgress, group.movementSpeed, now);
                 }
             }
 
-            // Scout movement interpolation
+            // Scout movement interpolation (simplified — no MovementInterpolationState tracking)
             foreach (var kvp in gameState.scouts)
             {
                 var scout = kvp.Value;
@@ -705,9 +627,7 @@ namespace Sporefront.Visual
                                                  desired.worldPosition.y - HexMetrics.HexToWorldPosition(scout.coordinate).y, 0f);
                     var toPos = new Vector3(nextTileCenter.x + typeOffset.x, nextTileCenter.y + typeOffset.y, ZPosition);
                     float t = Mathf.Clamp01((float)scout.movementProgress);
-                    var interpolatedPos = Vector3.Lerp(fromPos, toPos, t);
-
-                    desired.worldPosition = interpolatedPos;
+                    desired.worldPosition = Vector3.Lerp(fromPos, toPos, t);
                     desiredStates[scout.id] = desired;
                 }
             }
@@ -1058,8 +978,9 @@ namespace Sporefront.Visual
             float dt = Time.deltaTime;
 
             // Iterate over a snapshot of keys to allow struct mutation
-            var barKeys = new List<Guid>(buildingBars.Keys);
-            foreach (var id in barKeys)
+            barKeyBuffer.Clear();
+            barKeyBuffer.AddRange(buildingBars.Keys);
+            foreach (var id in barKeyBuffer)
             {
                 if (!buildingBars.TryGetValue(id, out var bars)) continue;
                 if (bars.hpFill == null) continue;
@@ -1428,6 +1349,65 @@ namespace Sporefront.Visual
             public bool isEntrenching;
             public BuildingType buildingType;
             public int buildingLevel;
+        }
+
+        /// <summary>
+        /// Shared interpolation logic for armies and villager groups.
+        /// Updates desired position, movement state, and actively-moving tracking.
+        /// </summary>
+        private void InterpolateMovingEntity(
+            Guid entityId, HexCoordinate coordinate, List<HexCoordinate> path,
+            int pathIndex, double movementProgress, double movementSpeed, double now)
+        {
+            activelyMovingEntities.Add(entityId);
+            var desired = desiredStates[entityId];
+            var fromPos = desired.worldPosition;
+            var nextTileCenter = HexMetrics.HexToWorldPosition(path[pathIndex]);
+            var typeOffset = new Vector3(
+                desired.worldPosition.x - HexMetrics.HexToWorldPosition(coordinate).x,
+                desired.worldPosition.y - HexMetrics.HexToWorldPosition(coordinate).y, 0f);
+            var toPos = new Vector3(nextTileCenter.x + typeOffset.x, nextTileCenter.y + typeOffset.y, ZPosition);
+            float t = Mathf.Clamp01((float)movementProgress);
+            desired.worldPosition = Vector3.Lerp(fromPos, toPos, t);
+            desiredStates[entityId] = desired;
+
+            int remainingTiles = path.Count - pathIndex;
+
+            // Compute next tile position for cross-tile extrapolation
+            Vector3 nextPos = Vector3.zero;
+            if (pathIndex + 1 < path.Count)
+            {
+                var nextCoord = path[pathIndex + 1];
+                var nextCenter = HexMetrics.HexToWorldPosition(nextCoord);
+                nextPos = new Vector3(nextCenter.x + typeOffset.x, nextCenter.y + typeOffset.y, ZPosition);
+            }
+
+            // Only reset interpolation baseline when engine movement data actually changed
+            bool engineUnchanged = movementStates.TryGetValue(entityId, out var existingState)
+                && existingState.lastEngineProgress == movementProgress
+                && existingState.fromPosition == fromPos
+                && existingState.toPosition == toPos;
+
+            if (engineUnchanged)
+            {
+                existingState.lastEngineSpeed = movementSpeed;
+                existingState.remainingTiles = remainingTiles;
+                existingState.nextTilePosition = nextPos;
+                movementStates[entityId] = existingState;
+            }
+            else
+            {
+                movementStates[entityId] = new MovementInterpolationState
+                {
+                    fromPosition = fromPos,
+                    toPosition = toPos,
+                    lastEngineProgress = movementProgress,
+                    lastEngineSpeed = movementSpeed,
+                    lastUpdateTime = now,
+                    remainingTiles = remainingTiles,
+                    nextTilePosition = nextPos
+                };
+            }
         }
 
         private struct MovementInterpolationState

--- a/Sporefront/Assets/Scripts/Visual/EntityTendrilRenderer.cs
+++ b/Sporefront/Assets/Scripts/Visual/EntityTendrilRenderer.cs
@@ -58,6 +58,7 @@ namespace Sporefront.Visual
 
         private EntityRenderer entityRenderer;
         private Dictionary<Guid, EntityTendrilData> activeTendrils = new Dictionary<Guid, EntityTendrilData>();
+        private List<Guid> _toRemoveBuffer = new List<Guid>();
 
         // ================================================================
         // Public API
@@ -75,8 +76,6 @@ namespace Sporefront.Visual
             var player = gameState.GetPlayer(localPlayerID);
             if (player == null) { ClearAll(); return; }
 
-            var shouldHaveTendrils = new HashSet<Guid>();
-
             // Check armies
             foreach (var armyID in player.ownedArmyIDs)
             {
@@ -86,7 +85,6 @@ namespace Sporefront.Visual
                 bool isMoving = army.currentPath != null && army.currentPath.Count > 0 && army.movementSpeed > 0;
                 if (isMoving)
                 {
-                    shouldHaveTendrils.Add(armyID);
                     Vector2 direction = ComputeMovementDirection(army.coordinate, army.currentPath, army.pathIndex);
                     Color color = entityRenderer.GetEntityColor(armyID);
 
@@ -117,7 +115,6 @@ namespace Sporefront.Visual
                 bool isMoving = group.currentPath != null && group.currentPath.Count > 0 && group.movementSpeed > 0;
                 if (isMoving)
                 {
-                    shouldHaveTendrils.Add(groupID);
                     Vector2 direction = ComputeMovementDirection(group.coordinate, group.currentPath, group.pathIndex);
                     Color color = entityRenderer.GetEntityColor(groupID);
 
@@ -144,7 +141,7 @@ namespace Sporefront.Visual
         {
             if (entityRenderer == null) return;
 
-            var toRemove = new List<Guid>();
+            _toRemoveBuffer.Clear();
             float dt = Time.deltaTime;
 
             foreach (var kvp in activeTendrils)
@@ -163,7 +160,7 @@ namespace Sporefront.Visual
                     if (data.growthProgress <= 0f)
                     {
                         if (data.rootGO != null) Destroy(data.rootGO);
-                        toRemove.Add(id);
+                        _toRemoveBuffer.Add(id);
                         continue;
                     }
                 }
@@ -173,7 +170,7 @@ namespace Sporefront.Visual
                 if (entityTransform == null)
                 {
                     if (data.rootGO != null) Destroy(data.rootGO);
-                    toRemove.Add(id);
+                    _toRemoveBuffer.Add(id);
                     continue;
                 }
                 if (data.rootGO != null)
@@ -194,7 +191,7 @@ namespace Sporefront.Visual
                 UpdateGrowthGradients(data);
             }
 
-            foreach (var id in toRemove)
+            foreach (var id in _toRemoveBuffer)
                 activeTendrils.Remove(id);
         }
 
@@ -276,19 +273,25 @@ namespace Sporefront.Visual
 
                 var strands = new LineRenderer[strandCount];
                 var gradients = new Gradient[strandCount];
+                var colorKeysArr = new GradientColorKey[strandCount][];
+                var alphaKeysArr = new GradientAlphaKey[strandCount][];
 
                 for (int s = 0; s < strandCount; s++)
                 {
                     strands[s] = CreateStrand(rootGO, t, s, endPoint, strandWidths[s],
                         color, maxOffset, seed, length);
                     gradients[s] = new Gradient();
+                    colorKeysArr[s] = new GradientColorKey[2];
+                    alphaKeysArr[s] = new GradientAlphaKey[4];
                 }
 
                 tendrils[t] = new TendrilStrandData
                 {
                     strands = strands,
                     gradients = gradients,
-                    endPoint = endPoint
+                    endPoint = endPoint,
+                    colorKeys = colorKeysArr,
+                    alphaKeys = alphaKeysArr
                 };
             }
 
@@ -482,6 +485,11 @@ namespace Sporefront.Visual
 
         private void UpdateGrowthGradients(EntityTendrilData data)
         {
+            // Skip if growth hasn't changed meaningfully since last update
+            if (Mathf.Abs(data.growthProgress - data.lastAppliedGrowth) < 0.001f)
+                return;
+            data.lastAppliedGrowth = data.growthProgress;
+
             float[] strandAlphas = data.isArmy ? ArmyStrandAlphas : VillagerStrandAlphas;
 
             foreach (var tendril in data.tendrils)
@@ -493,42 +501,31 @@ namespace Sporefront.Visual
                     float alpha = strandAlphas[s];
                     Color baseColor = data.baseColor;
                     var gradient = tendril.gradients[s];
+                    var ck = tendril.colorKeys[s];
+                    var ak = tendril.alphaKeys[s];
+
+                    // Mutate pre-allocated arrays in-place (no allocation)
+                    ck[0] = new GradientColorKey(baseColor, 0f);
+                    ck[1] = new GradientColorKey(baseColor, 1f);
 
                     if (data.growthProgress >= 0.99f)
                     {
-                        gradient.SetKeys(
-                            new GradientColorKey[]
-                            {
-                                new GradientColorKey(baseColor, 0f),
-                                new GradientColorKey(baseColor, 1f)
-                            },
-                            new GradientAlphaKey[]
-                            {
-                                new GradientAlphaKey(alpha, 0f),
-                                new GradientAlphaKey(alpha, 1f)
-                            }
-                        );
+                        ak[0] = new GradientAlphaKey(alpha, 0f);
+                        ak[1] = new GradientAlphaKey(alpha, 1f);
+                        ak[2] = new GradientAlphaKey(alpha, 1f);
+                        ak[3] = new GradientAlphaKey(alpha, 1f);
                     }
                     else
                     {
                         float fadeWidth = 0.1f;
                         float fadeStart = Mathf.Max(0f, data.growthProgress - fadeWidth);
-                        gradient.SetKeys(
-                            new GradientColorKey[]
-                            {
-                                new GradientColorKey(baseColor, 0f),
-                                new GradientColorKey(baseColor, 1f)
-                            },
-                            new GradientAlphaKey[]
-                            {
-                                new GradientAlphaKey(alpha, 0f),
-                                new GradientAlphaKey(alpha, fadeStart),
-                                new GradientAlphaKey(0f, Mathf.Min(data.growthProgress + fadeWidth, 1f)),
-                                new GradientAlphaKey(0f, 1f)
-                            }
-                        );
+                        ak[0] = new GradientAlphaKey(alpha, 0f);
+                        ak[1] = new GradientAlphaKey(alpha, fadeStart);
+                        ak[2] = new GradientAlphaKey(0f, Mathf.Min(data.growthProgress + fadeWidth, 1f));
+                        ak[3] = new GradientAlphaKey(0f, 1f);
                     }
 
+                    gradient.SetKeys(ck, ak);
                     tendril.strands[s].colorGradient = gradient;
                 }
             }
@@ -585,6 +582,7 @@ namespace Sporefront.Visual
             public GameObject rootGO;
             public TendrilStrandData[] tendrils;
             public float growthProgress;
+            public float lastAppliedGrowth = -1f;
             public bool isMoving;
             public Vector2 smoothedDirection;
             public Vector2 targetDirection;
@@ -597,6 +595,9 @@ namespace Sporefront.Visual
             public LineRenderer[] strands;
             public Gradient[] gradients;
             public Vector3 endPoint;
+            // Pre-allocated gradient key arrays to avoid per-frame allocations
+            public GradientColorKey[][] colorKeys;
+            public GradientAlphaKey[][] alphaKeys;
         }
     }
 }

--- a/Sporefront/Assets/Scripts/Visual/EvolutionPanel.cs
+++ b/Sporefront/Assets/Scripts/Visual/EvolutionPanel.cs
@@ -15,7 +15,7 @@ using Sporefront.Models;
 
 namespace Sporefront.Visual
 {
-    public class EvolutionPanel : MonoBehaviour
+    public class EvolutionPanel : SporefrontPanel
     {
         // ================================================================
         // Events
@@ -31,7 +31,6 @@ namespace Sporefront.Visual
         // ================================================================
 
         private GameObject panel;
-        private RectTransform contentRT;
 
         private int populationSize = 32;
         private int gamesPerEval = 6;
@@ -91,19 +90,19 @@ namespace Sporefront.Visual
         // Public API
         // ================================================================
 
-        public void Show()
+        public override void Show()
         {
             RefreshGenomeList();
             UpdateApplyButton();
             panel.SetActive(true);
         }
 
-        public void Hide()
+        public override void Hide()
         {
             panel.SetActive(false);
         }
 
-        public bool IsVisible => panel != null && panel.activeSelf;
+        public new bool IsVisible => panel != null && panel.activeSelf;
 
         /// <summary>
         /// Called by the manager when a generation completes.
@@ -121,8 +120,7 @@ namespace Sporefront.Visual
         {
             if (historyText == null) return;
 
-            string line = string.Format("Gen {0,3} | Fitness: {1:F2} | Win: {2:F0}% | Pop: {3}",
-                generation + 1, bestFitness, winRate * 100, populationCount);
+            string line = $"Gen {generation + 1,3} | Fitness: {bestFitness:F2} | Win: {winRate * 100:F0}% | Pop: {populationCount}";
 
             if (historyText.text == "No data yet.")
                 historyText.text = line;
@@ -382,8 +380,7 @@ namespace Sporefront.Visual
             nameLE.preferredHeight = 20;
 
             // Detail line
-            string detail = string.Format("Gen {0} | Fitness: {1:F2} | WR: {2}%",
-                genome.generation, genome.fitness, genome.WinRatePercent);
+            string detail = $"Gen {genome.generation} | Fitness: {genome.fitness:F2} | WR: {genome.WinRatePercent}%";
             var detailLabel = UIHelper.CreateLabel(vlg.transform, detail,
                 11, UIHelper.InkMutedText, TextAnchor.MiddleLeft);
             var detailLE = detailLabel.gameObject.AddComponent<LayoutElement>();

--- a/Sporefront/Assets/Scripts/Visual/FactionBannerPanel.cs
+++ b/Sporefront/Assets/Scripts/Visual/FactionBannerPanel.cs
@@ -14,12 +14,11 @@ using Sporefront.Models;
 
 namespace Sporefront.Visual
 {
-    public class FactionBannerPanel : MonoBehaviour
+    public class FactionBannerPanel : SporefrontPanel
     {
         private GameObject panel;
         private Text bannerLabel;
         private GameObject detailBackdrop;
-        private CanvasGroup backdropCG;
         private Coroutine fadeCoroutine;
         private FactionType currentFaction = FactionType.None;
         private RectTransform popupContentRT;
@@ -208,7 +207,7 @@ namespace Sporefront.Visual
         // Show / Close with Fade
         // ================================================================
 
-        public void Show()
+        public override void Show()
         {
             if (detailBackdrop == null) return;
             if (fadeCoroutine != null) StopCoroutine(fadeCoroutine);
@@ -223,7 +222,7 @@ namespace Sporefront.Visual
             fadeCoroutine = StartCoroutine(UIHelper.FadeOut(backdropCG));
         }
 
-        public void Hide()
+        public override void Hide()
         {
             Close();
         }
@@ -237,7 +236,7 @@ namespace Sporefront.Visual
             }
         }
 
-        public bool IsVisible => detailBackdrop != null && detailBackdrop.activeSelf;
+        public new bool IsVisible => detailBackdrop != null && detailBackdrop.activeSelf;
 
         // ================================================================
         // Helpers

--- a/Sporefront/Assets/Scripts/Visual/GameOverPanel.cs
+++ b/Sporefront/Assets/Scripts/Visual/GameOverPanel.cs
@@ -32,7 +32,7 @@ namespace Sporefront.Visual
     // Panel
     // ================================================================
 
-    public class GameOverPanel : MonoBehaviour
+    public class GameOverPanel : SporefrontPanel
     {
         // ================================================================
         // Events
@@ -44,9 +44,7 @@ namespace Sporefront.Visual
         // State
         // ================================================================
 
-        private GameObject backdrop;
         private GameObject panel;
-        private RectTransform contentRT;
 
         // ================================================================
         // Initialization
@@ -97,12 +95,10 @@ namespace Sporefront.Visual
             backdrop.SetActive(true);
         }
 
-        public void Hide()
+        public override void Hide()
         {
             backdrop.SetActive(false);
         }
-
-        public bool IsVisible => backdrop != null && backdrop.activeSelf;
 
         // ================================================================
         // Rebuild Content

--- a/Sporefront/Assets/Scripts/Visual/GameSceneManager.cs
+++ b/Sporefront/Assets/Scripts/Visual/GameSceneManager.cs
@@ -582,7 +582,7 @@ namespace Sporefront.Visual
             {
                 if (!success)
                 {
-                    Debug.LogError(string.Format("[GameSceneManager] Failed to create matchmaking game: {0}", error));
+                    Debug.LogError($"[GameSceneManager] Failed to create matchmaking game: {error}");
                     // Roll back local state — game was never created on the server
                     gameState = null;
                     isOnlineGame = false;
@@ -635,7 +635,7 @@ namespace Sporefront.Visual
                 ResetOnlineFlags();
                 gameStarted = true;
 
-                Debug.Log(string.Format("[GameSceneManager] Online game started as HOST — ID: {0}", onlineGameID));
+                Debug.Log($"[GameSceneManager] Online game started as HOST — ID: {onlineGameID}");
             });
         }
 
@@ -656,7 +656,7 @@ namespace Sporefront.Visual
             onlineGameID = config.matchGameID;
             isOnlineGame = true;
 
-            Debug.Log(string.Format("[GameSceneManager] Joining game as JOINER — ID: {0}", onlineGameID));
+            Debug.Log($"[GameSceneManager] Joining game as JOINER — ID: {onlineGameID}");
 
             // Show loading status
             uiManager?.SetMainMenuStatus("Joining game...");
@@ -675,7 +675,7 @@ namespace Sporefront.Visual
 
                 if (snapshot == null)
                 {
-                    Debug.LogError(string.Format("[GameSceneManager] Failed to load snapshot for join: {0}", error ?? "no snapshot"));
+                    Debug.LogError($"[GameSceneManager] Failed to load snapshot for join: {error ?? "no snapshot"}");
                     // Retry after a short delay — host may still be saving
                     StartCoroutine(RetryJoinAfterDelay(config, 2.0f));
                     return;
@@ -702,7 +702,7 @@ namespace Sporefront.Visual
                 }
                 catch (Exception e)
                 {
-                    Debug.LogError(string.Format("[GameSceneManager] Failed to restore game state: {0}", e.Message));
+                    Debug.LogError($"[GameSceneManager] Failed to restore game state: {e.Message}");
                     return;
                 }
 
@@ -773,7 +773,7 @@ namespace Sporefront.Visual
                 gameStarted = true;
                 joinRetryCount = 0;
 
-                Debug.Log(string.Format("[GameSceneManager] Online game joined — ID: {0}", onlineGameID));
+                Debug.Log($"[GameSceneManager] Online game joined — ID: {onlineGameID}");
             });
         }
 
@@ -952,7 +952,7 @@ namespace Sporefront.Visual
             {
                 if (!success)
                 {
-                    Debug.LogError(string.Format("[GameSceneManager] Failed to create online game: {0}", error));
+                    Debug.LogError($"[GameSceneManager] Failed to create online game: {error}");
                     // Roll back local state
                     gameState = null;
                     isOnlineGame = false;
@@ -1008,7 +1008,7 @@ namespace Sporefront.Visual
                 ResetOnlineFlags();
                 gameStarted = true;
 
-                Debug.Log(string.Format("[GameSceneManager] Online game started — ID: {0}, seed: {1}", onlineGameID, seed));
+                Debug.Log($"[GameSceneManager] Online game started — ID: {onlineGameID}, seed: {seed}");
             });
         }
 #endif
@@ -1226,9 +1226,8 @@ namespace Sporefront.Visual
                 int seconds = Mathf.Max(0, Mathf.CeilToInt(disconnectTimer));
                 int minutes = seconds / 60;
                 int secs = seconds % 60;
-                disconnectTimerLabel.text = string.Format(
-                    "Opponent disconnected. Waiting for reconnection... ({0}:{1:D2})",
-                    minutes, secs);
+                disconnectTimerLabel.text =
+                    $"Opponent disconnected. Waiting for reconnection... ({minutes}:{secs:D2})";
             }
 
             // Timer expired — opponent abandoned the game
@@ -1304,7 +1303,7 @@ namespace Sporefront.Visual
                 {
                     pendingRejoinSession = session;
                     uiManager?.SetRejoinVisible(true);
-                    Debug.Log(string.Format("[GameSceneManager] Active game found — ID: {0}", session.gameID));
+                    Debug.Log($"[GameSceneManager] Active game found — ID: {session.gameID}");
                 }
                 else
                 {
@@ -1340,8 +1339,7 @@ namespace Sporefront.Visual
             onlineGameID = session.gameID;
             isOnlineGame = true;
 
-            Debug.Log(string.Format("[GameSceneManager] Rejoining game — ID: {0}, attempt: {1}",
-                onlineGameID, attempt));
+            Debug.Log($"[GameSceneManager] Rejoining game — ID: {onlineGameID}, attempt: {attempt}");
 
             // Load the latest snapshot + any pending commands
             Engine.GameSessionService.Instance.LoadLatestSnapshot(onlineGameID, (snapshot, pendingCommands, error) =>
@@ -1350,16 +1348,14 @@ namespace Sporefront.Visual
                 {
                     if (attempt < GameConfig.Online.MaxJoinRetries)
                     {
-                        Debug.LogWarning(string.Format(
-                            "[GameSceneManager] Rejoin snapshot not available (attempt {0}/{1}), retrying...",
-                            attempt + 1, GameConfig.Online.MaxJoinRetries));
+                        Debug.LogWarning(
+                            $"[GameSceneManager] Rejoin snapshot not available (attempt {attempt + 1}/{GameConfig.Online.MaxJoinRetries}), retrying...");
                         StartCoroutine(RetryRejoinAfterDelay(session, attempt + 1));
                     }
                     else
                     {
-                        Debug.LogError(string.Format(
-                            "[GameSceneManager] Rejoin failed after {0} attempts: {1}",
-                            GameConfig.Online.MaxJoinRetries, error ?? "no snapshot"));
+                        Debug.LogError(
+                            $"[GameSceneManager] Rejoin failed after {GameConfig.Online.MaxJoinRetries} attempts: {error ?? "no snapshot"}");
                         isOnlineGame = false;
                         onlineGameID = null;
                     }
@@ -1373,7 +1369,7 @@ namespace Sporefront.Visual
                 }
                 catch (Exception e)
                 {
-                    Debug.LogError(string.Format("[GameSceneManager] Rejoin state restore failed: {0}", e.Message));
+                    Debug.LogError($"[GameSceneManager] Rejoin state restore failed: {e.Message}");
                     isOnlineGame = false;
                     onlineGameID = null;
                     return;
@@ -1468,8 +1464,7 @@ namespace Sporefront.Visual
                 pendingRejoinSession = null;
                 uiManager?.SetRejoinVisible(false);
 
-                Debug.Log(string.Format("[GameSceneManager] Rejoined online game — ID: {0}, isHost: {1}",
-                    onlineGameID, isHost));
+                Debug.Log($"[GameSceneManager] Rejoined online game — ID: {onlineGameID}, isHost: {isHost}");
             });
 #endif
         }
@@ -1477,7 +1472,7 @@ namespace Sporefront.Visual
         private System.Collections.IEnumerator RetryRejoinAfterDelay(Data.GameSession session, int attempt)
         {
             yield return new WaitForSeconds(GameConfig.Online.JoinRetryDelaySeconds);
-            Debug.Log(string.Format("[GameSceneManager] Retrying rejoin (attempt {0})...", attempt));
+            Debug.Log($"[GameSceneManager] Retrying rejoin (attempt {attempt})...");
             RejoinOnlineGame(session, attempt);
         }
 

--- a/Sporefront/Assets/Scripts/Visual/GameSetupPanel.cs
+++ b/Sporefront/Assets/Scripts/Visual/GameSetupPanel.cs
@@ -82,7 +82,7 @@ namespace Sporefront.Visual
     // Panel
     // ================================================================
 
-    public partial class GameSetupPanel : MonoBehaviour
+    public partial class GameSetupPanel : SporefrontPanel
     {
         // ================================================================
         // Events
@@ -108,7 +108,6 @@ namespace Sporefront.Visual
         // ================================================================
 
         private GameObject panel;
-        private RectTransform contentRT;
 
         // Two-screen containers
         private GameObject modeSelectContainer;
@@ -415,12 +414,12 @@ namespace Sporefront.Visual
             LayoutRebuilder.ForceRebuildLayoutImmediate(contentRT);
         }
 
-        public void Hide()
+        public override void Hide()
         {
             panel.SetActive(false);
         }
 
-        public bool IsVisible => panel != null && panel.activeSelf;
+        public new bool IsVisible => panel != null && panel.activeSelf;
 
         public RectTransform PanelRT => panel?.GetComponent<RectTransform>();
 

--- a/Sporefront/Assets/Scripts/Visual/GatherPanel.cs
+++ b/Sporefront/Assets/Scripts/Visual/GatherPanel.cs
@@ -15,7 +15,7 @@ using Sporefront.Models;
 
 namespace Sporefront.Visual
 {
-    public class GatherPanel : MonoBehaviour
+    public class GatherPanel : SporefrontPanel
     {
         // ================================================================
         // Events
@@ -31,12 +31,9 @@ namespace Sporefront.Visual
         // State
         // ================================================================
 
-        private GameObject backdrop;
         private GameObject modalPanel;
-        private RectTransform contentRT;
         private Text headerLabel;
         private Guid? currentResourcePointID;
-        private Guid localPlayerID;
         private Guid? selectedVillagerGroupID;
         private GameState cachedGameState;
         private bool cachedIsHuntable;
@@ -100,11 +97,6 @@ namespace Sporefront.Visual
             backdrop.SetActive(false);
         }
 
-        public void UpdateLocalPlayerID(Guid playerID)
-        {
-            localPlayerID = playerID;
-        }
-
         // ================================================================
         // Public API
         // ================================================================
@@ -117,7 +109,7 @@ namespace Sporefront.Visual
             backdrop.SetActive(true);
         }
 
-        public void Hide()
+        public override void Hide()
         {
             ClearPreview();
             currentResourcePointID = null;
@@ -131,8 +123,6 @@ namespace Sporefront.Visual
             if (!currentResourcePointID.HasValue || !backdrop.activeSelf) return;
             Rebuild(gameState);
         }
-
-        public bool IsVisible => backdrop != null && backdrop.activeSelf;
 
         // ================================================================
         // Rebuild
@@ -255,8 +245,8 @@ namespace Sporefront.Visual
             var sectionLE = sectionLabel.gameObject.AddComponent<LayoutElement>();
             sectionLE.preferredHeight = 28;
 
-            var groups = gameState.GetVillagerGroupsForPlayer(localPlayerID);
-            if (groups == null || groups.Count == 0)
+            var groups = new List<VillagerGroupData>(gameState.GetVillagerGroupsForPlayer(localPlayerID));
+            if (groups.Count == 0)
             {
                 var emptyLabel = UIHelper.CreateLabel(contentRT,
                     "  No villager groups available", UIConstants.FontSmall, UIHelper.InkMutedText);

--- a/Sporefront/Assets/Scripts/Visual/GenomeSelectionPanel.cs
+++ b/Sporefront/Assets/Scripts/Visual/GenomeSelectionPanel.cs
@@ -15,7 +15,7 @@ using Sporefront.Models;
 
 namespace Sporefront.Visual
 {
-    public class GenomeSelectionPanel : MonoBehaviour
+    public class GenomeSelectionPanel : SporefrontPanel
     {
         // ================================================================
         // Events
@@ -28,9 +28,7 @@ namespace Sporefront.Visual
         // State
         // ================================================================
 
-        private GameObject backdrop;
         private GameObject panel;
-        private RectTransform contentRT;
 
         private List<AIGenome> genomes = new List<AIGenome>();
         private AIGenome selectedGenome1;
@@ -78,7 +76,7 @@ namespace Sporefront.Visual
         // Public API
         // ================================================================
 
-        public void Show()
+        public override void Show()
         {
             selectedGenome1 = null;
             selectedGenome2 = null;
@@ -88,12 +86,10 @@ namespace Sporefront.Visual
             backdrop.SetActive(true);
         }
 
-        public void Hide()
+        public override void Hide()
         {
             backdrop.SetActive(false);
         }
-
-        public bool IsVisible => backdrop != null && backdrop.activeSelf;
 
         // ================================================================
         // Build Content
@@ -292,8 +288,7 @@ namespace Sporefront.Visual
             nameLE.preferredHeight = 20;
 
             // Detail line
-            string detail = string.Format("Gen {0} | Fitness: {1:F2} | WR: {2}%",
-                genome.generation, genome.fitness, genome.WinRatePercent);
+            string detail = $"Gen {genome.generation} | Fitness: {genome.fitness:F2} | WR: {genome.WinRatePercent}%";
             var detailLabel = UIHelper.CreateLabel(rowVLG.transform, detail,
                 11, UIHelper.InkMutedText, TextAnchor.MiddleLeft);
             var detailLE = detailLabel.gameObject.AddComponent<LayoutElement>();

--- a/Sporefront/Assets/Scripts/Visual/InGameMenuPanel.cs
+++ b/Sporefront/Assets/Scripts/Visual/InGameMenuPanel.cs
@@ -12,7 +12,7 @@ using Sporefront.Engine;
 
 namespace Sporefront.Visual
 {
-    public class InGameMenuPanel : MonoBehaviour
+    public class InGameMenuPanel : SporefrontPanel
     {
         // ================================================================
         // Events
@@ -30,11 +30,7 @@ namespace Sporefront.Visual
         // State
         // ================================================================
 
-        private GameObject backdrop;
-        private CanvasGroup backdropCG;
         private GameObject panel;
-        private Coroutine fadeCoroutine;
-        private Guid localPlayerID;
         private bool isOnlineGame;
         private GameObject surrenderButton;
         private GameObject surrenderConfirmGroup;
@@ -84,11 +80,6 @@ namespace Sporefront.Visual
             backdrop.SetActive(false);
         }
 
-        public void UpdateLocalPlayerID(Guid playerID)
-        {
-            localPlayerID = playerID;
-        }
-
         public void SetOnlineMode(bool online)
         {
             isOnlineGame = online;
@@ -104,10 +95,8 @@ namespace Sporefront.Visual
         // Public API
         // ================================================================
 
-        public void Show()
+        public override void Show()
         {
-            if (fadeCoroutine != null) StopCoroutine(fadeCoroutine);
-
             // Reset surrender confirmation state on each open
             if (surrenderConfirmGroup != null)
                 surrenderConfirmGroup.SetActive(false);
@@ -116,23 +105,19 @@ namespace Sporefront.Visual
 
             backdrop.SetActive(true);
             backdrop.transform.SetAsLastSibling(); // render above minimap & all HUD
-            fadeCoroutine = StartCoroutine(UIHelper.FadeIn(backdropCG));
+            FadeIn();
         }
 
         public void Close()
         {
-            if (fadeCoroutine != null) StopCoroutine(fadeCoroutine);
-            fadeCoroutine = StartCoroutine(UIHelper.FadeOut(backdropCG));
+            FadeOut();
             OnResumeGame?.Invoke();
         }
 
-        public void Hide()
+        public override void Hide()
         {
-            if (fadeCoroutine != null) StopCoroutine(fadeCoroutine);
             backdrop.SetActive(false);
         }
-
-        public bool IsVisible => backdrop != null && backdrop.activeSelf;
 
         // ================================================================
         // Build Content

--- a/Sporefront/Assets/Scripts/Visual/LiveCombatPanel.cs
+++ b/Sporefront/Assets/Scripts/Visual/LiveCombatPanel.cs
@@ -16,7 +16,7 @@ using Sporefront.Models.Combat;
 
 namespace Sporefront.Visual
 {
-    public class LiveCombatPanel : MonoBehaviour
+    public class LiveCombatPanel : SporefrontPanel
     {
         // ================================================================
         // Events
@@ -30,8 +30,6 @@ namespace Sporefront.Visual
         // ================================================================
 
         private GameObject panel;
-        private RectTransform contentRT;
-        private Guid localPlayerID;
         private Guid? trackedCombatID;
 
         // Cached UI references for rapid updates
@@ -88,10 +86,7 @@ namespace Sporefront.Visual
             panel.SetActive(false);
         }
 
-        public void UpdateLocalPlayerID(Guid playerID)
-        {
-            localPlayerID = playerID;
-        }
+        // UpdateLocalPlayerID inherited from SporefrontPanel
 
         // ================================================================
         // Public API
@@ -104,7 +99,7 @@ namespace Sporefront.Visual
             panel.SetActive(true);
         }
 
-        public void Hide()
+        public override void Hide()
         {
             trackedCombatID = null;
             panel.SetActive(false);
@@ -117,7 +112,7 @@ namespace Sporefront.Visual
             Rebuild(gameState);
         }
 
-        public bool IsVisible => panel != null && panel.activeSelf;
+        public new bool IsVisible => panel != null && panel.activeSelf;
 
         // ================================================================
         // Rebuild

--- a/Sporefront/Assets/Scripts/Visual/MainMenuPanel.cs
+++ b/Sporefront/Assets/Scripts/Visual/MainMenuPanel.cs
@@ -13,7 +13,7 @@ using Sporefront.Engine;
 
 namespace Sporefront.Visual
 {
-    public class MainMenuPanel : MonoBehaviour
+    public class MainMenuPanel : SporefrontPanel
     {
         // ================================================================
         // Events
@@ -77,7 +77,7 @@ namespace Sporefront.Visual
         // Public API
         // ================================================================
 
-        public void Show()
+        public override void Show()
         {
             RefreshUsername();
             ShowMainPage();
@@ -105,12 +105,12 @@ namespace Sporefront.Visual
             }
         }
 
-        public void Hide()
+        public override void Hide()
         {
             panel.SetActive(false);
         }
 
-        public bool IsVisible => panel != null && panel.activeSelf;
+        public new bool IsVisible => panel != null && panel.activeSelf;
 
         public void SetRejoinVisible(bool visible)
         {

--- a/Sporefront/Assets/Scripts/Visual/MatchmakingPanel.cs
+++ b/Sporefront/Assets/Scripts/Visual/MatchmakingPanel.cs
@@ -13,7 +13,7 @@ using Sporefront.Models;
 
 namespace Sporefront.Visual
 {
-    public class MatchmakingPanel : MonoBehaviour
+    public class MatchmakingPanel : SporefrontPanel
     {
         // ================================================================
         // Events
@@ -395,7 +395,7 @@ namespace Sporefront.Visual
         // Public API
         // ================================================================
 
-        public void Show()
+        public override void Show()
         {
             panel.SetActive(true);
             ShowScreen(MatchmakingScreen.FactionSelect);
@@ -404,7 +404,7 @@ namespace Sporefront.Visual
             pendingMatch = null;
         }
 
-        public void Hide()
+        public override void Hide()
         {
             // Clean up if we're still in queue
             if (MatchmakingService.Instance.IsInQueue || MatchmakingService.Instance.IsMatched)
@@ -415,7 +415,7 @@ namespace Sporefront.Visual
             panel.SetActive(false);
         }
 
-        public bool IsVisible => panel != null && panel.activeSelf;
+        public new bool IsVisible => panel != null && panel.activeSelf;
 
         // ================================================================
         // Update
@@ -434,7 +434,7 @@ namespace Sporefront.Visual
                 int minutes = (int)(elapsed / 60f);
                 int seconds = (int)(elapsed % 60f);
                 if (searchTimerLabel != null)
-                    searchTimerLabel.text = string.Format("{0}:{1:00}", minutes, seconds);
+                    searchTimerLabel.text = $"{minutes}:{seconds:00}";
             }
             else if (currentScreen == MatchmakingScreen.MatchFound && !localReady)
             {
@@ -477,7 +477,7 @@ namespace Sporefront.Visual
                 }
                 else
                 {
-                    Debug.LogWarning(string.Format("[MatchmakingPanel] Failed to enter queue: {0}", error));
+                    Debug.LogWarning($"[MatchmakingPanel] Failed to enter queue: {error}");
                 }
             });
 #else
@@ -557,7 +557,7 @@ namespace Sporefront.Visual
             if (opponentNameLabel != null)
                 opponentNameLabel.text = result.opponentDisplayName;
             if (opponentFactionLabel != null)
-                opponentFactionLabel.text = string.Format("Faction: {0}", result.opponentFaction);
+                opponentFactionLabel.text = $"Faction: {result.opponentFaction}";
 
             UpdateReadyStatus();
             ShowScreen(MatchmakingScreen.MatchFound);

--- a/Sporefront/Assets/Scripts/Visual/MenuTendrilAnimator.cs
+++ b/Sporefront/Assets/Scripts/Visual/MenuTendrilAnimator.cs
@@ -273,8 +273,6 @@ namespace Sporefront.Visual
 
             float limX = canvasW * 0.48f;
             float limY = canvasH * 0.48f;
-            bool hitEdge = false;
-
             for (int i = 1; i < pointCount; i++)
             {
                 float t = (float)i / (pointCount - 1);
@@ -290,7 +288,6 @@ namespace Sporefront.Visual
                 {
                     point = ClampToScreen(point);
                     pts.Add(point);
-                    hitEdge = true;
                     break;
                 }
                 pts.Add(point);

--- a/Sporefront/Assets/Scripts/Visual/MilitaryOverviewPanel.cs
+++ b/Sporefront/Assets/Scripts/Visual/MilitaryOverviewPanel.cs
@@ -15,7 +15,7 @@ using Sporefront.Models;
 
 namespace Sporefront.Visual
 {
-    public class MilitaryOverviewPanel : MonoBehaviour
+    public class MilitaryOverviewPanel : SporefrontPanel
     {
         // ================================================================
         // Events
@@ -27,10 +27,7 @@ namespace Sporefront.Visual
         // State
         // ================================================================
 
-        private GameObject backdrop;
         private GameObject panel;
-        private RectTransform contentRT;
-        private Guid localPlayerID;
 
         // Throttled rebuild
         private bool isDirty;
@@ -92,11 +89,6 @@ namespace Sporefront.Visual
             backdrop.SetActive(false);
         }
 
-        public void UpdateLocalPlayerID(Guid playerID)
-        {
-            localPlayerID = playerID;
-        }
-
         // ================================================================
         // Public API
         // ================================================================
@@ -110,7 +102,7 @@ namespace Sporefront.Visual
             backdrop.SetActive(true);
         }
 
-        public void Hide()
+        public override void Hide()
         {
             backdrop.SetActive(false);
             OnClose?.Invoke();
@@ -122,8 +114,6 @@ namespace Sporefront.Visual
             cachedGameState = gameState;
             isDirty = true;
         }
-
-        public bool IsVisible => backdrop != null && backdrop.activeSelf;
 
         private void Update()
         {

--- a/Sporefront/Assets/Scripts/Visual/NotificationInboxPanel.cs
+++ b/Sporefront/Assets/Scripts/Visual/NotificationInboxPanel.cs
@@ -15,7 +15,7 @@ using Sporefront.Models;
 
 namespace Sporefront.Visual
 {
-    public class NotificationInboxPanel : MonoBehaviour
+    public class NotificationInboxPanel : SporefrontPanel
     {
         // ================================================================
         // Events
@@ -46,10 +46,7 @@ namespace Sporefront.Visual
         // State
         // ================================================================
 
-        private GameObject backdrop;
         private GameObject panel;
-        private RectTransform contentRT;
-        private Guid localPlayerID;
 
         private List<InboxEntry> entries = new List<InboxEntry>();
 
@@ -134,22 +131,17 @@ namespace Sporefront.Visual
             backdrop.SetActive(false);
         }
 
-        public void UpdateLocalPlayerID(Guid playerID)
-        {
-            localPlayerID = playerID;
-        }
-
         // ================================================================
         // Public API
         // ================================================================
 
-        public void Show()
+        public override void Show()
         {
             Rebuild();
             backdrop.SetActive(true);
         }
 
-        public void Hide()
+        public override void Hide()
         {
             backdrop.SetActive(false);
             OnClose?.Invoke();
@@ -160,8 +152,6 @@ namespace Sporefront.Visual
             if (!backdrop.activeSelf) return;
             Rebuild();
         }
-
-        public bool IsVisible => backdrop != null && backdrop.activeSelf;
 
         // ================================================================
         // Notification Management

--- a/Sporefront/Assets/Scripts/Visual/NotificationPanel.cs
+++ b/Sporefront/Assets/Scripts/Visual/NotificationPanel.cs
@@ -12,7 +12,7 @@ using Sporefront.Models;
 
 namespace Sporefront.Visual
 {
-    public class NotificationPanel : MonoBehaviour
+    public class NotificationPanel : SporefrontPanel
     {
         // ================================================================
         // Types

--- a/Sporefront/Assets/Scripts/Visual/ReinforcePanel.cs
+++ b/Sporefront/Assets/Scripts/Visual/ReinforcePanel.cs
@@ -15,7 +15,7 @@ using Sporefront.Models;
 
 namespace Sporefront.Visual
 {
-    public class ReinforcePanel : MonoBehaviour
+    public class ReinforcePanel : SporefrontPanel
     {
         // ================================================================
         // Events
@@ -28,11 +28,8 @@ namespace Sporefront.Visual
         // State
         // ================================================================
 
-        private GameObject backdrop;
         private GameObject modalPanel;
-        private RectTransform contentRT;
         private Guid? currentArmyID;
-        private Guid localPlayerID;
 
         // Per-building selection state: buildingID -> (unitType -> selected count)
         private Dictionary<Guid, Dictionary<MilitaryUnitType, int>> selections =
@@ -97,11 +94,6 @@ namespace Sporefront.Visual
             backdrop.SetActive(false);
         }
 
-        public void UpdateLocalPlayerID(Guid playerID)
-        {
-            localPlayerID = playerID;
-        }
-
         // ================================================================
         // Public API
         // ================================================================
@@ -115,7 +107,7 @@ namespace Sporefront.Visual
             backdrop.SetActive(true);
         }
 
-        public void Hide()
+        public override void Hide()
         {
             currentArmyID = null;
             selections.Clear();
@@ -129,8 +121,6 @@ namespace Sporefront.Visual
             if (!currentArmyID.HasValue || !backdrop.activeSelf) return;
             Rebuild(gameState);
         }
-
-        public bool IsVisible => backdrop != null && backdrop.activeSelf;
 
         // ================================================================
         // Rebuild
@@ -197,7 +187,7 @@ namespace Sporefront.Visual
             var sectionLE = sectionLabel.gameObject.AddComponent<LayoutElement>();
             sectionLE.preferredHeight = 28;
 
-            var buildings = gameState.GetBuildingsForPlayer(localPlayerID);
+            var buildings = new List<BuildingData>(gameState.GetBuildingsForPlayer(localPlayerID));
             bool anyGarrisoned = false;
 
             // Sort by distance to army

--- a/Sporefront/Assets/Scripts/Visual/ResearchTreePanel.cs
+++ b/Sporefront/Assets/Scripts/Visual/ResearchTreePanel.cs
@@ -17,7 +17,7 @@ using Sporefront.Models;
 
 namespace Sporefront.Visual
 {
-    public class ResearchTreePanel : MonoBehaviour
+    public class ResearchTreePanel : SporefrontPanel
     {
         // ================================================================
         // Events
@@ -31,12 +31,9 @@ namespace Sporefront.Visual
         // State
         // ================================================================
 
-        private GameObject backdrop;
         private GameObject panel;
-        private RectTransform panelRT;
         private RectTransform treeContentRT;
         private ScrollRect treeScroll;
-        private Guid localPlayerID;
         private ResearchCategory currentCategory = ResearchCategory.Economic;
         private ResearchType? selectedNode;
 
@@ -207,10 +204,6 @@ namespace Sporefront.Visual
             backdrop.SetActive(false);
         }
 
-        public void UpdateLocalPlayerID(Guid playerID)
-        {
-            localPlayerID = playerID;
-        }
 
         // ================================================================
         // Active Research Bar
@@ -362,7 +355,7 @@ namespace Sporefront.Visual
             backdrop.SetActive(true);
         }
 
-        public void Hide()
+        public override void Hide()
         {
             if (pendingLineDrawCoroutine != null)
             {
@@ -378,8 +371,6 @@ namespace Sporefront.Visual
             if (!backdrop.activeSelf) return;
             Rebuild(gameState);
         }
-
-        public bool IsVisible => backdrop != null && backdrop.activeSelf;
 
         // ================================================================
         // Rebuild

--- a/Sporefront/Assets/Scripts/Visual/ResourceBarPanel.cs
+++ b/Sporefront/Assets/Scripts/Visual/ResourceBarPanel.cs
@@ -39,8 +39,10 @@ namespace Sporefront.Visual
         // ================================================================
 
         public event Action OnNotificationClicked;
+#pragma warning disable CS0067 // Events subscribed to externally by UIManager
         public event Action OnCombatLogClicked;
         public event Action OnSettingsClicked;
+#pragma warning restore CS0067
         public event Action OnMainMenuClicked;
         public event Action OnIdleVillagerClicked;
 

--- a/Sporefront/Assets/Scripts/Visual/ResourceOverviewPanel.cs
+++ b/Sporefront/Assets/Scripts/Visual/ResourceOverviewPanel.cs
@@ -16,7 +16,7 @@ using Sporefront.Models;
 
 namespace Sporefront.Visual
 {
-    public class ResourceOverviewPanel : MonoBehaviour
+    public class ResourceOverviewPanel : SporefrontPanel
     {
         // ================================================================
         // Events
@@ -28,10 +28,7 @@ namespace Sporefront.Visual
         // State
         // ================================================================
 
-        private GameObject backdrop;
         private GameObject panel;
-        private RectTransform contentRT;
-        private Guid localPlayerID;
 
         // Throttled rebuild
         private bool isDirty;
@@ -94,11 +91,6 @@ namespace Sporefront.Visual
             backdrop.SetActive(false);
         }
 
-        public void UpdateLocalPlayerID(Guid playerID)
-        {
-            localPlayerID = playerID;
-        }
-
         // ================================================================
         // Public API
         // ================================================================
@@ -112,7 +104,7 @@ namespace Sporefront.Visual
             backdrop.SetActive(true);
         }
 
-        public void Hide()
+        public override void Hide()
         {
             backdrop.SetActive(false);
             OnClose?.Invoke();
@@ -124,8 +116,6 @@ namespace Sporefront.Visual
             cachedGameState = gameState;
             isDirty = true;
         }
-
-        public bool IsVisible => backdrop != null && backdrop.activeSelf;
 
         private void Update()
         {

--- a/Sporefront/Assets/Scripts/Visual/SaveLoadPanel.cs
+++ b/Sporefront/Assets/Scripts/Visual/SaveLoadPanel.cs
@@ -12,7 +12,7 @@ using Sporefront.Engine;
 
 namespace Sporefront.Visual
 {
-    public class SaveLoadPanel : MonoBehaviour
+    public class SaveLoadPanel : SporefrontPanel
     {
         // ================================================================
         // Events
@@ -26,7 +26,6 @@ namespace Sporefront.Visual
         // State
         // ================================================================
 
-        private GameObject backdrop;
         private GameObject panel;
         private Transform slotContainer;
         private InputField saveNameInput;
@@ -79,12 +78,10 @@ namespace Sporefront.Visual
             backdrop.SetActive(true);
         }
 
-        public void Hide()
+        public override void Hide()
         {
             backdrop.SetActive(false);
         }
-
-        public bool IsVisible => backdrop != null && backdrop.activeSelf;
 
         // ================================================================
         // Build Content

--- a/Sporefront/Assets/Scripts/Visual/SelectedEntitiesPanel.cs
+++ b/Sporefront/Assets/Scripts/Visual/SelectedEntitiesPanel.cs
@@ -14,7 +14,7 @@ using Sporefront.Models;
 
 namespace Sporefront.Visual
 {
-    public class SelectedEntitiesPanel : MonoBehaviour
+    public class SelectedEntitiesPanel : SporefrontPanel
     {
         // ================================================================
         // Events
@@ -44,11 +44,10 @@ namespace Sporefront.Visual
         private GameObject panelRoot;
         private RectTransform contentParent;
         private List<RowInfo> rows = new List<RowInfo>();
-        private Guid localPlayerID;
         private bool initialized;
         private Guid? highlightedEntityID;
 
-        public bool IsVisible => panelRoot != null && panelRoot.activeSelf;
+        public new bool IsVisible => panelRoot != null && panelRoot.activeSelf;
 
         // ================================================================
         // Initialization
@@ -89,10 +88,7 @@ namespace Sporefront.Visual
             initialized = true;
         }
 
-        public void UpdateLocalPlayerID(Guid playerID)
-        {
-            localPlayerID = playerID;
-        }
+        // UpdateLocalPlayerID inherited from SporefrontPanel
 
         // ================================================================
         // Public API
@@ -132,7 +128,7 @@ namespace Sporefront.Visual
             UpdateRowHighlights();
         }
 
-        public void Hide()
+        public override void Hide()
         {
             if (panelRoot != null) panelRoot.SetActive(false);
         }

--- a/Sporefront/Assets/Scripts/Visual/SettingsPanel.cs
+++ b/Sporefront/Assets/Scripts/Visual/SettingsPanel.cs
@@ -15,7 +15,7 @@ using Sporefront.Models;
 
 namespace Sporefront.Visual
 {
-    public class SettingsPanel : MonoBehaviour
+    public class SettingsPanel : SporefrontPanel
     {
         // ================================================================
         // Events
@@ -37,10 +37,7 @@ namespace Sporefront.Visual
         // State
         // ================================================================
 
-        private GameObject backdrop;
         private GameObject panel;
-        private RectTransform contentRT;
-        private Guid localPlayerID;
 
         // ================================================================
         // Initialization
@@ -104,22 +101,17 @@ namespace Sporefront.Visual
             backdrop.SetActive(false);
         }
 
-        public void UpdateLocalPlayerID(Guid playerID)
-        {
-            localPlayerID = playerID;
-        }
-
         // ================================================================
         // Public API
         // ================================================================
 
-        public void Show()
+        public override void Show()
         {
             Rebuild();
             backdrop.SetActive(true);
         }
 
-        public void Hide()
+        public override void Hide()
         {
             backdrop.SetActive(false);
             OnClose?.Invoke();
@@ -130,8 +122,6 @@ namespace Sporefront.Visual
             if (!backdrop.activeSelf) return;
             Rebuild();
         }
-
-        public bool IsVisible => backdrop != null && backdrop.activeSelf;
 
         // ================================================================
         // Rebuild

--- a/Sporefront/Assets/Scripts/Visual/SpectatorOverlay.cs
+++ b/Sporefront/Assets/Scripts/Visual/SpectatorOverlay.cs
@@ -98,20 +98,18 @@ namespace Sporefront.Visual
             if (player1NameLabel != null)
                 player1NameLabel.text = player1Name;
             if (player1StatsLabel != null)
-                player1StatsLabel.text = string.Format("F:{0} W:{1} S:{2} A:{3} B:{4}",
-                    player1Food, player1Wood, player1Stone, player1Armies, player1Buildings);
+                player1StatsLabel.text = $"F:{player1Food} W:{player1Wood} S:{player1Stone} A:{player1Armies} B:{player1Buildings}";
 
             if (player2NameLabel != null)
                 player2NameLabel.text = player2Name;
             if (player2StatsLabel != null)
-                player2StatsLabel.text = string.Format("F:{0} W:{1} S:{2} A:{3} B:{4}",
-                    player2Food, player2Wood, player2Stone, player2Armies, player2Buildings);
+                player2StatsLabel.text = $"F:{player2Food} W:{player2Wood} S:{player2Stone} A:{player2Armies} B:{player2Buildings}";
 
             if (gameTimeLabel != null)
             {
                 int minutes = (int)gameTime / 60;
                 int seconds = (int)gameTime % 60;
-                gameTimeLabel.text = string.Format("{0}:{1:D2}", minutes, seconds);
+                gameTimeLabel.text = $"{minutes}:{seconds:D2}";
             }
         }
 

--- a/Sporefront/Assets/Scripts/Visual/SporefrontPanel.cs
+++ b/Sporefront/Assets/Scripts/Visual/SporefrontPanel.cs
@@ -1,0 +1,154 @@
+// ============================================================================
+// FILE: Visual/SporefrontPanel.cs
+// PURPOSE: Base class for all popup/modal panels. Centralizes backdrop
+//          creation, visibility checks, fade animations, and content clearing.
+// ============================================================================
+
+using System;
+using System.Collections;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Sporefront.Visual
+{
+    public abstract class SporefrontPanel : MonoBehaviour
+    {
+        // ================================================================
+        // Core References
+        // ================================================================
+
+        protected GameObject backdrop;
+        protected CanvasGroup backdropCG;
+        protected RectTransform panelRT;
+        protected RectTransform contentRT;
+        protected Guid localPlayerID;
+
+        // Fade state
+        private Coroutine fadeCoroutine;
+
+        // ================================================================
+        // Visibility
+        // ================================================================
+
+        public bool IsVisible => backdrop != null && backdrop.activeSelf;
+
+        // ================================================================
+        // Lifecycle Helpers
+        // ================================================================
+
+        /// <summary>
+        /// Creates the standard backdrop (full-screen semi-transparent overlay with click-to-close).
+        /// Call from Initialize() or BuildContent() before creating panel content.
+        /// </summary>
+        protected GameObject CreateBackdrop(Transform parent, float alpha = 0.4f, bool withFade = false)
+        {
+            backdrop = new GameObject("Backdrop");
+            backdrop.transform.SetParent(parent, false);
+            var rt = backdrop.AddComponent<RectTransform>();
+            rt.anchorMin = Vector2.zero;
+            rt.anchorMax = Vector2.one;
+            rt.offsetMin = Vector2.zero;
+            rt.offsetMax = Vector2.zero;
+            var img = backdrop.AddComponent<Image>();
+            img.color = new Color(0f, 0f, 0f, alpha);
+            backdrop.SetActive(false);
+
+            // Click-to-close
+            var btn = backdrop.AddComponent<Button>();
+            btn.transition = Selectable.Transition.None;
+            btn.onClick.AddListener(OnBackdropClicked);
+
+            if (withFade)
+            {
+                backdropCG = backdrop.AddComponent<CanvasGroup>();
+                backdropCG.alpha = 0f;
+            }
+
+            return backdrop;
+        }
+
+        /// <summary>
+        /// Override to customize what happens when the backdrop is clicked.
+        /// Default behavior calls Hide().
+        /// </summary>
+        protected virtual void OnBackdropClicked()
+        {
+            Hide();
+        }
+
+        // ================================================================
+        // Show / Hide
+        // ================================================================
+
+        public virtual void Show()
+        {
+            if (backdrop == null) return;
+            backdrop.SetActive(true);
+            if (backdropCG != null)
+                FadeIn();
+        }
+
+        public virtual void Hide()
+        {
+            if (backdrop == null) return;
+            if (backdropCG != null)
+                FadeOut();
+            else
+                backdrop.SetActive(false);
+        }
+
+        // ================================================================
+        // Fade Animations
+        // ================================================================
+
+        protected void FadeIn()
+        {
+            if (backdropCG == null) return;
+            backdrop.SetActive(true);
+            if (fadeCoroutine != null) StopCoroutine(fadeCoroutine);
+            fadeCoroutine = StartCoroutine(UIHelper.FadeIn(backdropCG));
+        }
+
+        protected void FadeOut(Action onComplete = null)
+        {
+            if (backdropCG == null)
+            {
+                if (backdrop != null) backdrop.SetActive(false);
+                onComplete?.Invoke();
+                return;
+            }
+            if (fadeCoroutine != null) StopCoroutine(fadeCoroutine);
+            fadeCoroutine = StartCoroutine(FadeOutCoroutine(onComplete));
+        }
+
+        private IEnumerator FadeOutCoroutine(Action onComplete)
+        {
+            yield return UIHelper.FadeOut(backdropCG);
+            if (backdrop != null) backdrop.SetActive(false);
+            onComplete?.Invoke();
+        }
+
+        // ================================================================
+        // Content Management
+        // ================================================================
+
+        /// <summary>
+        /// Destroys all children of contentRT. Safe to call when contentRT is null.
+        /// </summary>
+        protected void ClearContent()
+        {
+            if (contentRT == null) return;
+            for (int i = contentRT.childCount - 1; i >= 0; i--)
+                Destroy(contentRT.GetChild(i).gameObject);
+        }
+
+        // ================================================================
+        // Player Tracking
+        // ================================================================
+
+        public void UpdateLocalPlayerID(Guid playerID)
+        {
+            localPlayerID = playerID;
+        }
+    }
+}

--- a/Sporefront/Assets/Scripts/Visual/SporefrontPanel.cs.meta
+++ b/Sporefront/Assets/Scripts/Visual/SporefrontPanel.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0d40eed7cbfab44af94c21679c56a661

--- a/Sporefront/Assets/Scripts/Visual/TendrilWheelHUD.cs
+++ b/Sporefront/Assets/Scripts/Visual/TendrilWheelHUD.cs
@@ -61,7 +61,6 @@ namespace Sporefront.Visual
         // Active tracking
         private WheelButton activeRightButton;
         private WheelButton activeLeftButton;
-        private bool keyBadgesVisible;
 
         // Button → external event mapping
         private readonly Dictionary<WheelButton, Action> buttonEventMap
@@ -374,12 +373,10 @@ namespace Sporefront.Visual
             // Tab hold — show/hide key badges
             if (kb.tabKey.wasPressedThisFrame)
             {
-                keyBadgesVisible = true;
                 SetAllKeyBadges(true);
             }
             if (kb.tabKey.wasReleasedThisFrame)
             {
-                keyBadgesVisible = false;
                 SetAllKeyBadges(false);
             }
 

--- a/Sporefront/Assets/Scripts/Visual/TileInfoPanel.cs
+++ b/Sporefront/Assets/Scripts/Visual/TileInfoPanel.cs
@@ -17,7 +17,7 @@ using Sporefront.Commands;
 
 namespace Sporefront.Visual
 {
-    public class TileInfoPanel : MonoBehaviour
+    public class TileInfoPanel : SporefrontPanel
     {
         // ================================================================
         // Events
@@ -44,11 +44,8 @@ namespace Sporefront.Visual
         // State
         // ================================================================
 
-        private GameObject backdrop;
         private GameObject panel;
-        private RectTransform contentRT;
         private HexCoordinate? currentCoord;
-        private Guid localPlayerID;
         private bool showingMoveSelection;
         private bool showingAttackSelection;
         private GameState cachedGameState;
@@ -166,7 +163,7 @@ namespace Sporefront.Visual
             panel.SetActive(true);
         }
 
-        public void Hide()
+        public override void Hide()
         {
             currentCoord = null;
             showingMoveSelection = false;
@@ -191,7 +188,7 @@ namespace Sporefront.Visual
             Rebuild(gameState);
         }
 
-        public bool IsVisible => panel != null && panel.activeSelf;
+        public new bool IsVisible => panel != null && panel.activeSelf;
 
         // ================================================================
         // Rebuild Content

--- a/Sporefront/Assets/Scripts/Visual/TrainingOverviewPanel.cs
+++ b/Sporefront/Assets/Scripts/Visual/TrainingOverviewPanel.cs
@@ -16,7 +16,7 @@ using Sporefront.Models;
 
 namespace Sporefront.Visual
 {
-    public class TrainingOverviewPanel : MonoBehaviour
+    public class TrainingOverviewPanel : SporefrontPanel
     {
         // ================================================================
         // Events
@@ -29,10 +29,7 @@ namespace Sporefront.Visual
         // State
         // ================================================================
 
-        private GameObject backdrop;
         private GameObject panel;
-        private RectTransform contentRT;
-        private Guid localPlayerID;
 
         // Throttled rebuild
         private bool isDirty;
@@ -94,11 +91,6 @@ namespace Sporefront.Visual
             backdrop.SetActive(false);
         }
 
-        public void UpdateLocalPlayerID(Guid playerID)
-        {
-            localPlayerID = playerID;
-        }
-
         // ================================================================
         // Public API
         // ================================================================
@@ -112,7 +104,7 @@ namespace Sporefront.Visual
             backdrop.SetActive(true);
         }
 
-        public void Hide()
+        public override void Hide()
         {
             backdrop.SetActive(false);
             OnClose?.Invoke();
@@ -124,8 +116,6 @@ namespace Sporefront.Visual
             cachedGameState = gameState;
             isDirty = true;
         }
-
-        public bool IsVisible => backdrop != null && backdrop.activeSelf;
 
         private void Update()
         {

--- a/Sporefront/Assets/Scripts/Visual/UIHelper.cs
+++ b/Sporefront/Assets/Scripts/Visual/UIHelper.cs
@@ -556,16 +556,20 @@ namespace Sporefront.Visual
         /// Rich-text color-coded army status: [E] teal, [C] red, [R] amber.
         /// Returns empty string if no status flags are active.
         /// </summary>
+        private static readonly string HexAmber = ColorUtility.ToHtmlStringRGB(SporefrontColors.SporeAmber);
+        private static readonly string HexTeal = ColorUtility.ToHtmlStringRGB(SporefrontColors.SporeTeal);
+        private static readonly string HexRed = ColorUtility.ToHtmlStringRGB(SporefrontColors.SporeRed);
+
         public static string FormatArmyStatus(ArmyData army)
         {
             if (army.isEntrenching)
-                return $" <color=#{ColorUtility.ToHtmlStringRGB(SporefrontColors.SporeAmber)}>[E...]</color>";
+                return $" <color=#{HexAmber}>[E...]</color>";
             if (army.isEntrenched)
-                return $" <color=#{ColorUtility.ToHtmlStringRGB(SporefrontColors.SporeTeal)}>[E]</color>";
+                return $" <color=#{HexTeal}>[E]</color>";
             if (army.isInCombat)
-                return $" <color=#{ColorUtility.ToHtmlStringRGB(SporefrontColors.SporeRed)}>[C]</color>";
+                return $" <color=#{HexRed}>[C]</color>";
             if (army.isRetreating)
-                return $" <color=#{ColorUtility.ToHtmlStringRGB(SporefrontColors.SporeAmber)}>[R]</color>";
+                return $" <color=#{HexAmber}>[R]</color>";
             return "";
         }
 

--- a/Sporefront/Assets/Scripts/Visual/UIManager.cs
+++ b/Sporefront/Assets/Scripts/Visual/UIManager.cs
@@ -148,6 +148,9 @@ namespace Sporefront.Visual
         // Idle villager cycling
         private int idleVillagerCycleIndex;
 
+        // Registry of all SporefrontPanel instances for batch operations
+        private readonly List<SporefrontPanel> allPanels = new List<SporefrontPanel>();
+
         // Thread-safe queue for callbacks from background threads (e.g., ArenaSimulator)
         private readonly ConcurrentQueue<Action> mainThreadActions = new ConcurrentQueue<Action>();
 
@@ -405,7 +408,10 @@ namespace Sporefront.Visual
         {
             var go = new GameObject(name + "Manager");
             go.transform.SetParent(transform, false);
-            return go.AddComponent<T>();
+            var component = go.AddComponent<T>();
+            if (component is SporefrontPanel sp)
+                allPanels.Add(sp);
+            return component;
         }
 
         // ================================================================
@@ -1236,30 +1242,12 @@ namespace Sporefront.Visual
                 factionBanner.UpdateFaction(player.faction);
             factionBanner.ShowBanner();
 
-            // 3. Propagate localPlayerID to all panels that cached it during Initialize
+            // 3. Propagate localPlayerID to all registered panels
+            foreach (var panel in allPanels)
+                panel.UpdateLocalPlayerID(localPlayerID);
+            // Non-SporefrontPanel components with their own UpdateLocalPlayerID
             tileInfoPopup.UpdateLocalPlayerID(localPlayerID);
-            buildingDetail.UpdateLocalPlayerID(localPlayerID);
-            armyDetail.UpdateLocalPlayerID(localPlayerID);
             actionPanel.UpdateLocalPlayerID(localPlayerID);
-            buildingsOverview.UpdateLocalPlayerID(localPlayerID);
-            entitiesOverview.UpdateLocalPlayerID(localPlayerID);
-            militaryOverview.UpdateLocalPlayerID(localPlayerID);
-            resourceOverview.UpdateLocalPlayerID(localPlayerID);
-            trainingOverview.UpdateLocalPlayerID(localPlayerID);
-            commander.UpdateLocalPlayerID(localPlayerID);
-            researchTree.UpdateLocalPlayerID(localPlayerID);
-            liveCombat.UpdateLocalPlayerID(localPlayerID);
-            combatHistory.UpdateLocalPlayerID(localPlayerID);
-            combatDetail.UpdateLocalPlayerID(localPlayerID);
-            gatherPanel.UpdateLocalPlayerID(localPlayerID);
-            reinforcePanel.UpdateLocalPlayerID(localPlayerID);
-            villagerDeploy.UpdateLocalPlayerID(localPlayerID);
-            buildVillagerSelect.UpdateLocalPlayerID(localPlayerID);
-            upgradeVillagerSelect.UpdateLocalPlayerID(localPlayerID);
-            settings.UpdateLocalPlayerID(localPlayerID);
-            inGameMenu.UpdateLocalPlayerID(localPlayerID);
-            notificationInbox.UpdateLocalPlayerID(localPlayerID);
-            selectedEntitiesPanel.UpdateLocalPlayerID(localPlayerID);
             miniMap.UpdateLocalPlayerID(localPlayerID);
 
             // Build and show mini map
@@ -1365,7 +1353,7 @@ namespace Sporefront.Visual
             var result = GameEngine.Instance.ExecuteCommand(command);
             if (!result.Succeeded)
             {
-                var uiManager = UnityEngine.Object.FindObjectOfType<UIManager>();
+                var uiManager = UnityEngine.Object.FindAnyObjectByType<UIManager>();
                 uiManager?.ShowCommandFailure(result.FailureReason ?? "Command failed");
             }
         }

--- a/Sporefront/Assets/Scripts/Visual/UpgradeVillagerSelectPanel.cs
+++ b/Sporefront/Assets/Scripts/Visual/UpgradeVillagerSelectPanel.cs
@@ -16,7 +16,7 @@ using Sporefront.Models;
 
 namespace Sporefront.Visual
 {
-    public class UpgradeVillagerSelectPanel : MonoBehaviour
+    public class UpgradeVillagerSelectPanel : SporefrontPanel
     {
         // ================================================================
         // Events
@@ -29,11 +29,8 @@ namespace Sporefront.Visual
         // State
         // ================================================================
 
-        private GameObject backdrop;
         private GameObject modalPanel;
-        private RectTransform contentRT;
         private Text infoLabel;
-        private Guid localPlayerID;
 
         private Guid pendingBuildingID;
         private BuildingType pendingBuildingType;
@@ -109,11 +106,6 @@ namespace Sporefront.Visual
             backdrop.SetActive(false);
         }
 
-        public void UpdateLocalPlayerID(Guid playerID)
-        {
-            localPlayerID = playerID;
-        }
-
         // ================================================================
         // Public API
         // ================================================================
@@ -128,7 +120,7 @@ namespace Sporefront.Visual
             backdrop.SetActive(true);
         }
 
-        public void Hide()
+        public override void Hide()
         {
             backdrop.SetActive(false);
             OnClose?.Invoke();
@@ -139,8 +131,6 @@ namespace Sporefront.Visual
             if (!backdrop.activeSelf) return;
             Rebuild(gameState);
         }
-
-        public bool IsVisible => backdrop != null && backdrop.activeSelf;
 
         // ================================================================
         // Rebuild
@@ -173,8 +163,8 @@ namespace Sporefront.Visual
             var sectionLE = sectionLabel.gameObject.AddComponent<LayoutElement>();
             sectionLE.preferredHeight = 28;
 
-            var groups = gameState.GetVillagerGroupsForPlayer(localPlayerID);
-            if (groups == null || groups.Count == 0)
+            var groups = new List<VillagerGroupData>(gameState.GetVillagerGroupsForPlayer(localPlayerID));
+            if (groups.Count == 0)
             {
                 var emptyLabel = UIHelper.CreateLabel(contentRT,
                     "  No villager groups available", UIConstants.FontSmall, UIHelper.InkMutedText);

--- a/Sporefront/Assets/Scripts/Visual/VSLoadingPanel.cs
+++ b/Sporefront/Assets/Scripts/Visual/VSLoadingPanel.cs
@@ -14,7 +14,7 @@ using Sporefront.Models;
 
 namespace Sporefront.Visual
 {
-    public class VSLoadingPanel : MonoBehaviour
+    public class VSLoadingPanel : SporefrontPanel
     {
         // ================================================================
         // Config
@@ -33,7 +33,7 @@ namespace Sporefront.Visual
         private UITendrilRenderer tendrilRenderer;
         private CanvasGroup panelCanvasGroup;
         private CanvasGroup contentGroup;
-        private RectTransform panelRT;
+        private new RectTransform panelRT;
         private Action onComplete;
 
         private readonly List<BranchTiming> branchTimings = new List<BranchTiming>();

--- a/Sporefront/Assets/Scripts/Visual/VillagerDeployPanel.cs
+++ b/Sporefront/Assets/Scripts/Visual/VillagerDeployPanel.cs
@@ -15,7 +15,7 @@ using Sporefront.Models;
 
 namespace Sporefront.Visual
 {
-    public class VillagerDeployPanel : MonoBehaviour
+    public class VillagerDeployPanel : SporefrontPanel
     {
         // ================================================================
         // Events
@@ -41,13 +41,10 @@ namespace Sporefront.Visual
         // ================================================================
 
         private GameObject panel;
-        private RectTransform contentRT;
         private Guid? currentBuildingID;
-        private Guid localPlayerID;
 
         private TabMode currentTab = TabMode.DeployNew;
         private int deployCount = 1;
-        private Guid? selectedGroupID;
 
         // Merge sub-panel state
         private bool showMergePanel;
@@ -93,10 +90,7 @@ namespace Sporefront.Visual
             panel.SetActive(false);
         }
 
-        public void UpdateLocalPlayerID(Guid playerID)
-        {
-            localPlayerID = playerID;
-        }
+        // UpdateLocalPlayerID inherited from SporefrontPanel
 
         // ================================================================
         // Public API
@@ -107,7 +101,6 @@ namespace Sporefront.Visual
             currentBuildingID = buildingID;
             currentTab = TabMode.DeployNew;
             deployCount = 1;
-            selectedGroupID = null;
             showMergePanel = false;
             mergeGroupA = null;
             mergeGroupB = null;
@@ -115,7 +108,7 @@ namespace Sporefront.Visual
             panel.SetActive(true);
         }
 
-        public void Hide()
+        public override void Hide()
         {
             currentBuildingID = null;
             showMergePanel = false;
@@ -129,7 +122,7 @@ namespace Sporefront.Visual
             Rebuild(gameState);
         }
 
-        public bool IsVisible => panel != null && panel.activeSelf;
+        public new bool IsVisible => panel != null && panel.activeSelf;
 
         // ================================================================
         // Rebuild
@@ -286,8 +279,8 @@ namespace Sporefront.Visual
             var sectionLE = sectionLabel.gameObject.AddComponent<LayoutElement>();
             sectionLE.preferredHeight = 22;
 
-            var groups = gameState.GetVillagerGroupsForPlayer(localPlayerID);
-            if (groups == null || groups.Count == 0)
+            var groups = new List<VillagerGroupData>(gameState.GetVillagerGroupsForPlayer(localPlayerID));
+            if (groups.Count == 0)
             {
                 var emptyLabel = UIHelper.CreateLabel(contentRT,
                     "  No villager groups available", 12, UIHelper.InkMutedText);


### PR DESCRIPTION
## Summary

Three rounds of structural code improvements across 126 files, reducing ~620 net lines while improving consistency, maintainability, and reducing per-frame allocations.

### Round 1 — Foundation
- **SporefrontPanel** base class for 36+ UI panels (backdrop, fade, show/hide)
- **Data-driven BuildingType & MilitaryUnitType** — lookup tables replacing 25+ switch statements each
- **FactionAIConfig** — centralized faction-specific AI tuning (build orders, terrain preferences)
- **AIHelper & BuildHelper** — shared utilities for hunt arrivals, build validation, spawn positions
- **Command validation helpers** — `ValidateOperationalBuilding()`, `DeductResourcesWithChanges()`, `FindSpawnPosition()` on BaseEngineCommand
- **Reusable list patterns** in ConstructionEngine, EntityRenderer (eliminates per-tick `.ToList()` allocations)
- **Cached color hex strings** in UIHelper

### Round 2 — AI & Command Consolidation
- **`CanAfford()` migration** — 31 manual foreach loops → one-liner `player.CanAfford(cost)` calls across 8 files
- **FactionType data-driven** — 13 switch-statement methods → single `FactionTypeData` lookup table
- **Generic `TryBuildStructure()`** — 10 near-identical TryBuild methods (5 per AI planner) consolidated into parameterized helper
- **AttackCommand.Execute decomposition** — 200-line monolith → 5 focused methods with shared `GatherAttackerGroup()` helper (was duplicated 3×)
- **CombatEngine reusable snapshot** — poison processing uses `Clear()+AddRange()` instead of per-tick `.ToList()`

### Round 3 — Bug Fixes & Warning Cleanup
- **4 errors fixed**: DominationEngine typo (`__` → `_`), EntityTendrilRenderer wrong variable name, SporefrontPanel missing `CreateBackdrop` implementation + `FadeOut` signature mismatch
- **11 warnings fixed**: deprecated `FindObjectOfType` → `FindAnyObjectByType`, `new` keyword for hidden inherited members, 5 unused fields removed, unused variable cleanup

## Test plan
- [ ] Open project in Unity Editor — verify no compilation errors
- [ ] Run EditMode tests via Test Runner
- [ ] Play a full game vs AI (both factions) — verify AI builds, upgrades, trains, researches normally
- [ ] Trigger combat scenarios — verify AttackCommand works for building/army/villager/cross-tile targets
- [ ] Verify UI panels open/close with fade animations
- [ ] Run arena simulation — verify SimulationAIController builds and researches correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)